### PR TITLE
decrease http client timeout & crawler return when error

### DIFF
--- a/pkg/crawler/observable.go
+++ b/pkg/crawler/observable.go
@@ -29,6 +29,7 @@ func (a *AddressObservable) observe(
 	unspents, err := explorerSvc.GetUnspents(a.Address, [][]byte{a.BlindingKey})
 	if err != nil {
 		errChan <- err
+		return
 	}
 	var eventType EventType
 	switch a.AccountIndex {
@@ -80,6 +81,7 @@ func (t *TransactionObservable) observe(
 	txStatus, err := explorerSvc.GetTransactionStatus(t.TxID)
 	if err != nil {
 		errChan <- err
+		return
 	}
 
 	var confirmed bool

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-var client = &http.Client{Timeout: 30 * time.Second}
+var client = &http.Client{Timeout: 3 * time.Second}
 
 // NewHTTPRequest function builds http call
 // @param method <string>: http method


### PR DESCRIPTION
This decrease http client timeout and fix crawler issue which was happening when explorer returns error.

@tiero @altafan please review.