### PR TITLE
get block height

### DIFF
--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -92,6 +92,10 @@ func addObservableAfterTimeout(crawler Service) {
 
 type MockExplorer struct{}
 
+func (m MockExplorer) GetBlockHeight() (int, error) {
+	panic("implement me")
+}
+
 func (m MockExplorer) GetUnspentsForAddresses(addresses []string, blindingKeys [][]byte) ([]explorer.Utxo, error) {
 	panic("implement me")
 }

--- a/pkg/explorer/block.go
+++ b/pkg/explorer/block.go
@@ -1,0 +1,29 @@
+package explorer
+
+import (
+	"fmt"
+	"github.com/tdex-network/tdex-daemon/pkg/httputil"
+	"net/http"
+	"strconv"
+)
+
+func (e *explorer) GetBlockHeight() (int, error) {
+	url := fmt.Sprintf(
+		"%v/blocks/tip/height",
+		e.apiUrl,
+	)
+	status, resp, err := httputil.NewHTTPRequest("GET", url, "", nil)
+	if err != nil {
+		return 0, err
+	}
+	if status != http.StatusOK {
+		return 0, fmt.Errorf(resp)
+	}
+
+	blockHeight, err := strconv.Atoi(resp)
+	if err != nil {
+		return 0, err
+	}
+
+	return blockHeight, nil
+}

--- a/pkg/explorer/block.go
+++ b/pkg/explorer/block.go
@@ -14,7 +14,7 @@ func (e *explorer) GetBlockHeight() (int, error) {
 	)
 	status, resp, err := httputil.NewHTTPRequest("GET", url, "", nil)
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 	if status != http.StatusOK {
 		return 0, fmt.Errorf(resp)

--- a/pkg/explorer/explorer.go
+++ b/pkg/explorer/explorer.go
@@ -19,6 +19,7 @@ type Service interface {
 		addresses []string,
 		blindingKeys [][]byte,
 	) ([]Utxo, error)
+	GetBlockHeight() (int, error)
 }
 
 type explorer struct {


### PR DESCRIPTION
This adds new method, GetBlockHeight, to the explorer package.
It returns block tip of the blockchain.

@tiero please review.