### PR TITLE
basic instrumentation added

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -115,10 +115,12 @@ func main() {
 
 	log.Info("starting daemon")
 
+	statsDir := filepath.Join(config.GetString(config.DataDirPathKey), "stats")
 	ctx, cancelStats := context.WithCancel(context.Background())
 	stats.EnableMemoryStatistics(
 		ctx,
 		config.GetDuration(config.StatsIntervalKey)*time.Second,
+		statsDir,
 	)
 
 	defer stop(

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,8 @@ const (
 	SSLKeyPathKey = "SSL_KEY"
 	// MnemonicKey is the mnemonic of the master private key of the daemon's wallet
 	MnemonicKey = "MNEMONIC"
+	// StatsIntervalKey defines interval for printing basic tdex statistics
+	StatsIntervalKey = "STATS_INTERVAL"
 )
 
 var vip *viper.Viper
@@ -68,6 +70,7 @@ func init() {
 	vip.SetDefault(TradeExpiryTimeKey, 120)
 	vip.SetDefault(DataDirPathKey, defaultDataDir)
 	vip.SetDefault(PriceSlippageKey, 0.05)
+	vip.SetDefault(StatsIntervalKey, 10)
 
 	validate()
 

--- a/config/config.go
+++ b/config/config.go
@@ -200,6 +200,9 @@ func initDataDir() error {
 	if err := makeDirectoryIfNotExists(filepath.Join(dataDir, "db")); err != nil {
 		log.WithError(err).Panic("error while creating db folder")
 	}
+	if err := makeDirectoryIfNotExists(filepath.Join(dataDir, "stats")); err != nil {
+		log.WithError(err).Panic("error while creating stats folder")
+	}
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/magiconair/properties v1.8.1
+	github.com/prometheus/client_golang v0.9.3
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
@@ -236,6 +237,7 @@ github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzR
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -265,13 +267,17 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
+github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -1,0 +1,102 @@
+package stats
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"runtime"
+	"time"
+)
+
+const (
+	BYTE = 1 << (10 * iota)
+	KILOBYTE
+	MEGABYTE
+	GIGABYTE
+	TERABYTE
+)
+
+// EnableMemoryStatistics enables go routine that periodically prints memory
+// usage of the go process.
+func EnableMemoryStatistics(ctx context.Context, interval time.Duration) {
+
+	ticker := time.NewTicker(interval)
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				PrintMemoryStatistics()
+				PrintNumOfRoutines()
+			case <-ctx.Done():
+				err := DumpPrometheusDefaults()
+				if err != nil {
+					fmt.Println(err)
+				}
+				return
+			}
+		}
+	}()
+}
+
+// toGigabytes returns given memory in bytes to gigabytes.
+func toGigabytes(bytes uint64) float64 {
+	return float64(bytes) / GIGABYTE
+}
+
+// PrintMemoryStatistics prints memory statistics using go runtime library.
+func PrintMemoryStatistics() {
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+
+	bytesTotalAllocated := memStats.TotalAlloc
+	bytesHeapAllocated := memStats.HeapAlloc
+	countMalloc := memStats.Mallocs
+	countFrees := memStats.Frees
+
+	log.Infof(
+		"Total allocated: %.3fGB, Heap allocated: %.3fGB, "+
+			"Allocated objects count: %v, Freed objects count: %v",
+		toGigabytes(bytesTotalAllocated),
+		toGigabytes(bytesHeapAllocated),
+		countMalloc,
+		countFrees,
+	)
+}
+
+// DumpPrometheusDefaults write default Prometheus metrics to a file
+func DumpPrometheusDefaults() error {
+	file, err := os.OpenFile(
+		"stats",
+		os.O_APPEND|os.O_CREATE|os.O_RDWR,
+		0644,
+	)
+	if err != nil {
+		return err
+	}
+	writer := bufio.NewWriter(file)
+
+	metricFamily, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return err
+	}
+	for _, v := range metricFamily {
+		_, err := writer.WriteString(v.String() + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+	file.Close()
+
+	return nil
+}
+
+// PrintNumOfRoutines prints number of go routines currently running
+func PrintNumOfRoutines() {
+	log.Infof("Num of go routines: %v\n", runtime.NumGoroutine())
+}

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -70,7 +70,7 @@ func PrintMemoryStatistics() {
 // DumpPrometheusDefaults write default Prometheus metrics to a file
 func DumpPrometheusDefaults() error {
 	file, err := os.OpenFile(
-		"stats",
+		fmt.Sprintf("stats_%v", time.Now().Format(time.RFC3339)),
 		os.O_APPEND|os.O_CREATE|os.O_RDWR,
 		0644,
 	)

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 )
@@ -21,7 +22,11 @@ const (
 
 // EnableMemoryStatistics enables go routine that periodically prints memory
 // usage of the go process.
-func EnableMemoryStatistics(ctx context.Context, interval time.Duration) {
+func EnableMemoryStatistics(
+	ctx context.Context,
+	interval time.Duration,
+	path string,
+) {
 
 	ticker := time.NewTicker(interval)
 
@@ -32,7 +37,7 @@ func EnableMemoryStatistics(ctx context.Context, interval time.Duration) {
 				PrintMemoryStatistics()
 				PrintNumOfRoutines()
 			case <-ctx.Done():
-				err := DumpPrometheusDefaults()
+				err := DumpPrometheusDefaults(path)
 				if err != nil {
 					fmt.Println(err)
 				}
@@ -68,9 +73,11 @@ func PrintMemoryStatistics() {
 }
 
 // DumpPrometheusDefaults write default Prometheus metrics to a file
-func DumpPrometheusDefaults() error {
+func DumpPrometheusDefaults(path string) error {
 	file, err := os.OpenFile(
-		fmt.Sprintf("stats_%v", time.Now().Format(time.RFC3339)),
+		filepath.Join(
+			path,
+			time.Now().Format(time.RFC3339)),
 		os.O_APPEND|os.O_CREATE|os.O_RDWR,
 		0644,
 	)

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -62,7 +62,7 @@ func PrintMemoryStatistics() {
 	countMalloc := memStats.Mallocs
 	countFrees := memStats.Frees
 
-	log.Infof(
+	log.Debugf(
 		"Total allocated: %.3fGB, Heap allocated: %.3fGB, "+
 			"Allocated objects count: %v, Freed objects count: %v",
 		toGigabytes(bytesTotalAllocated),
@@ -105,5 +105,5 @@ func DumpPrometheusDefaults(path string) error {
 
 // PrintNumOfRoutines prints number of go routines currently running
 func PrintNumOfRoutines() {
-	log.Infof("Num of go routines: %v\n", runtime.NumGoroutine())
+	log.Debugf("Num of go routines: %v\n", runtime.NumGoroutine())
 }


### PR DESCRIPTION
This adds basic instrumentation, it prints basic process info like memory allocation and a number of goroutines.
On server stop event all default prometheus stats are printed to a file, this can potentially help to see basic info before server is stopped.

@tiero @altafan please review if you think that this can be usefull.