### PR TITLE
Decouple pkg/explorer from daemon config

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -43,7 +43,7 @@ func main() {
 	unspentRepository := storage.NewInMemoryUnspentRepository()
 	vaultRepository := storage.NewInMemoryVaultRepository()
 
-	explorerSvc := explorer.NewService()
+	explorerSvc := explorer.NewService(config.GetString(config.ExplorerEndpointKey))
 	observables, err := getObjectsToObserve(marketRepository, vaultRepository)
 
 	errorHandler := func(err error) {

--- a/internal/service/wallet/send_to_many.go
+++ b/internal/service/wallet/send_to_many.go
@@ -68,7 +68,7 @@ func (s *Service) SendToMany(ctx context.Context, req *pb.SendToManyRequest) (re
 		}
 
 		if req.GetPush() {
-			if _, err := explorer.BroadcastTransaction(txHex); err != nil {
+			if _, err := s.explorerService.BroadcastTransaction(txHex); err != nil {
 				return nil, err
 			}
 		}
@@ -109,7 +109,7 @@ func (s *Service) getUnspents(addresses []string, blindingKeys [][]byte) ([]expl
 }
 
 func (s *Service) getUnspentsForAddress(addr string, blindingKeys [][]byte, chUnspents chan []explorer.Utxo, chErr chan error) {
-	unspents, err := s.explorerService.GetUnSpents(addr, blindingKeys)
+	unspents, err := s.explorerService.GetUnspents(addr, blindingKeys)
 	if err != nil {
 		chErr <- err
 		return

--- a/pkg/crawler/blockchain.go
+++ b/pkg/crawler/blockchain.go
@@ -219,7 +219,7 @@ func (a *AddressObservable) observe(
 		return
 	}
 
-	unspents, err := explorerSvc.GetUnSpents(a.Address, [][]byte{a.BlindingKey})
+	unspents, err := explorerSvc.GetUnspents(a.Address, [][]byte{a.BlindingKey})
 	if err != nil {
 		errChan <- err
 	}

--- a/pkg/crawler/blockchain_test.go
+++ b/pkg/crawler/blockchain_test.go
@@ -1,6 +1,7 @@
 package crawler
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -111,10 +112,7 @@ func (m MockExplorer) GetTransactionStatus(txID string) (
 	return nil, nil
 }
 
-func (m MockExplorer) GetUnSpents(
-	addr string,
-	blindKeys [][]byte,
-) (
+func (m MockExplorer) GetUnspents(addr string, blindKeys [][]byte) (
 	[]explorer.Utxo,
 	error,
 ) {
@@ -128,6 +126,19 @@ func (m MockExplorer) GetUnSpents(
 		return []explorer.Utxo{MockUtxo{value: 101}}, nil
 	}
 	return nil, nil
+}
+
+func (m MockExplorer) GetTransactionHex(txID string) (string, error) {
+	return "", errors.New("implement me")
+}
+func (m MockExplorer) BroadcastTransaction(txHex string) (string, error) {
+	return "", errors.New("implement me")
+}
+func (m MockExplorer) Faucet(addr string) (string, error) {
+	return "", errors.New("implement me")
+}
+func (m MockExplorer) Mint(addr string, amount int) (string, string, error) {
+	return "", "", errors.New("implement me")
 }
 
 type MockUtxo struct {

--- a/pkg/explorer/coin_test.go
+++ b/pkg/explorer/coin_test.go
@@ -2,15 +2,17 @@ package explorer
 
 import (
 	"encoding/hex"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/stretchr/testify/assert"
-	"github.com/vulpemventures/go-elements/network"
-	"github.com/vulpemventures/go-elements/payment"
 	"math"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/stretchr/testify/assert"
+	"github.com/tdex-network/tdex-daemon/config"
+	"github.com/vulpemventures/go-elements/network"
+	"github.com/vulpemventures/go-elements/payment"
 )
 
 var testKey []byte
@@ -49,16 +51,15 @@ func TestGetUnspents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	explorerSvc := NewService(config.GetString(config.ExplorerEndpointKey))
 
-	_, err = Faucet(address)
+	_, err = explorerSvc.Faucet(address)
 	if err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(5 * time.Second)
 
-	explorerSvc := NewService()
-
-	utxos, err := explorerSvc.GetUnSpents(address, [][]byte{blindKey})
+	utxos, err := explorerSvc.GetUnspents(address, [][]byte{blindKey})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,20 +70,20 @@ func TestGetUnspents(t *testing.T) {
 	assert.Equal(t, true, len(utxos[0].SurjectionProof()) > 0)
 }
 
-func TestSelectUtxos(t *testing.T) {
+func TestSelectUnspents(t *testing.T) {
 	address, key1, err := newTestData()
 	if err != nil {
 		t.Fatal(err)
 	}
+	explorerSvc := NewService(config.GetString(config.ExplorerEndpointKey))
 
-	_, err = Faucet(address)
+	_, err = explorerSvc.Faucet(address)
 	if err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(5 * time.Second)
 
-	explorerSvc := NewService()
-	utxos, err := explorerSvc.GetUnSpents(address, [][]byte{key1})
+	utxos, err := explorerSvc.GetUnspents(address, [][]byte{key1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +94,7 @@ func TestSelectUtxos(t *testing.T) {
 	blindingKeys := [][]byte{key1, key2}
 	targetAmount := uint64(1.5 * math.Pow10(8))
 
-	selectedUtxos, change, err := SelectUnSpents(
+	selectedUtxos, change, err := SelectUnspents(
 		utxos,
 		blindingKeys,
 		targetAmount,
@@ -113,9 +114,9 @@ func TestFailingSelectUtxos(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	explorerSvc := NewService(config.GetString(config.ExplorerEndpointKey))
 
-	explorerSvc := NewService()
-	utxos, err := explorerSvc.GetUnSpents(address, [][]byte{blindKey})
+	utxos, err := explorerSvc.GetUnspents(address, [][]byte{blindKey})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +127,7 @@ func TestFailingSelectUtxos(t *testing.T) {
 	blindingKeys := [][]byte{key}
 	targetAmount := uint64(1.5 * math.Pow10(8))
 
-	_, _, err = SelectUnSpents(
+	_, _, err = SelectUnspents(
 		utxos,
 		blindingKeys,
 		targetAmount,

--- a/pkg/explorer/explorer.go
+++ b/pkg/explorer/explorer.go
@@ -1,0 +1,88 @@
+package explorer
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Service interface {
+	GetUnspents(addr string, blindKeys [][]byte) ([]Utxo, error)
+	GetTransactionHex(hash string) (string, error)
+	IsTransactionConfirmed(txID string) (bool, error)
+	GetTransactionStatus(txID string) (map[string]interface{}, error)
+	BroadcastTransaction(txHex string) (string, error)
+	// regtest only
+	Faucet(address string) (string, error)
+	Mint(address string, amount int) (string, string, error)
+}
+
+type explorer struct {
+	apiUrl string
+}
+
+func NewService(apiUrl string) Service {
+	return &explorer{apiUrl}
+}
+
+func SelectUnspents(
+	utxos []Utxo,
+	blindKeys [][]byte,
+	targetAmount uint64,
+	targetAsset string,
+) (coins []Utxo, change uint64, err error) {
+	chUnspents := make(chan Utxo, len(utxos))
+	chErr := make(chan error, 1)
+
+	unblindedUtxos := make([]Utxo, 0)
+	totalAmount := uint64(0)
+
+	for i := range utxos {
+		utxo := utxos[i]
+		if utxo.IsConfidential() {
+			go unblindUtxo(utxo, blindKeys, chUnspents, chErr)
+			select {
+
+			case err1 := <-chErr:
+				close(chErr)
+				close(chUnspents)
+				coins = nil
+				change = 0
+				err = fmt.Errorf("error on unblinding utxos: %s", err1)
+				return
+
+			case unspent := <-chUnspents:
+				if unspent.Asset() == targetAsset {
+					unblindedUtxos = append(unblindedUtxos, unspent)
+				}
+			}
+
+		} else {
+			if utxo.Asset() == targetAsset {
+				unblindedUtxos = append(unblindedUtxos, utxo)
+			}
+		}
+	}
+
+	indexes := getCoinsIndexes(targetAmount, unblindedUtxos)
+
+	selectedUtxos := make([]Utxo, 0)
+	if len(indexes) > 0 {
+		for _, v := range indexes {
+			totalAmount += unblindedUtxos[v].Value()
+			selectedUtxos = append(selectedUtxos, unblindedUtxos[v])
+		}
+	} else {
+		coins = nil
+		change = 0
+		err = errors.New(
+			"error on target amount: total utxo amount does not cover target amount",
+		)
+		return
+	}
+
+	changeAmount := totalAmount - targetAmount
+	coins = selectedUtxos
+	change = changeAmount
+
+	return
+}

--- a/pkg/explorer/transaction.go
+++ b/pkg/explorer/transaction.go
@@ -7,14 +7,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/tdex-network/tdex-daemon/config"
 	"github.com/tdex-network/tdex-daemon/pkg/httputil"
 )
 
-func GetTransactionHex(hash string) (string, error) {
+func (e *explorer) GetTransactionHex(hash string) (string, error) {
 	url := fmt.Sprintf(
 		"%s/tx/%s/hex",
-		config.GetString(config.ExplorerEndpointKey),
+		e.apiUrl,
 		hash,
 	)
 	status, resp, err := httputil.NewHTTPRequest("GET", url, "", nil)
@@ -28,9 +27,7 @@ func GetTransactionHex(hash string) (string, error) {
 	return resp, nil
 }
 
-func (e *explorer) IsTransactionConfirmed(
-	txID string,
-) (bool, error) {
+func (e *explorer) IsTransactionConfirmed(txID string) (bool, error) {
 	trxStatus, err := e.GetTransactionStatus(txID)
 	if err != nil {
 		return false, err
@@ -45,12 +42,10 @@ func (e *explorer) IsTransactionConfirmed(
 	return isConfirmed, nil
 }
 
-func (e *explorer) GetTransactionStatus(
-	txID string,
-) (map[string]interface{}, error) {
+func (e *explorer) GetTransactionStatus(txID string) (map[string]interface{}, error) {
 	url := fmt.Sprintf(
 		"%s/tx/%s/status",
-		config.GetString(config.ExplorerEndpointKey),
+		e.apiUrl,
 		txID,
 	)
 	status, resp, err := httputil.NewHTTPRequest("GET", url, "", nil)
@@ -70,8 +65,8 @@ func (e *explorer) GetTransactionStatus(
 	return trxStatus, nil
 }
 
-func BroadcastTransaction(txHex string) (string, error) {
-	url := fmt.Sprintf("%s/tx", config.GetString(config.ExplorerEndpointKey))
+func (e *explorer) BroadcastTransaction(txHex string) (string, error) {
+	url := fmt.Sprintf("%s/tx", e.apiUrl)
 	headers := map[string]string{
 		"Content-Type": "text/plain",
 	}
@@ -92,8 +87,8 @@ func BroadcastTransaction(txHex string) (string, error) {
 	return resp, nil
 }
 
-func Faucet(address string) (string, error) {
-	url := fmt.Sprintf("%s/faucet", config.GetString(config.ExplorerEndpointKey))
+func (e *explorer) Faucet(address string) (string, error) {
+	url := fmt.Sprintf("%s/faucet", e.apiUrl)
 	payload := map[string]string{"address": address}
 	body, _ := json.Marshal(payload)
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(body))
@@ -113,8 +108,8 @@ func Faucet(address string) (string, error) {
 	return respBody["txId"], nil
 }
 
-func Mint(address string, amount int) (string, string, error) {
-	url := fmt.Sprintf("%s/mint", config.GetString(config.ExplorerEndpointKey))
+func (e *explorer) Mint(address string, amount int) (string, string, error) {
+	url := fmt.Sprintf("%s/mint", e.apiUrl)
 	payload := map[string]interface{}{"address": address, "quantity": amount}
 	body, _ := json.Marshal(payload)
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(body))

--- a/pkg/explorer/transaction_test.go
+++ b/pkg/explorer/transaction_test.go
@@ -1,12 +1,14 @@
 package explorer
 
 import (
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/magiconair/properties/assert"
-	"github.com/vulpemventures/go-elements/network"
-	"github.com/vulpemventures/go-elements/payment"
 	"testing"
 	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/magiconair/properties/assert"
+	"github.com/tdex-network/tdex-daemon/config"
+	"github.com/vulpemventures/go-elements/network"
+	"github.com/vulpemventures/go-elements/payment"
 )
 
 func TestGetTransactionStatus(t *testing.T) {
@@ -18,15 +20,15 @@ func TestGetTransactionStatus(t *testing.T) {
 	p2wpkh := payment.FromPublicKey(pubkey, &network.Regtest, nil)
 	address, _ := p2wpkh.WitnessPubKeyHash()
 
+	explorerSvc := NewService(config.GetString(config.ExplorerEndpointKey))
+
 	// Fund sender address.
-	txID, err := Faucet(address)
+	txID, err := explorerSvc.Faucet(address)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	time.Sleep(5 * time.Second)
-
-	explorerSvc := NewService()
 
 	trxStatus, err := explorerSvc.GetTransactionStatus(txID)
 	if err != nil {

--- a/pkg/explorer/utxo.go
+++ b/pkg/explorer/utxo.go
@@ -226,14 +226,14 @@ func unblindUtxo(
 	chErr <- errors.New("unable to unblind utxo with provided keys")
 }
 
-func getUtxoDetails(
+func (e *explorer) getUtxoDetails(
 	out Utxo,
 	chUnspents chan Utxo,
 	chErr chan error,
 ) {
 	unspent := out.(witnessUtxo)
 
-	prevoutTxHex, err := GetTransactionHex(unspent.Hash())
+	prevoutTxHex, err := e.GetTransactionHex(unspent.Hash())
 	if err != nil {
 		chErr <- err
 		return

--- a/pkg/wallet/transaction.go
+++ b/pkg/wallet/transaction.go
@@ -144,7 +144,7 @@ func (w *Wallet) UpdateSwapTx(opts UpdateSwapTxOpts) (string, []explorer.Utxo, e
 		return "", nil, err
 	}
 
-	selectedUnspents, change, err := explorer.SelectUnSpents(
+	selectedUnspents, change, err := explorer.SelectUnspents(
 		opts.Unspents,
 		unspentsBlinidingKeys,
 		opts.InputAmount,
@@ -323,7 +323,7 @@ func (w *Wallet) UpdateTx(opts UpdateTxOpts) (*UpdateTxResult, error) {
 		// list of outputs to add by adding the change output if necessary
 		for _, asset := range inAssets {
 			if totalAmountsByAsset[asset] > 0 {
-				selectedUnspents, change, err := explorer.SelectUnSpents(
+				selectedUnspents, change, err := explorer.SelectUnspents(
 					opts.Unspents,
 					unspentsBlinidingKeys,
 					totalAmountsByAsset[asset],
@@ -383,7 +383,7 @@ func (w *Wallet) UpdateTx(opts UpdateTxOpts) (*UpdateTxResult, error) {
 				outputsToAdd[changeOutputIndex].Value, _ = bufferutil.ValueToBytes(changeAmount - feeAmount)
 			} else {
 				unspents := getRemainingUnspents(opts.Unspents, inputsToAdd)
-				selectedUnspents, change, err := explorer.SelectUnSpents(
+				selectedUnspents, change, err := explorer.SelectUnspents(
 					unspents,
 					unspentsBlinidingKeys,
 					feeAmount,
@@ -404,7 +404,7 @@ func (w *Wallet) UpdateTx(opts UpdateTxOpts) (*UpdateTxResult, error) {
 			// inputs to add to the tx and add another output for the eventual change
 			// returned by the coin selection
 			unspents := getRemainingUnspents(opts.Unspents, inputsToAdd)
-			selectedUnspents, change, err := explorer.SelectUnSpents(
+			selectedUnspents, change, err := explorer.SelectUnspents(
 				unspents,
 				unspentsBlinidingKeys,
 				feeAmount,


### PR DESCRIPTION
Before this the explorer package was depending on the config one.
With this that dependency is removed so that explorer can be re-used outside of this project.

This closes #47 .

Please @tiero @sekulicd review this.