### PR TITLE
Add trade gRPC client

### DIFF
--- a/pkg/trade/client.go
+++ b/pkg/trade/client.go
@@ -1,0 +1,47 @@
+package tradeclient
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	pbtrade "github.com/tdex-network/tdex-protobuf/generated/go/trade"
+	pbtypes "github.com/tdex-network/tdex-protobuf/generated/go/types"
+
+	"google.golang.org/grpc"
+)
+
+// Client allows to connect with a trader service and to call its RPCs
+type Client struct {
+	client pbtrade.TradeClient
+	conn   *grpc.ClientConn
+}
+
+// NewTradeClient returns a new Client connected to the server at the given
+// host and port through an insecure connection
+func NewTradeClient(host string, port int) (*Client, error) {
+	opts := []grpc.DialOption{}
+	opts = append(opts, grpc.WithInsecure())
+	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", host, port), opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	client := pbtrade.NewTradeClient(conn)
+	return &Client{client, conn}, nil
+}
+
+// CloseConnection closes the connections between the current client and the
+// server
+func (c *Client) CloseConnection() error {
+	return c.conn.Close()
+}
+
+func isValidAsset(asset string) bool {
+	buf, err := hex.DecodeString(asset)
+	return err != nil || len(buf) != 32
+}
+
+func isValidTradeType(tradeType int) bool {
+	return tradeType != int(pbtypes.TradeType_BUY) &&
+		tradeType != int(pbtypes.TradeType_SELL)
+}

--- a/pkg/trade/market.go
+++ b/pkg/trade/market.go
@@ -1,0 +1,80 @@
+package tradeclient
+
+import (
+	"context"
+
+	pbtrade "github.com/tdex-network/tdex-protobuf/generated/go/trade"
+	pbtypes "github.com/tdex-network/tdex-protobuf/generated/go/types"
+)
+
+// Markets calls the Markets rpc and returns its response
+func (c *Client) Markets() (*pbtrade.MarketsReply, error) {
+	return c.client.Markets(context.Background(), &pbtrade.MarketsRequest{})
+}
+
+// BalancesOpts is the struct given to Balances method
+type BalancesOpts struct {
+	MarketBaseAsset  string
+	MarketQuoteAsset string
+}
+
+func (o BalancesOpts) validate() error {
+	if !isValidAsset(o.MarketBaseAsset) {
+		return ErrInvalidBaseAsset
+	}
+	if !isValidAsset(o.MarketQuoteAsset) {
+		return ErrInvalidQuoteAsset
+	}
+	return nil
+}
+
+// Balances crafts the request and calls the Balances rpc
+func (c *Client) Balances(opts BalancesOpts) (*pbtrade.BalancesReply, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	request := &pbtrade.BalancesRequest{
+		Market: &pbtypes.Market{
+			BaseAsset:  opts.MarketBaseAsset,
+			QuoteAsset: opts.MarketQuoteAsset,
+		},
+	}
+	return c.client.Balances(context.Background(), request)
+}
+
+// MarketPriceOpts is the struct given to MarketPrice method
+type MarketPriceOpts struct {
+	MarketBaseAsset  string
+	MarketQuoteAsset string
+	TradeType        int
+}
+
+func (o MarketPriceOpts) validate() error {
+	if !isValidAsset(o.MarketBaseAsset) {
+		return ErrInvalidBaseAsset
+	}
+	if !isValidAsset(o.MarketQuoteAsset) {
+		return ErrInvalidQuoteAsset
+	}
+	if isValidTradeType(o.TradeType) {
+		return ErrInvalidTradeType
+	}
+	return nil
+}
+
+// MarketPrice crafts the request and calls the MarketPrice rpc
+func (c *Client) MarketPrice(opts MarketPriceOpts) (*pbtrade.MarketPriceReply, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	request := &pbtrade.MarketPriceRequest{
+		Market: &pbtypes.Market{
+			BaseAsset:  opts.MarketBaseAsset,
+			QuoteAsset: opts.MarketQuoteAsset,
+		},
+		Type: pbtypes.TradeType(opts.TradeType),
+	}
+	return c.client.MarketPrice(context.Background(), request)
+}

