### PR TITLE
Update Makefile targets and build scripts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,18 +67,3 @@ archives:
     builds:
       - tdex
     name_template: "tdex-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-#dockers:
-#  -
-#    goos: linux
-#    goarch: amd64
-#    goarm: ''
-#    binaries:
-#    - tdexd-linux
-#    - tdex
-#    image_templates:
-#    - "ghcr.io/tdex-network/tdexd:latest"
-#    - "ghcr.io/tdex-network/tdexd:{{ .Tag }}"
-#    dockerfile: goreleaser.Dockerfile
-#    build_flag_templates:
-#    - "--pull"
-

--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,16 @@
-.PHONY: build-arm build-linux build-mac clean cov fmt help vet test
+.PHONY: build run clean cov fmt help vet test
 
-## build-arm: build binary for ARM
-build-arm:
-	export GO111MODULE=on
-	chmod u+x ./scripts/build
-	./scripts/build linux arm
-
-## build-linux: build binary for Linux
-build-linux:
-	export GO111MODULE=on
-	chmod u+x ./scripts/build
-	./scripts/build linux amd64
-
-## build-mac: build binary for Mac
-build-mac:
-	export GO111MODULE=on
-	chmod u+x ./scripts/build
-	./scripts/build darwin amd64
-
-## build-cli-arm: build CLI for ARM
-build-cli-arm:
-	export GO111MODULE=on
-	chmod u+x ./scripts/build
-	./scripts/build-cli linux arm
-
-## build-linux: build CLI for Linux
-build-cli-linux:
-	export GO111MODULE=on
-	chmod u+x ./scripts/build
-	./scripts/build-cli linux amd64
-
-## build-cli-mac: build CLI for Mac
-build-cli-mac:
-	export GO111MODULE=on
-	chmod u+x ./scripts/build
-	./scripts/build-cli darwin amd64
 
 
 ## build: build for all platforms
-build: build-arm build-linux build-mac
+build: 
+	chmod u+x ./scripts/build
+	./scripts/build
 
 ## build-cli: build CLI for all platforms
-build-cli: build-cli-arm build-cli-linux build-cli-mac
+build-cli: 
+	chmod u+x ./scripts/build-cli
+	./scripts/build-cli
 
 
 ## clean: cleans the binary
@@ -70,23 +39,15 @@ help:
 	@echo "Usage: \n"
 	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
 
-## run-linux: Run locally with default configuration
-run-linux: clean build-linux
+## run: Run locally with default configuration in regtest
+run: clean
 	export TDEX_NETWORK=regtest; \
 	export TDEX_EXPLORER_ENDPOINT=http://127.0.0.1:3001; \
 	export TDEX_LOG_LEVEL=5; \
 	export TDEX_BASE_ASSET=5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225; \
 	export TDEX_FEE_ACCOUNT_BALANCE_THRESHOLD=1000; \
-	./build/tdexd-linux-amd64
+	go run ./cmd/tdexd
 
-## run-mac: Run locally with default configuration
-run-mac: clean build-mac
-	export TDEX_NETWORK=regtest; \
-	export TDEX_EXPLORER_ENDPOINT=http://127.0.0.1:3001; \
-	export TDEX_LOG_LEVEL=5; \
-	export TDEX_BASE_ASSET=5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225; \
-	export TDEX_FEE_ACCOUNT_BALANCE_THRESHOLD=1000; \
-	./build/tdexd-darwin-amd64
 
 ## vet: code analysis
 vet:

--- a/scripts/build
+++ b/scripts/build
@@ -7,7 +7,10 @@ PARENT_PATH=$(dirname $(
   pwd -P
 ))
 
+OS=$(eval "go env GOOS")
+ARCH=$(eval "go env GOARCH")
+
 pushd $PARENT_PATH
 mkdir -p build
-GOOS=$1 GOARCH=$2 go build -ldflags="-s -w" -o build/tdexd-$1-$2 cmd/tdexd/main.go
+GO111MODULE=on CGO_ENABLED=1 go build -ldflags="-s -w" -o build/tdexd-$OS-$ARCH cmd/tdexd/main.go
 popd

--- a/scripts/build-cli
+++ b/scripts/build-cli
@@ -12,5 +12,5 @@ ARCH=$(eval "go env GOARCH")
 
 pushd $PARENT_PATH
 mkdir -p build
-go build -ldflags="-s -w" -o build/tdex-$OS-$ARCH ./cmd/tdex
+GO111MODULE=on go build -ldflags="-s -w" -o build/tdex-$OS-$ARCH ./cmd/tdex
 popd

--- a/scripts/build-cli
+++ b/scripts/build-cli
@@ -7,7 +7,10 @@ PARENT_PATH=$(dirname $(
   pwd -P
 ))
 
+OS=$(eval "go env GOOS")
+ARCH=$(eval "go env GOARCH")
+
 pushd $PARENT_PATH
 mkdir -p build
-GOOS=$1 GOARCH=$2 go build -ldflags="-s -w" -o build/tdex-$1-$2 ./cmd/tdex
+go build -ldflags="-s -w" -o build/tdex-$OS-$ARCH ./cmd/tdex
 popd


### PR DESCRIPTION
This is just an improvement for build scripts, to automatically recognize OS and ARCH for the build. Cross-compilation takes place on CI via .goreleaser.yml﻿ so no need to custom scripts 


Please @altafan review 