### PR TITLE
Start observing blockchain after unlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,4 +120,4 @@ integrationtest:
 	export TDEX_LOG_LEVEL=5; \
 	export TDEX_BASE_ASSET=5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225; \
 	export TDEX_FEE_ACCOUNT_BALANCE_THRESHOLD=1000; \
-	go test -v -count=1 -race ./cmd/tdexd
+	go test -v -count=1 ./cmd/tdexd

--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -54,6 +54,15 @@ func main() {
 		ErrorHandler:           func(err error) { log.Warn(err) },
 		IntervalInMilliseconds: config.GetInt(config.CrawlIntervalKey),
 	})
+	blockchainListener := application.NewBlockchainListener(
+		unspentRepository,
+		marketRepository,
+		vaultRepository,
+		crawlerSvc,
+		explorerSvc,
+		dbManager,
+	)
+
 	traderSvc := application.NewTradeService(
 		marketRepository,
 		tradeRepository,
@@ -67,17 +76,8 @@ func main() {
 		unspentRepository,
 		crawlerSvc,
 		explorerSvc,
+		blockchainListener,
 	)
-
-	blockchainListener := application.NewBlockchainListener(
-		unspentRepository,
-		marketRepository,
-		vaultRepository,
-		crawlerSvc,
-		explorerSvc,
-		dbManager,
-	)
-	blockchainListener.ObserveBlockchain()
 
 	operatorSvc := application.NewOperatorService(
 		marketRepository,

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -26,6 +26,7 @@ type blockchainListener struct {
 	crawlerSvc        crawler.Service
 	explorerSvc       explorer.Service
 	dbManager         ports.DbManager
+	started           bool
 	// Loggers
 	feeDepositLogged    bool
 	feeBalanceLowLogged bool
@@ -69,12 +70,18 @@ func newBlockchainListener(
 }
 
 func (b *blockchainListener) ObserveBlockchain() {
-	go b.crawlerSvc.Start()
-	go b.handleBlockChainEvents()
+	if !b.started {
+		go b.crawlerSvc.Start()
+		go b.handleBlockChainEvents()
+		b.started = true
+	}
 }
 
 func (b *blockchainListener) StopObserveBlockchain() {
-	b.crawlerSvc.Stop()
+	if b.started {
+		b.crawlerSvc.Stop()
+		b.started = false
+	}
 }
 
 func (b *blockchainListener) handleBlockChainEvents() {

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -157,7 +157,7 @@ func (b *blockchainListener) checkFeeAccountBalance(ctx context.Context, event c
 		b.feeDepositLogged = false
 	} else {
 		if !b.feeDepositLogged {
-			log.Info("fee account deposited, trades can be served")
+			log.Info("fee account funded. Trades can be served")
 			b.feeDepositLogged = true
 		}
 		b.feeBalanceLowLogged = false

--- a/internal/core/application/test_util.go
+++ b/internal/core/application/test_util.go
@@ -101,12 +101,21 @@ func newMockServices(
 		ErrorHandler:           func(err error) { fmt.Println(err) },
 		IntervalInMilliseconds: 100,
 	})
+	blockchainListener := NewBlockchainListener(
+		unspentRepo,
+		marketRepo,
+		vaultRepo,
+		crawlerSvc,
+		explorerSvc,
+		dbManager,
+	)
 
 	walletSvc := newWalletService(
 		vaultRepo,
 		unspentRepo,
 		crawlerSvc,
 		explorerSvc,
+		blockchainListener,
 	)
 
 	if !vaultRepositoryIsEmpty {
@@ -135,17 +144,6 @@ func newMockServices(
 			panic(err)
 		}
 	}
-
-	blockchainListener := NewBlockchainListener(
-		unspentRepo,
-		marketRepo,
-		vaultRepo,
-		crawlerSvc,
-		explorerSvc,
-		dbManager,
-	)
-	// observe the blockchain
-	blockchainListener.ObserveBlockchain()
 
 	// create services to test
 	tradeSvc := newTradeService(
@@ -220,7 +218,6 @@ func newTestWallet(w *mockedWallet) (*walletService, context.Context, func()) {
 		ErrorHandler:           func(err error) { fmt.Println(err) },
 		IntervalInMilliseconds: 100,
 	})
-
 	blockchainListener := NewBlockchainListener(
 		unspentRepo,
 		marketRepo,
@@ -229,14 +226,13 @@ func newTestWallet(w *mockedWallet) (*walletService, context.Context, func()) {
 		explorerSvc,
 		dbManager,
 	)
-	// observe the blockchain
-	blockchainListener.ObserveBlockchain()
 
 	walletSvc := newWalletService(
 		vaultRepo,
 		unspentRepo,
 		crawlerSvc,
 		explorerSvc,
+		blockchainListener,
 	)
 
 	ctx := context.Background()

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -57,12 +57,13 @@ type WalletService interface {
 }
 
 type walletService struct {
-	vaultRepository   domain.VaultRepository
-	unspentRepository domain.UnspentRepository
-	crawlerService    crawler.Service
-	explorerService   explorer.Service
-	walletInitialized bool
-	walletIsSyncing   bool
+	vaultRepository    domain.VaultRepository
+	unspentRepository  domain.UnspentRepository
+	crawlerService     crawler.Service
+	explorerService    explorer.Service
+	blockchainListener BlockchainListener
+	walletInitialized  bool
+	walletIsSyncing    bool
 }
 
 func NewWalletService(
@@ -70,12 +71,14 @@ func NewWalletService(
 	unspentRepository domain.UnspentRepository,
 	crawlerService crawler.Service,
 	explorerService explorer.Service,
+	blockchainListener BlockchainListener,
 ) WalletService {
 	return newWalletService(
 		vaultRepository,
 		unspentRepository,
 		crawlerService,
 		explorerService,
+		blockchainListener,
 	)
 }
 
@@ -84,12 +87,14 @@ func newWalletService(
 	unspentRepository domain.UnspentRepository,
 	crawlerService crawler.Service,
 	explorerService explorer.Service,
+	blockchainListener BlockchainListener,
 ) *walletService {
 	w := &walletService{
-		vaultRepository:   vaultRepository,
-		unspentRepository: unspentRepository,
-		crawlerService:    crawlerService,
-		explorerService:   explorerService,
+		vaultRepository:    vaultRepository,
+		unspentRepository:  unspentRepository,
+		crawlerService:     crawlerService,
+		explorerService:    explorerService,
+		blockchainListener: blockchainListener,
 	}
 	// to understand if the service has an already initialized wallet we check
 	// if the inner vaultRepo is able to return a Vault without passing mnemonic
@@ -189,7 +194,7 @@ func (w *walletService) UnlockWallet(
 		return ErrWalletNotInitialized
 	}
 
-	return w.vaultRepository.UpdateVault(
+	if err := w.vaultRepository.UpdateVault(
 		ctx,
 		nil,
 		"",
@@ -199,7 +204,12 @@ func (w *walletService) UnlockWallet(
 			}
 			return v, nil
 		},
-	)
+	); err != nil {
+		return err
+	}
+
+	w.blockchainListener.ObserveBlockchain()
+	return nil
 }
 
 func (w *walletService) ChangePassword(

--- a/internal/core/domain/vault_model.go
+++ b/internal/core/domain/vault_model.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcutil"
+	"github.com/tdex-network/tdex-daemon/config"
 	"github.com/tdex-network/tdex-daemon/pkg/wallet"
 )
 
@@ -50,14 +51,16 @@ func NewVault(mnemonic []string, passphrase string) (*Vault, error) {
 		return nil, err
 	}
 
+	strMnemonic := strings.Join(mnemonic, " ")
 	encryptedMnemonic, err := wallet.Encrypt(wallet.EncryptOpts{
-		PlainText:  strings.Join(mnemonic, " "),
+		PlainText:  strMnemonic,
 		Passphrase: passphrase,
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	config.Set(config.MnemonicKey, strMnemonic)
 	return &Vault{
 		EncryptedMnemonic:      encryptedMnemonic,
 		PassphraseHash:         btcutil.Hash160([]byte(passphrase)),

--- a/pkg/crawler/service.go
+++ b/pkg/crawler/service.go
@@ -1,7 +1,6 @@
 package crawler
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -113,7 +112,7 @@ func (u *utxoCrawler) AddObservable(observable Observable) {
 	if !contains(u.observables, observable) {
 		obs, ok := observable.(*AddressObservable)
 		if ok {
-			log.Debug("Start observing new account: " + fmt.Sprint(obs.AccountIndex))
+			log.Debugf("new address for account %d added to watchlist", obs.AccountIndex)
 		}
 
 		u.observables = append([]Observable{observable}, u.observables...)


### PR DESCRIPTION
Before this, the bc listener was started by the main function of the daemon. This was the cause of annoying  warn messages when restoring an already used wallet. With this, the bc listener and crawler services are activated only after unlocking the wallet.

Also prior this, there was a bug that was not allowing the operator to unlock a restored wallet. This addresses the issue by setting the plain text mnemonic to viper within the `NewVault` factory function of the vault domain.

Last but not least, this makes sure that after the wallet is initialized, it's locked no matter if an error in the meanwhile.

This closes #226 
This closes #185.

Please @tiero review this.