--- a/pkg/trade/trade_complete.go
+++ b/pkg/trade/trade_complete.go
@@ -1,0 +1,77 @@
+package tradeclient
+
+import (
+	"context"
+	"errors"
+
+	pbswap "github.com/tdex-network/tdex-protobuf/generated/go/swap"
+	pbtrade "github.com/tdex-network/tdex-protobuf/generated/go/trade"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// TradeCompleteOpts is the struct given to TradeComplete method
+type TradeCompleteOpts struct {
+	SwapComplete []byte
+	SwapFail     []byte
+}
+
+var (
+	// ErrNullTradeCompleteOpts ...
+	ErrNullTradeCompleteOpts = errors.New("swap complete and swap fail messages must not be both null")
+	// ErrInvalidTradeCompleteOpts ...
+	ErrInvalidTradeCompleteOpts = errors.New("swap complete and swap fail messages must not be both defined")
+	// ErrInvalidSwapCompleteMessage ...
+	ErrInvalidSwapCompleteMessage = errors.New("swap complete must be a valid serialized message")
+	// ErrInvalidSwapFailMessage ...
+	ErrInvalidSwapFailMessage = errors.New("swap fail must be a valid serialized message")
+)
+
+func (o TradeCompleteOpts) validate() error {
+	if len(o.SwapComplete) <= 0 && len(o.SwapFail) <= 0 {
+		return ErrNullTradeCompleteOpts
+	}
+	if len(o.SwapComplete) > 0 && len(o.SwapFail) > 0 {
+		return ErrInvalidTradeCompleteOpts
+	}
+	if len(o.SwapComplete) > 0 {
+		if err := proto.Unmarshal(o.SwapComplete, &pbswap.SwapComplete{}); err != nil {
+			return ErrInvalidSwapCompleteMessage
+		}
+	}
+	if len(o.SwapFail) > 0 {
+		if err := proto.Unmarshal(o.SwapFail, &pbswap.SwapFail{}); err != nil {
+			return ErrInvalidSwapFailMessage
+		}
+	}
+
+	return nil
+}
+
+// TradeComplete crafts the request and calls the TradeComplete rpc
+func (c *Client) TradeComplete(opts TradeCompleteOpts) (*pbtrade.TradeCompleteReply, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	var swapComplete *pbswap.SwapComplete
+	var swapFail *pbswap.SwapFail
+	if len(opts.SwapComplete) > 0 {
+		swapComplete = &pbswap.SwapComplete{}
+		proto.Unmarshal(opts.SwapComplete, swapComplete)
+	}
+	if len(opts.SwapFail) > 0 {
+		swapFail = &pbswap.SwapFail{}
+		proto.Unmarshal(opts.SwapFail, swapFail)
+	}
+
+	request := &pbtrade.TradeCompleteRequest{
+		SwapComplete: swapComplete,
+		SwapFail:     swapFail,
+	}
+	stream, err := c.client.TradeComplete(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+	return stream.Recv()
+}

--- a/pkg/trade/trade_propose.go
+++ b/pkg/trade/trade_propose.go
@@ -1,0 +1,73 @@
+package tradeclient
+
+import (
+	"context"
+	"errors"
+
+	pbswap "github.com/tdex-network/tdex-protobuf/generated/go/swap"
+	pbtrade "github.com/tdex-network/tdex-protobuf/generated/go/trade"
+	pbtypes "github.com/tdex-network/tdex-protobuf/generated/go/types"
+
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	// ErrInvalidBaseAsset ...
+	ErrInvalidBaseAsset = errors.New("base asset must be a 32-byte array in hex format")
+	// ErrInvalidQuoteAsset ...
+	ErrInvalidQuoteAsset = errors.New("quote asset must be a 32-byte array in hex format")
+	// ErrMalformedSwapRequestMessage ...
+	ErrMalformedSwapRequestMessage = errors.New("swap request must be a valid serialized message")
+	// ErrInvalidTradeType ...
+	ErrInvalidTradeType = errors.New("trade type must be either BUY or SELL")
+)
+
+// TradeProposeOpts is the struct given to TradePropose method
+type TradeProposeOpts struct {
+	MarketBaseAsset  string
+	MarketQuoteAsset string
+	SwapRequest      []byte
+	TradeType        int
+}
+
+func (o TradeProposeOpts) validate() error {
+	if isValidAsset(o.MarketBaseAsset) {
+		return ErrInvalidBaseAsset
+	}
+	if isValidAsset(o.MarketQuoteAsset) {
+		return ErrInvalidQuoteAsset
+	}
+	if err := proto.Unmarshal(o.SwapRequest, &pbswap.SwapRequest{}); err != nil {
+		return ErrMalformedSwapRequestMessage
+	}
+	if isValidTradeType(o.TradeType) {
+		return ErrInvalidTradeType
+	}
+
+	return nil
+}
+
+// TradePropose crafts the request and calls the TradePropose rpc
+func (c *Client) TradePropose(opts TradeProposeOpts) (*pbtrade.TradeProposeReply, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	market := &pbtypes.Market{
+		BaseAsset:  opts.MarketBaseAsset,
+		QuoteAsset: opts.MarketQuoteAsset,
+	}
+	swapRequest := &pbswap.SwapRequest{}
+	proto.Unmarshal(opts.SwapRequest, swapRequest)
+
+	request := &pbtrade.TradeProposeRequest{
+		Market:      market,
+		SwapRequest: swapRequest,
+		Type:        pbtypes.TradeType(opts.TradeType),
+	}
+	stream, err := c.client.TradePropose(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+	return stream.Recv()
+}


### PR DESCRIPTION
This adds a new package `pkg/trade` containing the gRPC TradeClient that allows one to call interact with a TradeServer and its RPCs at a specific host and port.

At the moment only the client connecting through insecure connection is supported. Supporting other types of connection should be as easy as creating new factory functions like the NewTradeClient added here.

This closes #55.

Please @tiero, @sekulicd  review this.