### PR TITLE
Disable restore wallet with Elements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -159,6 +159,11 @@ func Set(key string, value interface{}) {
 	vip.Set(key, value)
 }
 
+// IsSet returns whether the give key is set
+func IsSet(key string) bool {
+	return vip.IsSet(key)
+}
+
 // GetMnemonic returns the current set mnemonic
 func GetMnemonic() []string {
 	var mnemonic []string

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -133,6 +133,13 @@ func (w *walletService) InitWallet(
 		return nil
 	}
 
+	if restore && config.IsSet(config.ElementsRPCEndpointKey) {
+		return fmt.Errorf(
+			"Restoring a wallet through the Elements explorer is not availble at the " +
+				"moment. Please restart the daemon using the Esplora block explorer.",
+		)
+	}
+
 	// lock vault no regardless an error occurs or not
 	var vault *domain.Vault
 	defer func() {

--- a/pkg/crawler/observable.go
+++ b/pkg/crawler/observable.go
@@ -2,11 +2,12 @@ package crawler
 
 import (
 	"context"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
 	"sync"
 	"time"
 
+	"golang.org/x/time/rate"
+
+	log "github.com/sirupsen/logrus"
 	"github.com/tdex-network/tdex-daemon/internal/core/domain"
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
 )
@@ -70,7 +71,6 @@ func (a *AddressObservable) observe(
 		errChan <- err
 		return
 	}
-	log.Debugf("address observer: %v", a.Address)
 
 	observableStatus.Set(Processed)
 
@@ -202,6 +202,7 @@ func newObservableHandler(
 }
 
 func (oh *observableHandler) start() {
+	oh.logAction("start")
 	oh.wg.Add(1)
 	for {
 		select {
@@ -224,6 +225,17 @@ func (oh *observableHandler) start() {
 }
 
 func (oh *observableHandler) stop() {
+	oh.logAction("stop")
 	oh.stopChan <- 1
 	oh.wg.Done()
+}
+
+func (oh *observableHandler) logAction(action string) {
+	obs := oh.observable
+	switch obs.(type) {
+	case *AddressObservable:
+		log.Debugf("%s observing address: %v", action, obs.key())
+	case *TransactionObservable:
+		log.Debugf("%s observing tx: %v", action, obs.key())
+	}
 }

--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -136,7 +136,7 @@ func (m MockExplorer) GetUnspents(addr string, blindKeys [][]byte) (
 func (m MockExplorer) GetTransactionHex(txID string) (string, error) {
 	return "", errors.New("implement me")
 }
-func (m MockExplorer) GetTransactionsForAddress(addr string) ([]explorer.Transaction, error) {
+func (m MockExplorer) GetTransactionsForAddress(addr string, blindingKey []byte) ([]explorer.Transaction, error) {
 	return nil, errors.New("implement me")
 }
 func (m MockExplorer) BroadcastTransaction(txHex string) (string, error) {

--- a/pkg/explorer/elements/transaction.go
+++ b/pkg/explorer/elements/transaction.go
@@ -77,7 +77,7 @@ func (e *elements) GetTransactionStatus(txid string) (map[string]interface{}, er
 // associated with it when importing to prevent doing this operation for those
 // already tracked. The transactions are retrieved via the
 // listreceivedbyaddress RPC.
-func (e *elements) GetTransactionsForAddress(addr string) ([]explorer.Transaction, error) {
+func (e *elements) GetTransactionsForAddress(addr string, blindingKey []byte) ([]explorer.Transaction, error) {
 	addrLabel, err := addressLabel(addr)
 	if err != nil {
 		return nil, fmt.Errorf("label: %w", err)
@@ -87,7 +87,7 @@ func (e *elements) GetTransactionsForAddress(addr string) ([]explorer.Transactio
 		return nil, fmt.Errorf("check import: %w", err)
 	}
 	if !isImportedAddress {
-		if err := e.importAddress(addr, addrLabel, true); err != nil {
+		if err := e.importAddress(addr, addrLabel, blindingKey, true); err != nil {
 			return nil, fmt.Errorf("import: %w", err)
 		}
 	}

--- a/pkg/explorer/elements/transaction_test.go
+++ b/pkg/explorer/elements/transaction_test.go
@@ -47,7 +47,7 @@ func TestIsTransactionConfirmed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(2 * time.Second)
 
 	isConfirmed, err := elementsSvc.IsTransactionConfirmed(txid)
 	if err != nil {
@@ -72,7 +72,7 @@ func TestGetTransactionStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(2 * time.Second)
 
 	status, err := elementsSvc.GetTransactionStatus(txid)
 	if err != nil {
@@ -103,7 +103,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(2 * time.Second)
 
 	txs, err := elementsSvc.GetTransactionsForAddress(addr, blindKey)
 	if err != nil {

--- a/pkg/explorer/elements/transaction_test.go
+++ b/pkg/explorer/elements/transaction_test.go
@@ -91,7 +91,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	addr, _, err := newTestData()
+	addr, blindKey, err := newTestData()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	txs, err := elementsSvc.GetTransactionsForAddress(addr)
+	txs, err := elementsSvc.GetTransactionsForAddress(addr, blindKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/explorer/esplora/transaction.go
+++ b/pkg/explorer/esplora/transaction.go
@@ -66,7 +66,7 @@ func (e *esplora) GetTransactionStatus(txID string) (map[string]interface{}, err
 	return trxStatus, nil
 }
 
-func (e *esplora) GetTransactionsForAddress(address string) ([]explorer.Transaction, error) {
+func (e *esplora) GetTransactionsForAddress(address string, _ []byte) ([]explorer.Transaction, error) {
 	url := fmt.Sprintf("%s/address/%s/txs", e.apiURL, address)
 	status, resp, err := httputil.NewHTTPRequest("GET", url, "", nil)
 	if err != nil {

--- a/pkg/explorer/esplora/transaction_test.go
+++ b/pkg/explorer/esplora/transaction_test.go
@@ -4,20 +4,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec"
 	"github.com/magiconair/properties/assert"
-	"github.com/vulpemventures/go-elements/network"
-	"github.com/vulpemventures/go-elements/payment"
 )
 
 func TestGetTransactionStatus(t *testing.T) {
-	privkey, err := btcec.NewPrivateKey(btcec.S256())
+	addr, _, err := newTestData()
 	if err != nil {
 		t.Fatal(err)
 	}
-	pubkey := privkey.PubKey()
-	p2wpkh := payment.FromPublicKey(pubkey, &network.Regtest, nil)
-	address, _ := p2wpkh.WitnessPubKeyHash()
 
 	explorerSvc, err := newService()
 	if err != nil {
@@ -25,7 +19,7 @@ func TestGetTransactionStatus(t *testing.T) {
 	}
 
 	// Fund sender address.
-	txID, err := explorerSvc.Faucet(address)
+	txID, err := explorerSvc.Faucet(addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,13 +42,10 @@ func TestGetTransactionStatus(t *testing.T) {
 }
 
 func TestGetTransactionsForAddress(t *testing.T) {
-	privkey, err := btcec.NewPrivateKey(btcec.S256())
+	addr, blindKey, err := newTestData()
 	if err != nil {
 		t.Fatal(err)
 	}
-	pubkey := privkey.PubKey()
-	p2wpkh := payment.FromPublicKey(pubkey, &network.Regtest, nil)
-	address, _ := p2wpkh.WitnessPubKeyHash()
 
 	explorerSvc, err := newService()
 	if err != nil {
@@ -62,13 +53,13 @@ func TestGetTransactionsForAddress(t *testing.T) {
 	}
 
 	// Fund sender address.
-	if _, err := explorerSvc.Faucet(address); err != nil {
+	if _, err := explorerSvc.Faucet(addr); err != nil {
 		t.Fatal(err)
 	}
 
 	time.Sleep(5 * time.Second)
 
-	txs, err := explorerSvc.GetTransactionsForAddress(address)
+	txs, err := explorerSvc.GetTransactionsForAddress(addr, blindKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/explorer/esplora/unspents_test.go
+++ b/pkg/explorer/esplora/unspents_test.go
@@ -44,7 +44,7 @@ func TestGetUnspents(t *testing.T) {
 }
 
 func TestSelectUnspents(t *testing.T) {
-	address, key1, err := newTestData()
+	addr, blindKey, err := newTestData()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,18 +53,17 @@ func TestSelectUnspents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = explorerSvc.Faucet(address)
-	if err != nil {
+	if _, err := explorerSvc.Faucet(addr); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(5 * time.Second)
 
-	utxos, err := explorerSvc.GetUnspents(address, [][]byte{key1})
+	utxos, err := explorerSvc.GetUnspents(addr, [][]byte{blindKey})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	targetAmount := uint64(1.5 * math.Pow10(8))
+	targetAmount := uint64(0.7 * math.Pow10(8))
 
 	selectedUtxos, change, err := explorer.SelectUnspents(
 		utxos,
@@ -75,8 +74,8 @@ func TestSelectUnspents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedChange := uint64(0.5 * math.Pow10(8))
-	assert.Equal(t, 2, len(selectedUtxos))
+	expectedChange := uint64(0.3 * math.Pow10(8))
+	assert.Equal(t, 1, len(selectedUtxos))
 	assert.Equal(t, expectedChange, change)
 }
 
@@ -88,14 +87,7 @@ func newService() (explorer.Service, error) {
 	return NewService(endpoint)
 }
 
-var testKey []byte
-var testAddress string
-
 func newTestData() (string, []byte, error) {
-	if len(testKey) > 0 && len(testAddress) > 0 {
-		return testAddress, testKey, nil
-	}
-
 	key, err := btcec.NewPrivateKey(btcec.S256())
 	if err != nil {
 		return "", nil, err
@@ -114,7 +106,5 @@ func newTestData() (string, []byte, error) {
 		return "", nil, err
 	}
 
-	testAddress = addr
-	testKey = blindKey.Serialize()
-	return testAddress, testKey, nil
+	return addr, blindKey.Serialize(), nil
 }

--- a/pkg/explorer/explorer.go
+++ b/pkg/explorer/explorer.go
@@ -58,7 +58,7 @@ type Service interface {
 	GetTransactionStatus(txid string) (status map[string]interface{}, err error)
 	// GetTransactionsForAddress returns the list of all txs relative to the
 	// given address.
-	GetTransactionsForAddress(address string) (txs []Transaction, err error)
+	GetTransactionsForAddress(address string, blindingKey []byte) (txs []Transaction, err error)
 	// BroadcastTransaction attempts to add the given tx in hex format to the
 	// mempool and returns its tx hash.
 	BroadcastTransaction(txhex string) (txid string, err error)


### PR DESCRIPTION
CHANGELOG:
* Add a `blindKey` arg to the explorer interface's GetTransansactionsForAddress and relative changes. 
* Disable restore wallet with Elements explorer.
* Improve crawler logs by logging only start/stop of an observable.

Closes #283.
Closes #282.

Please @tiero review this.