### PR TITLE
Optional restore for InitWallet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.5.1
-	github.com/tdex-network/tdex-protobuf v0.0.0-20210222134250-77814a8c3ea3
+	github.com/tdex-network/tdex-protobuf v0.0.0-20210303152020-690e6e604cae
 	github.com/thanhpk/randstr v1.0.4
 	github.com/timshannon/badgerhold/v2 v2.0.0-20201016201833-94bc303c76d4
 	github.com/tyler-smith/go-bip39 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,8 @@ github.com/tdex-network/tdex-protobuf v0.0.0-20201201222008-03e29cbfd003 h1:yF8H
 github.com/tdex-network/tdex-protobuf v0.0.0-20201201222008-03e29cbfd003/go.mod h1:tVWv01BSMH/neJOsixdDFU5T0ll0OZbPliLXBsYQjA8=
 github.com/tdex-network/tdex-protobuf v0.0.0-20210222134250-77814a8c3ea3 h1:UYe+5Fqep7pwr+36p5GA2MdCAvaJY+s2wQrjftdac+4=
 github.com/tdex-network/tdex-protobuf v0.0.0-20210222134250-77814a8c3ea3/go.mod h1:tVWv01BSMH/neJOsixdDFU5T0ll0OZbPliLXBsYQjA8=
+github.com/tdex-network/tdex-protobuf v0.0.0-20210303152020-690e6e604cae h1:LNI7IDdED4p5DVm9xIOTE1lJo1p9MRg72EGPPjhQaF8=
+github.com/tdex-network/tdex-protobuf v0.0.0-20210303152020-690e6e604cae/go.mod h1:tVWv01BSMH/neJOsixdDFU5T0ll0OZbPliLXBsYQjA8=
 github.com/thanhpk/randstr v1.0.4 h1:IN78qu/bR+My+gHCvMEXhR/i5oriVHcTB/BJJIRTsNo=
 github.com/thanhpk/randstr v1.0.4/go.mod h1:M/H2P1eNLZzlDwAzpkkkUvoyNNMbzRGhESZuEQk3r0U=
 github.com/timshannon/badgerhold/v2 v2.0.0-20201016201833-94bc303c76d4 h1:5g8lFrH34MM7MhZyluuTOJEuCjDHPgFZfNSHvOBLaNE=

--- a/internal/core/application/wallet_service_test.go
+++ b/internal/core/application/wallet_service_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/vulpemventures/go-elements/network"
 )
 
+const restoreWallet = true
+
 func TestNewWalletService(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -46,7 +48,7 @@ func TestInitWalletWrongSeed(t *testing.T) {
 	t.Cleanup(close)
 
 	wrongSeed := []string{"test"}
-	err := walletSvc.InitWallet(ctx, wrongSeed, "pass")
+	err := walletSvc.InitWallet(ctx, wrongSeed, "pass", !restoreWallet)
 	assert.Error(t, err)
 }
 
@@ -77,7 +79,7 @@ func TestInitEmptyWallet(t *testing.T) {
 		Network:        &network.Regtest,
 	})
 
-	err := walletSvc.InitWallet(ctx, emptyWallet.mnemonic, emptyWallet.password)
+	err := walletSvc.InitWallet(ctx, emptyWallet.mnemonic, emptyWallet.password, !restoreWallet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +119,7 @@ func TestInitUsedWallet(t *testing.T) {
 		Network:        &network.Regtest,
 	})
 
-	err := walletSvc.InitWallet(ctx, usedWallet.mnemonic, usedWallet.password)
+	err := walletSvc.InitWallet(ctx, usedWallet.mnemonic, usedWallet.password, restoreWallet)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/interfaces/grpc/handler/wallet.go
+++ b/internal/interfaces/grpc/handler/wallet.go
@@ -116,6 +116,7 @@ func (w walletHandler) initWallet(
 				ctx,
 				mnemonic,
 				string(password),
+				req.GetRestore(),
 			); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Before this, the daemon was always trying to restore the wallet while processing an `InitWallet` request. This has been made optional now. The operator can specify if the wallet must be restore by adding a `restore: true` flag to the request. By default the restoration is skipped.

Closes #264.

Please @tiero review this