### PR TITLE
pass logger as input param to dbmanager

### DIFF
--- a/cmd/grpc/main.go
+++ b/cmd/grpc/main.go
@@ -33,7 +33,7 @@ func main() {
 	log.SetLevel(log.Level(config.GetInt(config.LogLevelKey)))
 
 	dbDir := filepath.Join(config.GetString(config.DataDirPathKey), "db")
-	dbManager, err := dbbadger.NewDbManager(dbDir)
+	dbManager, err := dbbadger.NewDbManager(dbDir, log.New())
 	if err != nil {
 		log.WithError(err).Panic("error while opening db")
 	}

--- a/internal/core/application/blockchain_listener_test.go
+++ b/internal/core/application/blockchain_listener_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestUpdateUnspentsForAddress(t *testing.T) {
-	dbManager, err := dbbadger.NewDbManager("testdb")
+	dbManager, err := dbbadger.NewDbManager("testdb", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/core/application/test_util.go
+++ b/internal/core/application/test_util.go
@@ -45,7 +45,7 @@ func b2h(b []byte) string {
 // 	- unspents funding the close market (1 LBTC utxo of amount 1 BTC)
 //	- unspents funding the fee account (1 LBTC utxo of amount 1 BTC)
 func newTestTrader() (*traderService, context.Context, func()) {
-	dbManager, err := dbbadger.NewDbManager("testtrader")
+	dbManager, err := dbbadger.NewDbManager("testtrader", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/core/application/wallet_service_test.go
+++ b/internal/core/application/wallet_service_test.go
@@ -20,7 +20,7 @@ import (
 var ctx = context.Background()
 
 func newTestWallet(w *mockedWallet) (*walletService, func()) {
-	dbManager, err := dbbadger.NewDbManager("testdb")
+	dbManager, err := dbbadger.NewDbManager("testdb", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/infrastructure/storage/db/badger/db_manager.go
+++ b/internal/infrastructure/storage/db/badger/db_manager.go
@@ -13,11 +13,9 @@ type DbManager struct {
 	Store *badgerhold.Store
 }
 
-func NewDbManager(dbDir string) (*DbManager, error) {
+func NewDbManager(dbDir string, logger badger.Logger) (*DbManager, error) {
 	opts := badger.DefaultOptions(dbDir)
-	//TODO add logger as input param so we can control log level,
-	//which is currently annoying in testing
-	//opts.Logger = nil
+	opts.Logger = logger
 
 	db, err := badgerhold.Open(badgerhold.Options{
 		Encoder:          JsonEncode,

--- a/internal/infrastructure/storage/db/badger/test_util.go
+++ b/internal/infrastructure/storage/db/badger/test_util.go
@@ -22,7 +22,7 @@ var testDbDir = "testdb"
 func before() {
 	var err error
 
-	dbManager, err = NewDbManager(testDbDir)
+	dbManager, err = NewDbManager(testDbDir, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This adds enhancement to the DbManager, which now receives logger as input param.
Main motivation was to disable badgerhold to log all stuff which was slowing down test cases.

It closes #103 

@tiero @altafan please review.