### PR TITLE
Optimize memory compsumption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
+	github.com/dgraph-io/badger v1.6.2
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/gogo/protobuf v1.2.1
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -96,8 +97,11 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
+github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
+github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=
 github.com/dgraph-io/badger/v2 v2.2007.2 h1:EjjK0KqwaFMlPin1ajhP943VPENHJdEz1KLIegjaI3k=
 github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
+github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -229,6 +233,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/internal/infrastructure/storage/db/badger/db_manager.go
+++ b/internal/infrastructure/storage/db/badger/db_manager.go
@@ -202,6 +202,7 @@ func createDb(dbDir string, logger badger.Logger) (*badgerhold.Store, error) {
 	opts := badger.DefaultOptions(dbDir)
 	opts.Logger = logger
 	opts.ValueLogLoadingMode = options.FileIO
+	opts.Compression = options.ZSTD
 
 	db, err := badgerhold.Open(badgerhold.Options{
 		Encoder:          badgerhold.DefaultEncode,

--- a/internal/infrastructure/storage/db/badger/db_manager.go
+++ b/internal/infrastructure/storage/db/badger/db_manager.go
@@ -190,7 +190,7 @@ func JSONDecode(data []byte, value interface{}) error {
 // EncodeKey encodes key values with a type prefix which allows multiple
 //different types to exist in the badger DB
 func EncodeKey(key interface{}, typeName string) ([]byte, error) {
-	encoded, err := JSONEncode(key)
+	encoded, err := badgerhold.DefaultEncode(key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/storage/db/badger/trade_repository_impl.go
+++ b/internal/infrastructure/storage/db/badger/trade_repository_impl.go
@@ -3,6 +3,7 @@ package dbbadger
 import (
 	"context"
 	"errors"
+
 	pb "github.com/tdex-network/tdex-protobuf/generated/go/operator"
 
 	"github.com/dgraph-io/badger/v2"
@@ -227,7 +228,7 @@ func (t tradeRepositoryImpl) getAllTrades(ctx context.Context) []*domain.Trade {
 			item := it.Item()
 			data, _ := item.ValueCopy(nil)
 			var trade domain.Trade
-			err := JSONDecode(data, &trade)
+			err := badgerhold.DefaultDecode(data, &trade)
 			if err == nil {
 				trades = append(trades, &trade)
 			}

--- a/internal/infrastructure/storage/db/badger/unspent_repository_impl.go
+++ b/internal/infrastructure/storage/db/badger/unspent_repository_impl.go
@@ -202,7 +202,7 @@ func (u unspentRepositoryImpl) getAllUnspents(ctx context.Context) []domain.Unsp
 			item := it.Item()
 			data, _ := item.ValueCopy(nil)
 			var unspent domain.Unspent
-			err := JSONDecode(data, &unspent)
+			err := badgerhold.DefaultDecode(data, &unspent)
 			if err == nil {
 				tradeID, err := u.getLock(ctx, unspent.Key())
 				if err == nil {
@@ -526,7 +526,7 @@ func (u unspentRepositoryImpl) insertLock(
 		return err
 	}
 
-	encData, err := JSONEncode(LockedUnspent{tradeID})
+	encData, err := badgerhold.DefaultEncode(LockedUnspent{tradeID})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes #249:
* Add garbage collection
* Change binary serialization instead of JSON
* Tweaks badger configuration to avoid memory-mapping log files.

Moving to binary serialization drastically improves memory usage.

I tried to run 3 different daemons with the same configuration and by repeating the same operations:
* derive 5 fee addresses and fund each of them with 10 utxos (50 in total)
* derive 5 addresses for a market and fund the market with 1 utxo per each address

The first daemon was the master version and the datadir, overall, ended occupying 4.7MB on disk.
The second daemon had all the changes but the binary serialization and its datadir was 3.7MB.
The last daemon had all the changes and took only 315KB on the disk.

Please @tiero, review this.