### PR TITLE
Add CLI commands for claiming deposit & claiming fee RPCs

### DIFF
--- a/cmd/tdex/claimfee.go
+++ b/cmd/tdex/claimfee.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	pboperator "github.com/tdex-network/tdex-protobuf/generated/go/operator"
+
+	"github.com/urfave/cli/v2"
+)
+
+var claimfee = cli.Command{
+	Name:  "claimfee",
+	Usage: "claim deposits for the fee account",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "outpoints",
+			Usage: "list of outpoints referring to utxos [{\"hash\": <string>, \"index\": <number>}]",
+		},
+	},
+	Action: claimFeeAction,
+}
+
+func claimFeeAction(ctx *cli.Context) error {
+	outpoints, err := parseOutpoints(ctx.String("outpoints"))
+	if err != nil {
+		return err
+	}
+
+	client, cleanup, err := getOperatorClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if _, err := client.ClaimFeeDeposit(
+		context.Background(), &pboperator.ClaimFeeDepositRequest{
+			Outpoints: outpoints,
+		},
+	); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("fee account is funded")
+
+	return nil
+}
+
+func parseOutpoints(str string) ([]*pboperator.TxOutpoint, error) {
+	var outpoints []*pboperator.TxOutpoint
+	if err := json.Unmarshal([]byte(str), &outpoints); err != nil {
+		return nil, errors.New("unable to parse provided outpoints")
+	}
+	return outpoints, nil
+}

--- a/cmd/tdex/claimmarket.go
+++ b/cmd/tdex/claimmarket.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	pboperator "github.com/tdex-network/tdex-protobuf/generated/go/operator"
+	pbtypes "github.com/tdex-network/tdex-protobuf/generated/go/types"
+
+	"github.com/urfave/cli/v2"
+)
+
+var claimmarket = cli.Command{
+	Name:  "claimmarket",
+	Usage: "claim deposits for a market",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "outpoints",
+			Usage: "list of outpoints referring to utxos [{\"hash\": <string>, \"index\": <number>}]",
+		},
+	},
+	Action: claimMarketAction,
+}
+
+func claimMarketAction(ctx *cli.Context) error {
+	outpoints, err := parseOutpoints(ctx.String("outpoints"))
+	if err != nil {
+		return err
+	}
+
+	client, cleanup, err := getOperatorClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	baseAsset, quoteAsset, err := getMarketFromState()
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.ClaimMarketDeposit(
+		context.Background(), &pboperator.ClaimMarketDepositRequest{
+			Market: &pbtypes.Market{
+				BaseAsset:  baseAsset,
+				QuoteAsset: quoteAsset,
+			},
+			Outpoints: outpoints,
+		},
+	); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("market is funded")
+
+	return nil
+}

--- a/cmd/tdex/dropmarket.go
+++ b/cmd/tdex/dropmarket.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	pboperator "github.com/tdex-network/tdex-protobuf/generated/go/operator"
+
+	"github.com/urfave/cli/v2"
+)
+
+var dropmarket = cli.Command{
+	Name:  "dropmarket",
+	Usage: "drop a market",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "account_index",
+			Usage: "the account index of the market to drop",
+		},
+	},
+	Action: dropMarketAction,
+}
+
+func dropMarketAction(ctx *cli.Context) error {
+	client, cleanup, err := getOperatorClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	accountIndex := ctx.Uint64("account_index")
+
+	_, err = client.DropMarket(
+		context.Background(), &pboperator.DropMarketRequest{
+			AccountIndex: accountIndex,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("market is dropped")
+	return nil
+}

--- a/cmd/tdex/main.go
+++ b/cmd/tdex/main.go
@@ -44,10 +44,13 @@ func main() {
 		&unlockwallet,
 		&depositfee,
 		&depositmarket,
+		&claimfee,
+		&claimmarket,
 		&listmarket,
 		&listswaps,
 		&openmarket,
 		&closemarket,
+		&dropmarket,
 		&updatestrategy,
 		&updateprice,
 		&listutxos,
@@ -151,7 +154,7 @@ func getOperatorClient(ctx *cli.Context) (pboperator.OperatorClient, func(),
 	if err != nil {
 		return nil, nil, err
 	}
-	cleanup := func() { _ = conn.Close() }
+	cleanup := func() { conn.Close() }
 
 	return pboperator.NewOperatorClient(conn), cleanup, nil
 }


### PR DESCRIPTION
This adds the `claimfee`, `claimmarket` and `dropmarket` commands to the CLI.

Please @tiero review this.