### PR TITLE
[GRPC Web server] Allow all origin + custom checks for requests

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -178,11 +179,31 @@ func serveMux(address string, grpcServer *grpc.Server) error {
 
 	go grpcServer.Serve(grpcL)
 	go http.Serve(httpL, http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		// if grpcWebServer.IsGrpcWebRequest(req) {
-		grpcWebServer.ServeHTTP(resp, req)
-		// }
+		if isValidRequest(req) {
+			grpcWebServer.ServeHTTP(resp, req)
+		}
 	}))
 
 	go mux.Serve()
 	return nil
+}
+
+func isValidRequest(req *http.Request) bool {
+	return isValidGrpcWebOptionRequest(req) || isValidGrpcWebRequest(req)
+}
+
+func isValidGrpcWebRequest(req *http.Request) bool {
+	return req.Method == http.MethodPost && isValidGrpcContentTypeHeader(req.Header.Get("content-type"))
+}
+
+func isValidGrpcContentTypeHeader(contentType string) bool {
+	return strings.HasPrefix(contentType, "application/grpc-web-text") ||
+		strings.HasPrefix(contentType, "application/grpc-web")
+}
+
+func isValidGrpcWebOptionRequest(req *http.Request) bool {
+	accessControlHeader := req.Header.Get("Access-Control-Request-Headers")
+	return req.Method == http.MethodOptions &&
+		strings.Contains(accessControlHeader, "x-grpc-web") &&
+		strings.Contains(accessControlHeader, "content-type")
 }


### PR DESCRIPTION
**This PR drop the `IsGrpcWebRequest` check and replace it by custom ones in main.go**

TL;DR
- Allow all origins in GrpcWebServer.
- Check the received request (must be a valid OPTION request or a valid grpc web request): see `isValidRequest` function in `main.go`.

it closes #201 

@sekulicd @tiero @altafan please review