### PR TITLE
Crawler and BlockchainListener improvements

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -70,7 +70,6 @@ func main() {
 
 	crawlerSvc := crawler.NewService(crawler.Opts{
 		ExplorerSvc:            explorerSvc,
-		Observables:            []crawler.Observable{},
 		ErrorHandler:           func(err error) { log.Warn(err) },
 		IntervalInMilliseconds: config.GetInt(config.CrawlIntervalKey),
 	})
@@ -90,12 +89,11 @@ func main() {
 		vaultRepository,
 		unspentRepository,
 		explorerSvc,
-		crawlerSvc,
+		blockchainListener,
 	)
 	walletSvc := application.NewWalletService(
 		vaultRepository,
 		unspentRepository,
-		crawlerSvc,
 		explorerSvc,
 		blockchainListener,
 	)
@@ -106,7 +104,7 @@ func main() {
 		tradeRepository,
 		unspentRepository,
 		explorerSvc,
-		crawlerSvc,
+		blockchainListener,
 	)
 
 	// Ports
@@ -191,12 +189,11 @@ func stop(
 	traderServer.Stop()
 	log.Debug("disabled trader interface")
 
-	blockchainListener.StopObserveBlockchain()
+	blockchainListener.StopObservation()
 	// give the crawler the time to terminate
 	time.Sleep(
 		time.Duration(config.GetInt(config.CrawlIntervalKey)) * time.Millisecond,
 	)
-	log.Debug("stopped observing blockchain")
 
 	dbManager.Store.Close()
 	dbManager.UnspentStore.Close()

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tdex-network/tdex-daemon/config"
@@ -16,19 +17,26 @@ const readOnlyTx = true
 
 //BlockchainListener defines the needed method sto start and stop a blockchain listener
 type BlockchainListener interface {
-	ObserveBlockchain()
-	StopObserveBlockchain()
+	StartObservation()
+	StopObservation()
+
+	StartObserveAddress(accountIndex int, addr string, blindKey []byte)
+	StopObserveAddress(addr string)
+
+	StartObserveTx(txid string)
+	StopObserveTx(txid string)
 }
 
 type blockchainListener struct {
-	unspentRepository domain.UnspentRepository
-	marketRepository  domain.MarketRepository
-	vaultRepository   domain.VaultRepository
-	tradeRepository   domain.TradeRepository
-	crawlerSvc        crawler.Service
-	explorerSvc       explorer.Service
-	dbManager         ports.DbManager
-	started           bool
+	unspentRepository  domain.UnspentRepository
+	marketRepository   domain.MarketRepository
+	vaultRepository    domain.VaultRepository
+	tradeRepository    domain.TradeRepository
+	crawlerSvc         crawler.Service
+	explorerSvc        explorer.Service
+	dbManager          ports.DbManager
+	started            bool
+	pendingObservables []crawler.Observable
 	// Loggers
 	feeDepositLogged    bool
 	feeBalanceLowLogged bool
@@ -67,96 +75,170 @@ func newBlockchainListener(
 	dbManager ports.DbManager,
 ) *blockchainListener {
 	return &blockchainListener{
-		unspentRepository: unspentRepository,
-		marketRepository:  marketRepository,
-		vaultRepository:   vaultRepository,
-		tradeRepository:   tradeRepository,
-		crawlerSvc:        crawlerSvc,
-		explorerSvc:       explorerSvc,
-		dbManager:         dbManager,
-		mutex:             &sync.RWMutex{},
+		unspentRepository:  unspentRepository,
+		marketRepository:   marketRepository,
+		vaultRepository:    vaultRepository,
+		tradeRepository:    tradeRepository,
+		crawlerSvc:         crawlerSvc,
+		explorerSvc:        explorerSvc,
+		dbManager:          dbManager,
+		mutex:              &sync.RWMutex{},
+		pendingObservables: make([]crawler.Observable, 0),
 	}
 }
 
-func (b *blockchainListener) ObserveBlockchain() {
+func (b *blockchainListener) StartObservation() {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
 	if !b.started {
+		log.Debug("start crawler")
 		go b.crawlerSvc.Start()
-		go b.handleBlockChainEvents()
+		log.Debug("start listening on event channel")
+		go b.listentToEventChannel()
+		go b.startPendingObservables()
 		b.started = true
 	}
 }
 
-func (b *blockchainListener) StopObserveBlockchain() {
+func (b *blockchainListener) StopObservation() {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
 	if b.started {
+		log.Debug("stop crawler")
 		b.crawlerSvc.Stop()
 		b.started = false
 	}
 }
 
-func (b *blockchainListener) handleBlockChainEvents() {
-	for event := range b.crawlerSvc.GetEventChannel() {
-		go b.handleEvent(event)
+func (b *blockchainListener) StartObserveAddress(
+	accountIndex int,
+	addr string,
+	blindKey []byte,
+) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	observable := &crawler.AddressObservable{
+		AccountIndex: accountIndex,
+		Address:      addr,
+		BlindingKey:  blindKey,
+	}
+
+	if !b.started {
+		b.pendingObservables = append(b.pendingObservables, observable)
+		return
+	}
+	b.crawlerSvc.AddObservable(observable)
+}
+
+func (b *blockchainListener) StartObserveTx(txid string) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	observable := &crawler.TransactionObservable{TxID: txid}
+
+	if !b.started {
+		b.pendingObservables = append(b.pendingObservables, observable)
+		return
+	}
+	b.crawlerSvc.AddObservable(observable)
+}
+
+func (b *blockchainListener) StopObserveAddress(addr string) {
+	b.crawlerSvc.RemoveObservable(&crawler.AddressObservable{
+		Address: addr,
+	})
+}
+
+func (b *blockchainListener) StopObserveTx(txid string) {
+	b.crawlerSvc.RemoveObservable(&crawler.TransactionObservable{TxID: txid})
+}
+
+func (b *blockchainListener) listentToEventChannel() {
+	for {
+		select {
+		case event := <-b.crawlerSvc.GetEventChannel():
+			switch event.Type() {
+			case crawler.QuitSignal:
+				log.Debug("QuitEvent detected")
+				log.Debug("stop listening on event channel")
+				return
+			case crawler.FeeAccountDeposit:
+				ctx, err := b.handleUnspents(event)
+				if err != nil {
+					break
+				}
+				if _, err := b.dbManager.RunTransaction(
+					ctx,
+					readOnlyTx,
+					func(ctx context.Context) (interface{}, error) {
+						return nil, b.checkFeeAccountBalance(ctx)
+					},
+				); err != nil {
+					log.Warnf(
+						"trying to check balance for fee account: %s\n",
+						err.Error(),
+					)
+					break
+				}
+
+			case crawler.MarketAccountDeposit:
+				ctx, err := b.handleUnspents(event)
+				if err != nil {
+					break
+				}
+				e := event.(crawler.AddressEvent)
+				if _, err := b.dbManager.RunTransaction(
+					ctx,
+					!readOnlyTx,
+					func(ctx context.Context) (interface{}, error) {
+						return nil, b.checkMarketAccountFundings(ctx, e.AccountIndex)
+					},
+				); err != nil {
+					log.Warnf(
+						"trying to check fundings for market account %d: %s\n",
+						e.AccountIndex,
+						err.Error(),
+					)
+					break
+				}
+			case crawler.TransactionConfirmed:
+				e := event.(crawler.TransactionEvent)
+				ctx := context.Background()
+				if _, err := b.dbManager.RunTransaction(
+					ctx,
+					!readOnlyTx,
+					func(ctx context.Context) (interface{}, error) {
+						return nil, b.updateTrade(ctx, e)
+					},
+				); err != nil {
+					log.Warnf(
+						"trying to update trade completion status %s\n",
+						err.Error(),
+					)
+					break
+				}
+				// stop watching for a tx after it's confirmed
+				b.StopObserveTx(e.TxID)
+			}
+		default:
+		}
 	}
 }
 
-func (b *blockchainListener) handleEvent(event crawler.Event) {
-	switch event.Type() {
-	case crawler.FeeAccountDeposit:
-		ctx, err := b.handleUnspents(event)
-		if err != nil {
-			break
-		}
-		if _, err := b.dbManager.RunTransaction(
-			ctx,
-			readOnlyTx,
-			func(ctx context.Context) (interface{}, error) {
-				return nil, b.checkFeeAccountBalance(ctx)
-			},
-		); err != nil {
-			log.Warnf(
-				"trying to check balance for fee account: %s\n",
-				err.Error(),
-			)
-			break
-		}
-
-	case crawler.MarketAccountDeposit:
-		ctx, err := b.handleUnspents(event)
-		if err != nil {
-			break
-		}
-		e := event.(crawler.AddressEvent)
-		if _, err := b.dbManager.RunTransaction(
-			ctx,
-			!readOnlyTx,
-			func(ctx context.Context) (interface{}, error) {
-				return nil, b.checkMarketAccountFundings(ctx, e.AccountIndex)
-			},
-		); err != nil {
-			log.Warnf(
-				"trying to check fundings for market account %d: %s\n",
-				e.AccountIndex,
-				err.Error(),
-			)
-			break
-		}
-	case crawler.TransactionConfirmed:
-		e := event.(crawler.TransactionEvent)
-		ctx := context.Background()
-		if _, err := b.dbManager.RunTransaction(
-			ctx,
-			!readOnlyTx,
-			func(ctx context.Context) (interface{}, error) {
-				return nil, b.updateTrade(ctx, e)
-			},
-		); err != nil {
-			log.Warnf(
-				"trying to update trade completion status %s\n",
-				err.Error(),
-			)
-			break
-		}
+func (b *blockchainListener) startPendingObservables() {
+	if len(b.pendingObservables) <= 0 {
+		return
 	}
+
+	for _, observable := range b.pendingObservables {
+		b.crawlerSvc.AddObservable(observable)
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	b.pendingObservables = nil
 }
 
 func (b *blockchainListener) updateTrade(

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -161,8 +161,8 @@ func (b *blockchainListener) listentToEventChannel() {
 		select {
 		case event := <-b.crawlerSvc.GetEventChannel():
 			switch event.Type() {
-			case crawler.QuitSignal:
-				log.Debug("QuitEvent detected")
+			case crawler.CloseSignal:
+				log.Debug("CloseEvent detected")
 				log.Debug("stop listening on event channel")
 				return
 			case crawler.FeeAccountDeposit:

--- a/internal/core/application/test_util.go
+++ b/internal/core/application/test_util.go
@@ -105,7 +105,6 @@ func newMockServices(
 	}
 	crawlerSvc := crawler.NewService(crawler.Opts{
 		ExplorerSvc:            explorerSvc,
-		Observables:            []crawler.Observable{},
 		ErrorHandler:           func(err error) { fmt.Println(err) },
 		IntervalInMilliseconds: 100,
 	})
@@ -122,7 +121,6 @@ func newMockServices(
 	walletSvc := newWalletService(
 		vaultRepo,
 		unspentRepo,
-		crawlerSvc,
 		explorerSvc,
 		blockchainListener,
 	)
@@ -155,7 +153,7 @@ func newMockServices(
 		vaultRepo,
 		unspentRepo,
 		explorerSvc,
-		crawlerSvc,
+		blockchainListener,
 	)
 
 	operatorSvc := NewOperatorService(
@@ -164,11 +162,11 @@ func newMockServices(
 		tradeRepo,
 		unspentRepo,
 		explorerSvc,
-		crawlerSvc,
+		blockchainListener,
 	)
 
 	close := func() {
-		blockchainListener.StopObserveBlockchain()
+		blockchainListener.StopObservation()
 		config.Set(config.MnemonicKey, "")
 	}
 
@@ -223,7 +221,6 @@ func newTestWallet(w *mockedWallet) (*walletService, context.Context, func()) {
 	explorerSvc, _ := getExplorer()
 	crawlerSvc := crawler.NewService(crawler.Opts{
 		ExplorerSvc:            explorerSvc,
-		Observables:            []crawler.Observable{},
 		ErrorHandler:           func(err error) { fmt.Println(err) },
 		IntervalInMilliseconds: 100,
 	})
@@ -240,7 +237,6 @@ func newTestWallet(w *mockedWallet) (*walletService, context.Context, func()) {
 	walletSvc := newWalletService(
 		vaultRepo,
 		unspentRepo,
-		crawlerSvc,
 		explorerSvc,
 		blockchainListener,
 	)
@@ -248,7 +244,7 @@ func newTestWallet(w *mockedWallet) (*walletService, context.Context, func()) {
 	ctx := context.Background()
 
 	closeFn := func() {
-		blockchainListener.StopObserveBlockchain()
+		blockchainListener.StopObservation()
 		config.Set(config.MnemonicKey, "")
 	}
 

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -1,0 +1,30 @@
+package crawler
+
+import (
+	"github.com/tdex-network/tdex-daemon/pkg/explorer"
+)
+
+// Event are emitted through a channel during observation.
+type Event interface {
+	Type() EventType
+}
+
+// Observable represent object that can be observe on the blockchain.
+type Observable interface {
+	observe(
+		explorerSvc explorer.Service,
+		errChan chan error,
+		eventChan chan Event,
+	)
+	key() string
+}
+
+// Service is the interface for Crawler
+type Service interface {
+	Start()
+	Stop()
+	AddObservable(observable Observable)
+	RemoveObservable(observable Observable)
+	IsObservingAddresses(addresses []string) bool
+	GetEventChannel() chan Event
+}

--- a/pkg/crawler/event.go
+++ b/pkg/crawler/event.go
@@ -3,7 +3,8 @@ package crawler
 import "github.com/tdex-network/tdex-daemon/pkg/explorer"
 
 const (
-	FeeAccountDeposit EventType = iota
+	QuitSignal EventType = iota
+	FeeAccountDeposit
 	MarketAccountDeposit
 	TransactionConfirmed
 	TransactionUnConfirmed
@@ -13,6 +14,8 @@ type EventType int
 
 func (et EventType) String() string {
 	switch et {
+	case QuitSignal:
+		return "QuitSignal"
 	case FeeAccountDeposit:
 		return "FeeAccountDeposit"
 	case MarketAccountDeposit:
@@ -24,6 +27,12 @@ func (et EventType) String() string {
 	default:
 		return "Unknown"
 	}
+}
+
+type QuitEvent struct{}
+
+func (q QuitEvent) Type() EventType {
+	return QuitSignal
 }
 
 type AddressEvent struct {

--- a/pkg/crawler/event.go
+++ b/pkg/crawler/event.go
@@ -3,7 +3,7 @@ package crawler
 import "github.com/tdex-network/tdex-daemon/pkg/explorer"
 
 const (
-	QuitSignal EventType = iota
+	CloseSignal EventType = iota
 	FeeAccountDeposit
 	MarketAccountDeposit
 	TransactionConfirmed
@@ -14,8 +14,8 @@ type EventType int
 
 func (et EventType) String() string {
 	switch et {
-	case QuitSignal:
-		return "QuitSignal"
+	case CloseSignal:
+		return "CloseSignal"
 	case FeeAccountDeposit:
 		return "FeeAccountDeposit"
 	case MarketAccountDeposit:
@@ -29,10 +29,10 @@ func (et EventType) String() string {
 	}
 }
 
-type QuitEvent struct{}
+type CloseEvent struct{}
 
-func (q QuitEvent) Type() EventType {
-	return QuitSignal
+func (q CloseEvent) Type() EventType {
+	return CloseSignal
 }
 
 type AddressEvent struct {

--- a/pkg/crawler/service.go
+++ b/pkg/crawler/service.go
@@ -2,9 +2,7 @@ package crawler
 
 import (
 	"sync"
-	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
 )
 
@@ -13,206 +11,120 @@ const (
 	errorQueueMaxSize = 10
 )
 
-// Event are emitted through a channel during observation.
-type Event interface {
-	Type() EventType
-}
-
-// Observable represent object that can be observe on the blockchain.
-type Observable interface {
-	observe(
-		w *sync.WaitGroup,
-		explorerSvc explorer.Service,
-		errChan chan error,
-		eventChan chan Event,
-	)
-	isEqual(observable Observable) bool
-}
-
-// Service is the interface for Crawler
-type Service interface {
-	Start()
-	Stop()
-	AddObservable(observable Observable)
-	RemoveObservable(observable Observable)
-	IsObservingAddresses(addresses []string) bool
-	GetEventChannel() chan Event
-}
-
-type utxoCrawler struct {
-	interval     *time.Ticker
+type blockchainCrawler struct {
+	interval     int
 	explorerSvc  explorer.Service
 	errChan      chan error
-	quitChan     chan int
 	eventChan    chan Event
-	observables  []Observable
+	observables  map[string]*observableHandler
 	errorHandler func(err error)
 	mutex        *sync.RWMutex
+	wg           *sync.WaitGroup
 }
 
 // Opts defines the parameters needed for creating a crawler service with NewService method
 type Opts struct {
 	ExplorerSvc            explorer.Service
 	IntervalInMilliseconds int
-	Observables            []Observable
 	ErrorHandler           func(err error)
 }
 
 // NewService returns an utxoCrawelr that is ready for watch for blockchain activites. Use Start and Stop methods to manage it.
 func NewService(opts Opts) Service {
-
-	interval := time.NewTicker(time.Duration(opts.IntervalInMilliseconds) * time.Millisecond)
-
-	return &utxoCrawler{
-		interval:     interval,
+	return &blockchainCrawler{
+		interval:     opts.IntervalInMilliseconds,
 		explorerSvc:  opts.ExplorerSvc,
 		errChan:      make(chan error, errorQueueMaxSize),
-		quitChan:     make(chan int),
 		eventChan:    make(chan Event, eventQueueMaxSize),
-		observables:  opts.Observables,
+		observables:  map[string]*observableHandler{},
 		errorHandler: opts.ErrorHandler,
 		mutex:        &sync.RWMutex{},
+		wg:           &sync.WaitGroup{},
 	}
 }
 
 // Start starts crawler which periodically "scans" blockchain for specific
 // events/Observable object
-func (u *utxoCrawler) Start() {
-	var wg sync.WaitGroup
-	log.Debug("start observe")
+func (bc *blockchainCrawler) Start() {
 	for {
 		select {
-		case <-u.interval.C:
-			log.Debug("observe interval")
-			u.observeAll(&wg)
-		case err := <-u.errChan:
-			go u.errorHandler(err)
-		case <-u.quitChan:
-			log.Debug("stop observe")
-			u.interval.Stop()
-			wg.Wait()
-			close(u.eventChan)
-			return
+		case err, more := <-bc.errChan:
+			if !more {
+				return
+			}
+			go bc.errorHandler(err)
 		}
 	}
 }
 
 // Stop stops crawler
-func (u *utxoCrawler) Stop() {
-	u.quitChan <- 1
+func (bc *blockchainCrawler) Stop() {
+	bc.mutex.Lock()
+	defer bc.mutex.Unlock()
+	for _, obsHandler := range bc.observables {
+		go obsHandler.stop()
+	}
+	bc.wg.Wait()
+	bc.eventChan <- QuitEvent{}
+	close(bc.errChan)
+	return
 }
 
 // GetEventChannel returns Event channel which can be used to "listen" to
 // blockchain events
-func (u *utxoCrawler) GetEventChannel() chan Event {
-	return u.eventChan
+func (bc *blockchainCrawler) GetEventChannel() chan Event {
+	bc.mutex.RLock()
+	defer bc.mutex.RUnlock()
+	return bc.eventChan
 }
 
 // AddObservable adds new Observable to the list of Observables to be "watched
 // over" only if the same Observable is not already in the list
-func (u *utxoCrawler) AddObservable(observable Observable) {
-	u.mutex.Lock()
-	defer u.mutex.Unlock()
+func (bc *blockchainCrawler) AddObservable(observable Observable) {
+	bc.mutex.Lock()
+	defer bc.mutex.Unlock()
 
-	if !contains(u.observables, observable) {
-		obs, ok := observable.(*AddressObservable)
-		if ok {
-			log.Debugf("new address for account %d added to watchlist", obs.AccountIndex)
-		}
+	if _, ok := bc.observables[observable.key()]; !ok {
+		obsHandler := newObservableHandler(
+			observable,
+			bc.explorerSvc,
+			bc.wg,
+			bc.interval,
+			bc.eventChan,
+			bc.errChan,
+		)
 
-		u.observables = append([]Observable{observable}, u.observables...)
+		bc.observables[observable.key()] = obsHandler
+		go obsHandler.start()
 	}
 }
 
 // RemoveObservable stops "watching" given Observable
-func (u *utxoCrawler) RemoveObservable(observable Observable) {
-	observables := u.getObservable()
+func (bc *blockchainCrawler) RemoveObservable(observable Observable) {
+	bc.mutex.Lock()
+	defer bc.mutex.Unlock()
 
-	u.mutex.Lock()
+	if obsHandler, ok := bc.observables[observable.key()]; ok {
 
-	switch obs := observable.(type) {
-	case *AddressObservable:
-		u.removeAddressObservable(*obs, observables)
-	case *TransactionObservable:
-		u.removeTransactionObservable(*obs, observables)
+		obsHandler.stop()
+		delete(bc.observables, observable.key())
 	}
-	u.mutex.Unlock()
 }
 
 //IsObservingAddresses returns true if the crawler is observing at least one address given as parameter.
 //false in the other case
-func (u *utxoCrawler) IsObservingAddresses(addresses []string) bool {
+func (bc *blockchainCrawler) IsObservingAddresses(addresses []string) bool {
 	if len(addresses) == 0 {
 		return false
 	}
-	observables := u.getObservable()
-	for _, observable := range observables {
-		switch observable := observable.(type) {
-		case *AddressObservable:
-			for _, addr := range addresses {
-				if observable.Address == addr {
-					return true
-				}
-			}
-			continue
-		default:
-			continue
+
+	bc.mutex.RLock()
+	defer bc.mutex.RUnlock()
+
+	for _, addr := range addresses {
+		if _, ok := bc.observables[addr]; !ok {
+			return false
 		}
 	}
-	return false
-}
-
-func (u *utxoCrawler) observeAll(w *sync.WaitGroup) {
-	observables := u.getObservable()
-	for _, o := range observables {
-		w.Add(1)
-		go o.observe(w, u.explorerSvc, u.errChan, u.eventChan)
-	}
-}
-
-func (u *utxoCrawler) getObservable() []Observable {
-	u.mutex.RLock()
-	defer u.mutex.RUnlock()
-	return u.observables
-}
-
-func (u *utxoCrawler) removeAddressObservable(
-	observable AddressObservable,
-	observables []Observable) {
-	newObservableList := make([]Observable, 0)
-	for _, obs := range observables {
-		if o, ok := obs.(*AddressObservable); ok {
-			if o.Address != observable.Address {
-				newObservableList = append(newObservableList, o)
-			}
-		} else {
-			newObservableList = append(newObservableList, o)
-		}
-	}
-	u.observables = newObservableList
-}
-
-func (u *utxoCrawler) removeTransactionObservable(
-	observable TransactionObservable,
-	observables []Observable) {
-	newObservableList := make([]Observable, 0)
-	for _, obs := range observables {
-		if o, ok := obs.(*TransactionObservable); ok {
-			if o.TxID != observable.TxID {
-				newObservableList = append(newObservableList, o)
-			}
-		} else {
-			newObservableList = append(newObservableList, o)
-		}
-	}
-	u.observables = newObservableList
-}
-
-func contains(observables []Observable, observable Observable) bool {
-	for _, o := range observables {
-		if o.isEqual(observable) {
-			return true
-		}
-	}
-	return false
+	return true
 }

--- a/pkg/crawler/service.go
+++ b/pkg/crawler/service.go
@@ -65,7 +65,7 @@ func (bc *blockchainCrawler) Stop() {
 		go obsHandler.stop()
 	}
 	bc.wg.Wait()
-	bc.eventChan <- QuitEvent{}
+	bc.eventChan <- CloseEvent{}
 	close(bc.errChan)
 	return
 }

--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -37,13 +37,10 @@ func listen(t *testing.T, crawlSvc Service) {
 loop:
 	for {
 		select {
-		case event, more := <-eventChan:
-			if !more {
-				break loop
-			}
+		case event := <-eventChan:
 			switch e := event.(type) {
-			// case QuitEvent:
-			// 	break
+			case CloseEvent:
+				break loop
 			case AddressEvent:
 				for _, u := range e.Utxos {
 					t.Log(fmt.Sprintf("%v %v %v", "ADR", e.EventType, u.Value()))


### PR DESCRIPTION
This contains a little refactor of the crawler pkg and also of the BlockchainListener service of the application level.

Before this, the crawler was using a single ticker for all its observables, now, on the contrary, every observable has its own ticker (every ticker has the same duration still - refers to CRAWL_INTERVAL env var).
The usage of its inner channels has been fixed:
* the original `quitChan` has been removed
* `errChan` is closed when stopping the crawler
* a special event `QuitEvent` is now sent over the `eventChan` to notify the client (listening for events with `GetEventChannel()`) that no more events will be sent over the channel, which can be considered closed. In fact, this happens ONLY when stopping the crawler. Since the crawler manages many go-routines (one per each observable), the `eventChan` can't be safely closed, generating a race condition. This is the reason why the channel is not closed but a close signal is sent over it instead.
* a new `observableHandler` type has been added which takes care of starting and stopping the observation go-routine. When stopping the crawler, every observableHandler is stopped, and only after that the `CloseEvent` is sent over the `eventChan`. This way it's not possible that some other events are read from that channel after `CloseEvent`.

Before this, services were making directly use of the crawler service (basically only for adding addresses and txs). Starting from this, instead, the BlockchainListener has been refactored a bit so that other app services use it instead of the crawler_
* existing start/stop methods have been renamed `StartObservation()` and `StopObservation()`
* new public methods for adding/removing addresses or txs to the crawler's observations
* prevent adding observables to the crawler before it has been started (this was actually happening and we weren't aware of this problem yet) - the bc listener now has a pendingObservables field which is filled in such situation and emptied right after starting the service.

BONUS: before this, every app service was making a blocking call for adding observables; now these kind of operations are ALL non-blocking (make use of go-routine) except for only one situation: when creating the wallet service we already check if it can be restored from storage in [`newWalletService`](https://github.com/altafan/tdex-daemon/blob/crawler-async/internal/core/application/wallet_service.go#L82). In this case the observation phase must be blocking because the wallet shouldn't be considered initialized BEFORE the listener has started tracking all wallet addresses.

This closes #256.
This closes #257.

Please @tiero @sekulicd  review this.