### PR TITLE
[Testing] Unlock wallet in wallet service test

### DIFF
--- a/internal/core/application/wallet_service_test.go
+++ b/internal/core/application/wallet_service_test.go
@@ -138,7 +138,7 @@ func TestWalletUnlock(t *testing.T) {
 	walletSvc, ctx, close := newTestWallet(dryLockedWallet)
 	defer close()
 
-	address, blindingKey, err := walletSvc.GenerateAddressAndBlindingKey(ctx)
+	_, _, err := walletSvc.GenerateAddressAndBlindingKey(ctx)
 	assert.Equal(t, domain.ErrMustBeUnlocked, err)
 
 	err = walletSvc.UnlockWallet(ctx, dryLockedWallet.password)
@@ -146,7 +146,7 @@ func TestWalletUnlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	address, blindingKey, err = walletSvc.GenerateAddressAndBlindingKey(ctx)
+	address, blindingKey, err := walletSvc.GenerateAddressAndBlindingKey(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/core/application/wallet_service_test.go
+++ b/internal/core/application/wallet_service_test.go
@@ -177,10 +177,16 @@ func TestGenerateAddressAndWalletBalance(t *testing.T) {
 	walletSvc, ctx, close := newTestWallet(dryWallet)
 	defer close()
 
+	err := walletSvc.UnlockWallet(ctx, dryWallet.password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	address, _, err := walletSvc.GenerateAddressAndBlindingKey(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 
 	_, err = walletSvc.explorerService.Faucet(address)
 	if err != nil {

--- a/internal/core/application/wallet_service_test.go
+++ b/internal/core/application/wallet_service_test.go
@@ -244,8 +244,15 @@ func TestSendToMany(t *testing.T) {
 		},
 	}
 
-	walletSvc, ctx, close := newTestWallet(newTradeWallet())
+	wallet := newTradeWallet()
+
+	walletSvc, ctx, close := newTestWallet(wallet)
 	defer close()
+
+	err := walletSvc.UnlockWallet(ctx, wallet.password)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	address, _, err := walletSvc.GenerateAddressAndBlindingKey(ctx)
 	if err != nil {

--- a/pkg/explorer/transaction.go
+++ b/pkg/explorer/transaction.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 
 	"github.com/tdex-network/tdex-daemon/pkg/httputil"
@@ -113,7 +114,11 @@ func (e *explorer) Faucet(address string) (string, error) {
 		return "", err
 	}
 	respBody := map[string]string{}
+
 	err = json.Unmarshal(data, &respBody)
+	if jsonErr, ok := err.(*json.SyntaxError); ok {
+        log.Printf("syntax error at byte offset %d", jsonErr.Offset)
+    }
 	if err != nil {
 		return "", err
 	}

--- a/pkg/explorer/transaction.go
+++ b/pkg/explorer/transaction.go
@@ -110,8 +110,8 @@ func (e *explorer) Faucet(address string) (string, error) {
 		return "", err
 	}
 
-	if hasInternalServerError(resp) {
-		return "", errors.New("Faucet: Internal server error (500)")
+	if isNotStatusOK(resp) {
+		return "", errors.New("Faucet: HTTP error. Error code = " + fmt.Sprint(resp.StatusCode))
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -137,8 +137,8 @@ func (e *explorer) Mint(address string, amount int) (string, string, error) {
 		return "", "", err
 	}
 
-	if hasInternalServerError(resp) {
-		return "", "", errors.New("Mint: Internal server error (500)")
+	if isNotStatusOK(resp) {
+		return "", "", errors.New("Mint: HTTP error. Error code = " + fmt.Sprint(resp.StatusCode))
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -175,6 +175,6 @@ func parseTransactions(txList string) ([]Transaction, error) {
 	return txs, nil
 }
 
-func hasInternalServerError(response *http.Response) bool {
-	return response.StatusCode == 500
+func isNotStatusOK(response *http.Response) bool {
+	return response.StatusCode != 200
 }


### PR DESCRIPTION
**This PR unlocks the wallet before running unit tests in `TestGenerateAddressAndWalletBalance` & `TestSendToMany` in `wallet_service_test.go`**

- unlock wallet in TestGenerateAddressAndWalletBalance
- unlock wallet in TestSendToMany
- add error handling when status code != 200 for Faucet and Mint in `transaction.go`

it closes #218 

@tiero @altafan @sekulicd please review