### PR TITLE
Return private blind keys in UpdateTx

### DIFF
--- a/pkg/wallet/transaction.go
+++ b/pkg/wallet/transaction.go
@@ -341,13 +341,13 @@ func (w *Wallet) UpdateTx(opts UpdateTxOpts) (*UpdateTxResult, error) {
 					changeOutput, _ := newTxOutput(asset, change, script)
 					outputsToAdd = append(outputsToAdd, changeOutput)
 
-					blindingKey, _, err := w.DeriveBlindingKeyPair(DeriveBlindingKeyPairOpts{
+					prvBlindingKey, _, err := w.DeriveBlindingKeyPair(DeriveBlindingKeyPairOpts{
 						Script: script,
 					})
 					if err != nil {
 						return nil, err
 					}
-					changeOutputsBlindingKeys[hex.EncodeToString(script)] = blindingKey.Serialize()
+					changeOutputsBlindingKeys[hex.EncodeToString(script)] = prvBlindingKey.Serialize()
 				}
 			}
 		}
@@ -418,11 +418,11 @@ func (w *Wallet) UpdateTx(opts UpdateTxOpts) (*UpdateTxResult, error) {
 				)
 				outputsToAdd = append(outputsToAdd, lbtcChangeOutput)
 
-				lbtcChangeBlindingKey, _, _ := w.DeriveBlindingKeyPair(DeriveBlindingKeyPairOpts{
+				lbtcChangePrvBlindingKey, _, _ := w.DeriveBlindingKeyPair(DeriveBlindingKeyPairOpts{
 					Script: lbtcChangeScript,
 				})
 
-				changeOutputsBlindingKeys[hex.EncodeToString(lbtcChangeScript)] = lbtcChangeBlindingKey.Serialize()
+				changeOutputsBlindingKeys[hex.EncodeToString(lbtcChangeScript)] = lbtcChangePrvBlindingKey.Serialize()
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the UpdateTx method of pkg/wallet so that it returns a map script->blind privkey instead of a map script->blind pubkey as `ChangeOutputsBlindingKeys`.
This error was affecting then the blinding of the transaction since BlindSwapTransactions expectes a map string-> blind prvkey, causing the fee change output of a trade tx to be blinded with an incorrect blind key, making it not unblindable.

This closes #121.

Please @tiero, review this.