### PR TITLE
Swap pkg: Add validation of given transaction

### DIFF
--- a/internal/core/domain/trade_service.go
+++ b/internal/core/domain/trade_service.go
@@ -90,6 +90,21 @@ func (t *Trade) Complete(psetBase64 string, txID string) (*CompleteResult, error
 		return nil, ErrMustBeAccepted
 	}
 
+	if err := pkgswap.ValidateCompletePset(pkgswap.ValidateCompletePsetOpts{
+		PsetBase64:         psetBase64,
+		InputBlindingKeys:  t.SwapAcceptMessage().GetInputBlindingKey(),
+		OutputBlindingKeys: t.SwapAcceptMessage().GetOutputBlindingKey(),
+		SwapRequest:        t.SwapRequestMessage(),
+	}); err != nil {
+		t.Fail(
+			t.SwapAccept.ID,
+			FailedToCompleteStatus,
+			pkgswap.ErrCodeFailedToComplete,
+			err.Error(),
+		)
+		return &CompleteResult{OK: false}, nil
+	}
+
 	opts := wallet.FinalizeAndExtractTransactionOpts{
 		PsetBase64: psetBase64,
 	}

--- a/pkg/swap/complete.go
+++ b/pkg/swap/complete.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-//CompleteOpts is the struct given to the Complete method
+// CompleteOpts is the struct given to the Complete method
 type CompleteOpts struct {
 	Message    []byte
 	PsetBase64 string
@@ -50,4 +50,63 @@ func Complete(complete CompleteOpts) (string, []byte, error) {
 	}
 
 	return randomID, msgCompleteSerialized, nil
+}
+
+// ValidateCompletePsetOpts is the struct given to the ValidateCompletePset method
+type ValidateCompletePsetOpts struct {
+	PsetBase64         string
+	InputBlindingKeys  map[string][]byte
+	OutputBlindingKeys map[string][]byte
+	SwapRequest        *pb.SwapRequest
+}
+
+// ValidateCompletePset takes a VerifyCompeltePsetOpts and returns whether the
+// final signed pset matches the original SwapRequest message
+func ValidateCompletePset(opts ValidateCompletePsetOpts) error {
+	ptx, err := pset.NewPsetFromBase64(opts.PsetBase64)
+	if err != nil {
+		return err
+	}
+
+	swapRequest := opts.SwapRequest
+
+	totalP, err := countCumulativeAmount(ptx.Inputs, swapRequest.GetAssetP(), opts.InputBlindingKeys)
+	if err != nil {
+		return err
+	}
+	if totalP < swapRequest.GetAmountP() {
+		return fmt.Errorf("cumulative utxos count is not enough to cover SwapRequest.amount_p")
+	}
+
+	outputRFound, err := outputFoundInTransaction(
+		ptx.UnsignedTx.Outputs,
+		swapRequest.GetAmountR(),
+		swapRequest.GetAssetR(),
+		opts.OutputBlindingKeys,
+	)
+	if err != nil {
+		return err
+	}
+	if !outputRFound {
+		return fmt.Errorf("either SwapRequest.amount_r or SwapRequest.asset_r do not match the provided pset")
+	}
+
+	totalR, err := countCumulativeAmount(ptx.Inputs, swapRequest.GetAssetR(), opts.InputBlindingKeys)
+	if err != nil {
+		return err
+	}
+	if totalR < swapRequest.GetAmountR() {
+		return fmt.Errorf("cumulative utxos count is not enough to cover SwapRequest.amount_r")
+	}
+
+	outputPFound, err := outputFoundInTransaction(
+		ptx.UnsignedTx.Outputs,
+		swapRequest.GetAmountP(),
+		swapRequest.GetAssetP(),
+		opts.OutputBlindingKeys,
+	)
+	if !outputPFound {
+		return fmt.Errorf("either SwapRequest.amount_p or SwapRequest.asset_p do not match the provided pset")
+	}
+	return nil
 }


### PR DESCRIPTION
This adds the validation of the transaction provided to trader/TradePropose so that we make sure it matches the  parameters of the original SwapRequest message.

This closes #117.

Please @tiero, review this.