### PR TITLE
[Elements explorer] Rescan only when restoring funds

### DIFF
--- a/pkg/explorer/elements/service.go
+++ b/pkg/explorer/elements/service.go
@@ -50,7 +50,11 @@ func NewService(endpoint string, rescanTimestamp interface{}) (
 	return service, nil
 }
 
-func (e *elements) importAddress(addr, label string) error {
+func (e *elements) importAddress(addr, label string, rescan bool) error {
+	rescanTime := e.rescanTimestamp
+	if !rescan {
+		rescanTime = "now"
+	}
 	r, err := e.client.call("importmulti", []interface{}{
 		[]map[string]interface{}{
 			{
@@ -59,11 +63,11 @@ func (e *elements) importAddress(addr, label string) error {
 				},
 				"watchonly": true,
 				"label":     label,
-				"timestamp": e.rescanTimestamp,
+				"timestamp": rescanTime,
 			},
 		},
 		map[string]bool{
-			"rescan": true,
+			"rescan": rescan,
 		},
 	})
 	if err = handleError(err, &r); err != nil {

--- a/pkg/explorer/elements/transaction.go
+++ b/pkg/explorer/elements/transaction.go
@@ -87,7 +87,7 @@ func (e *elements) GetTransactionsForAddress(addr string) ([]explorer.Transactio
 		return nil, fmt.Errorf("check import: %w", err)
 	}
 	if !isImportedAddress {
-		if err := e.importAddress(addr, addrLabel); err != nil {
+		if err := e.importAddress(addr, addrLabel, true); err != nil {
 			return nil, fmt.Errorf("import: %w", err)
 		}
 	}

--- a/pkg/explorer/elements/unspents.go
+++ b/pkg/explorer/elements/unspents.go
@@ -24,7 +24,7 @@ func (e *elements) GetUnspents(addr string, blindKeys [][]byte) ([]explorer.Utxo
 	}
 
 	if !isAddressImported {
-		if err := e.importAddress(addr, addrLabel); err != nil {
+		if err := e.importAddress(addr, addrLabel, false); err != nil {
 			return nil, fmt.Errorf("import: %w", err)
 		}
 	}
@@ -83,7 +83,7 @@ func (e *elements) GetUnspentsForAddresses(
 		}
 
 		if !isAddressImported {
-			if err := e.importAddress(addr, addrLabel); err != nil {
+			if err := e.importAddress(addr, addrLabel, false); err != nil {
 				return nil, fmt.Errorf("import: %w", err)
 			}
 		}


### PR DESCRIPTION
This fixes the Elements explorer so that addresses are rescanned only when restoring funds (GetTransactionsForAddress), preventing do so when fetching unspents for address(es) (GetUnspents GetUnspentsForAddresses).

Please @tiero review this