### PR TITLE
Add txhex log in case of broadcast failing

### DIFF
--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -451,7 +451,7 @@ func (t *tradeService) tradeComplete(
 	// we are going to broadcast the transaction, this will actually tell if the
 	//transaction is a valid one to be included in blockcchain
 	if _, err = t.explorerSvc.BroadcastTransaction(res.TxHex); err != nil {
-		log.WithError(err).Warn("unable to broadcast trade tx")
+		log.WithError(err).Warnf("unable to broadcast trade tx - txhex: %s", res.TxHex)
 		return
 	}
 

--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -451,7 +451,7 @@ func (t *tradeService) tradeComplete(
 	// we are going to broadcast the transaction, this will actually tell if the
 	//transaction is a valid one to be included in blockcchain
 	if _, err = t.explorerSvc.BroadcastTransaction(res.TxHex); err != nil {
-		log.WithError(err).Warnf("unable to broadcast trade tx - txhex: %s", res.TxHex)
+		log.WithError(err).WithField("hex", res.TxHex).Warn("unable to broadcast trade tx")
 		return
 	}
 


### PR DESCRIPTION
This reintroduces the log of the hex of a trade tx in case it fails to be included in mempool when broadcasted via the explorer service.

Please @tiero review this.