### PR TITLE
Increase crawler default interval

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -81,7 +81,7 @@ func init() {
 	vip.SetDefault(ExplorerEndpointKey, "https://blockstream.info/liquid/api")
 	vip.SetDefault(LogLevelKey, 4)
 	vip.SetDefault(DefaultFeeKey, 0.25)
-	vip.SetDefault(CrawlIntervalKey, 2000)
+	vip.SetDefault(CrawlIntervalKey, 5000)
 	vip.SetDefault(FeeAccountBalanceThresholdKey, 5000)
 	vip.SetDefault(NetworkKey, network.Liquid.Name)
 	vip.SetDefault(BaseAssetKey, network.Liquid.AssetID)


### PR DESCRIPTION
This increases the crawler default interval from 2 to 5 secs.

Please @tiero review this.