### PR TITLE
Pass network in Vault initialisation

### DIFF
--- a/internal/core/domain/vault_model.go
+++ b/internal/core/domain/vault_model.go
@@ -135,6 +135,7 @@ func NewVault(mnemonic []string, passphrase string, net *network.Network) (*Vaul
 		PassphraseHash:         btcutil.Hash160([]byte(passphrase)),
 		Accounts:               map[int]*Account{},
 		AccountAndKeyByAddress: map[string]AccountAndKey{},
+		Network:                net,
 	}, nil
 }
 


### PR DESCRIPTION
This fixes bug caused by wrong Vault initialisation which was missing network. 

@tiero @altafan please review.