### PR TITLE
Trade service component test & move badger transaction creation at app level

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -84,7 +84,6 @@ func main() {
 		crawlerSvc,
 		repoManager,
 		marketsBaseAsset,
-		feeThreshold,
 		network,
 	)
 
@@ -104,7 +103,7 @@ func main() {
 		marketsBaseAsset,
 		marketsFee,
 		network,
-		uint64(config.GetInt(config.FeeAccountBalanceThresholdKey)),
+		feeThreshold,
 	)
 	walletSvc, err := application.NewWalletService(
 		repoManager,

--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -132,9 +132,9 @@ func main() {
 		interceptor.StreamInterceptor(),
 	)
 
-	traderHandler := grpchandler.NewTraderHandler(traderSvc, repoManager)
-	walletHandler := grpchandler.NewWalletHandler(walletSvc, repoManager)
-	operatorHandler := grpchandler.NewOperatorHandler(operatorSvc, repoManager)
+	traderHandler := grpchandler.NewTraderHandler(traderSvc)
+	walletHandler := grpchandler.NewWalletHandler(walletSvc)
+	operatorHandler := grpchandler.NewOperatorHandler(operatorSvc)
 
 	// Register proto implementations on Trader interface
 	pbtrader.RegisterTradeServer(traderGrpcServer, traderHandler)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/timshannon/badgerhold/v2 v2.0.0-20201016201833-94bc303c76d4
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/vulpemventures/go-bip39 v1.0.2
-	github.com/vulpemventures/go-elements v0.2.0
+	github.com/vulpemventures/go-elements v0.2.1-0.20210409173614-5b1acc1d1e95
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0

--- a/go.sum
+++ b/go.sum
@@ -307,6 +307,8 @@ github.com/vulpemventures/go-elements v0.1.1 h1:x8xxc6FUBrbxasNw7v3wk8vICg1qvHlw
 github.com/vulpemventures/go-elements v0.1.1/go.mod h1:OtH2q9NiwybzT9X0AWvkNY+sbxy3okD+vC9oAu5hWhE=
 github.com/vulpemventures/go-elements v0.2.0 h1:rBz1nMLMyCQS5+XSjzz6MtLjwmZ2+mdtBJOFHTVhzQs=
 github.com/vulpemventures/go-elements v0.2.0/go.mod h1:O5QYFgeOmfSPX3shsV+lvEotvzcDFtLoYY0jjdT+sVw=
+github.com/vulpemventures/go-elements v0.2.1-0.20210409173614-5b1acc1d1e95 h1:k/5gNh2T0+iGup0oWk7K3G80Xdcll7bmjcCvFa9JvZ8=
+github.com/vulpemventures/go-elements v0.2.1-0.20210409173614-5b1acc1d1e95/go.mod h1:O5QYFgeOmfSPX3shsV+lvEotvzcDFtLoYY0jjdT+sVw=
 github.com/vulpemventures/go-secp256k1-zkp v1.1.0 h1:Z3qKc/lYxEQ1cukwwjD4n7EBCrg7N6of4hylVsD+lOA=
 github.com/vulpemventures/go-secp256k1-zkp v1.1.0/go.mod h1:zo7CpgkuPgoe7fAV+inyxsI9IhGmcoFgyD8nqZaPSOM=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -34,12 +34,8 @@ type blockchainListener struct {
 	repoManager        ports.RepoManager
 	started            bool
 	pendingObservables []crawler.Observable
-	// Loggers
-	feeDepositLogged    bool
-	feeBalanceLowLogged bool
-	marketBaseAsset     string
-	feeBalanceThreshold uint64
-	network             *network.Network
+	marketBaseAsset    string
+	network            *network.Network
 
 	mutex *sync.RWMutex
 }
@@ -49,14 +45,12 @@ func NewBlockchainListener(
 	crawlerSvc crawler.Service,
 	repoManager ports.RepoManager,
 	marketBaseAsset string,
-	feeBalanceThreshold uint64,
 	net *network.Network,
 ) BlockchainListener {
 	return newBlockchainListener(
 		crawlerSvc,
 		repoManager,
 		marketBaseAsset,
-		feeBalanceThreshold,
 		net,
 	)
 }
@@ -65,17 +59,15 @@ func newBlockchainListener(
 	crawlerSvc crawler.Service,
 	repoManager ports.RepoManager,
 	marketBaseAsset string,
-	feeBalanceThreshold uint64,
 	net *network.Network,
 ) *blockchainListener {
 	return &blockchainListener{
-		crawlerSvc:          crawlerSvc,
-		repoManager:         repoManager,
-		mutex:               &sync.RWMutex{},
-		pendingObservables:  make([]crawler.Observable, 0),
-		marketBaseAsset:     marketBaseAsset,
-		feeBalanceThreshold: feeBalanceThreshold,
-		network:             net,
+		crawlerSvc:         crawlerSvc,
+		repoManager:        repoManager,
+		mutex:              &sync.RWMutex{},
+		pendingObservables: make([]crawler.Observable, 0),
+		marketBaseAsset:    marketBaseAsset,
+		network:            net,
 	}
 }
 

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -36,6 +36,36 @@ func (m *mockBlinderManager) UnblindOutput(
 
 // **** Explorer ****
 
+type mockTradeManager struct {
+	mock.Mock
+	counter int
+	lock    *sync.Mutex
+}
+
+func newMockedTradeManager() *mockTradeManager {
+	return &mockTradeManager{
+		lock: &sync.Mutex{},
+	}
+}
+
+func (m *mockTradeManager) FillProposal(
+	opts application.FillProposalOpts,
+) (*application.FillProposalResult, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.counter++
+	args := m.Called(opts)
+
+	var res *application.FillProposalResult
+	if a := args.Get(0); a != nil {
+		res = a.(*application.FillProposalResult)
+	}
+	return res, args.Error(1)
+}
+
+// **** Explorer ****
+
 type mockExplorer struct {
 	mock.Mock
 }
@@ -273,4 +303,28 @@ func (c mockCryptoHandler) Encrypt(mnemonic, passpharse string) (string, error) 
 
 func (c mockCryptoHandler) Decrypt(encryptedMnemonic, passpharse string) (string, error) {
 	return c.decrypt(encryptedMnemonic, passpharse)
+}
+
+// **** PsetParser ****
+
+type mockPsetParser struct {
+	mock.Mock
+}
+
+func (m mockPsetParser) GetTxID(psetBase64 string) (string, error) {
+	args := m.Called(psetBase64)
+	var res string
+	if a := args.Get(0); a != nil {
+		res = a.(string)
+	}
+	return res, args.Error(1)
+}
+
+func (m mockPsetParser) GetTxHex(psetBase64 string) (string, error) {
+	args := m.Called(psetBase64)
+	var res string
+	if a := args.Get(0); a != nil {
+		res = a.(string)
+	}
+	return res, args.Error(1)
 }

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -133,8 +133,7 @@ func (o *operatorService) DepositMarket(
 	var accountIndex int
 
 	// First case: the assets are given. If are valid and a market exist we need to derive a new address for that account.
-	if len(baseAsset) > 0 && len(quoteAsset) > 0 {
-		// check the asset strings
+	if len(baseAsset) > 0 || len(quoteAsset) > 0 {
 		if err := validateAssetString(baseAsset); err != nil {
 			return nil, domain.ErrMarketInvalidBaseAsset
 		}
@@ -143,12 +142,10 @@ func (o *operatorService) DepositMarket(
 			return nil, domain.ErrMarketInvalidQuoteAsset
 		}
 
-		// Checks if base asset is valid
 		if baseAsset != o.marketBaseAsset {
 			return nil, domain.ErrMarketInvalidBaseAsset
 		}
 
-		//Checks if quote asset exists
 		_, accountOfExistentMarket, err := o.repoManager.MarketRepository().GetMarketByAsset(
 			ctx,
 			quoteAsset,
@@ -161,7 +158,7 @@ func (o *operatorService) DepositMarket(
 		}
 
 		accountIndex = accountOfExistentMarket
-	} else if len(baseAsset) == 0 && len(quoteAsset) == 0 {
+	} else {
 		// Second case: base and quote asset are empty. this means we need to create a new market.
 		_, latestAccountIndex, err := o.repoManager.MarketRepository().GetLatestMarket(
 			ctx,
@@ -171,19 +168,7 @@ func (o *operatorService) DepositMarket(
 		}
 
 		nextAccountIndex := latestAccountIndex + 1
-		fee := o.marketFee
-		if _, err := o.repoManager.MarketRepository().GetOrCreateMarket(
-			ctx,
-			&domain.Market{AccountIndex: nextAccountIndex, Fee: fee},
-		); err != nil {
-			return nil, err
-		}
-
 		accountIndex = nextAccountIndex
-	} else if baseAsset != o.marketBaseAsset {
-		return nil, domain.ErrMarketInvalidBaseAsset
-	} else {
-		return nil, domain.ErrMarketInvalidQuoteAsset
 	}
 	if numOfAddresses == 0 {
 		numOfAddresses = 1
@@ -302,7 +287,6 @@ func (o *operatorService) CloseMarket(
 	baseAsset string,
 	quoteAsset string,
 ) error {
-	// check the asset strings
 	err := validateAssetString(baseAsset)
 	if err != nil {
 		return domain.ErrMarketInvalidBaseAsset
@@ -336,7 +320,6 @@ func (o *operatorService) UpdateMarketFee(
 	ctx context.Context,
 	req MarketWithFee,
 ) (*MarketWithFee, error) {
-	// check the asset strings
 	if err := validateAssetString(req.BaseAsset); err != nil {
 		return nil, domain.ErrMarketInvalidBaseAsset
 	}
@@ -345,12 +328,11 @@ func (o *operatorService) UpdateMarketFee(
 		return nil, domain.ErrMarketInvalidQuoteAsset
 	}
 
-	// Checks if base asset is correct
 	if req.BaseAsset != o.marketBaseAsset {
 		return nil, ErrMarketNotExist
 	}
-	//Checks if market exist
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
+
+	mkt, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
 		ctx,
 		req.QuoteAsset,
 	)
@@ -361,7 +343,6 @@ func (o *operatorService) UpdateMarketFee(
 		return nil, ErrMarketNotExist
 	}
 
-	//Updates the fee and the fee asset
 	if err := o.repoManager.MarketRepository().UpdateMarket(
 		ctx,
 		accountIndex,
@@ -374,12 +355,6 @@ func (o *operatorService) UpdateMarketFee(
 	); err != nil {
 		return nil, err
 	}
-
-	// Ignore errors. If we reached this point it must exists.
-	mkt, _ := o.repoManager.MarketRepository().GetOrCreateMarket(
-		ctx,
-		&domain.Market{AccountIndex: accountIndex},
-	)
 
 	return &MarketWithFee{
 		Market: Market{
@@ -397,35 +372,26 @@ func (o *operatorService) UpdateMarketPrice(
 	ctx context.Context,
 	req MarketWithPrice,
 ) error {
-	// check the asset strings
-	err := validateAssetString(req.BaseAsset)
-	if err != nil {
+	if err := validateAssetString(req.BaseAsset); err != nil {
 		return domain.ErrMarketInvalidBaseAsset
 	}
 
-	err = validateAssetString(req.QuoteAsset)
-	if err != nil {
+	if err := validateAssetString(req.QuoteAsset); err != nil {
 		return domain.ErrMarketInvalidQuoteAsset
 	}
 
-	// Checks if base asset is correct
 	if req.BaseAsset != o.marketBaseAsset {
 		return domain.ErrMarketInvalidBaseAsset
 	}
 
-	// validate the new prices amount
-	err = validateAmount(req.Price.BasePrice)
-	if err != nil {
+	if err := validateAmount(req.Price.BasePrice); err != nil {
 		return domain.ErrMarketInvalidBasePrice
 	}
 
-	// validate the new prices amount
-	err = validateAmount(req.Price.QuotePrice)
-	if err != nil {
+	if err := validateAmount(req.Price.QuotePrice); err != nil {
 		return domain.ErrMarketInvalidQuotePrice
 	}
 
-	//Checks if market exist
 	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
 		ctx,
 		req.QuoteAsset,
@@ -437,7 +403,7 @@ func (o *operatorService) UpdateMarketPrice(
 		return ErrMarketNotExist
 	}
 
-	//Updates the base price and the quote price
+	// Updates the base price and the quote price
 	return o.repoManager.MarketRepository().UpdatePrices(
 		ctx,
 		accountIndex,
@@ -454,22 +420,18 @@ func (o *operatorService) UpdateMarketStrategy(
 	ctx context.Context,
 	req MarketStrategy,
 ) error {
-	// check the asset strings
-	err := validateAssetString(req.Market.BaseAsset)
-	if err != nil {
+	if err := validateAssetString(req.Market.BaseAsset); err != nil {
 		return domain.ErrMarketInvalidBaseAsset
 	}
 
-	err = validateAssetString(req.Market.QuoteAsset)
-	if err != nil {
+	if err := validateAssetString(req.Market.QuoteAsset); err != nil {
 		return domain.ErrMarketInvalidQuoteAsset
 	}
 
-	// Checks if base asset is correct
 	if req.BaseAsset != o.marketBaseAsset {
 		return ErrMarketNotExist
 	}
-	//Checks if market exist
+
 	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
 		ctx,
 		req.QuoteAsset,
@@ -482,16 +444,13 @@ func (o *operatorService) UpdateMarketStrategy(
 		return ErrMarketNotExist
 	}
 
-	//For now we support only BALANCED or PLUGGABLE (ie. price feed)
 	requestStrategy := req.Strategy
-	//Updates the strategy
+
 	return o.repoManager.MarketRepository().UpdateMarket(
 		ctx,
 		accountIndex,
 		func(m *domain.Market) (*domain.Market, error) {
-
 			switch requestStrategy {
-
 			case domain.StrategyTypePluggable:
 				if err := m.MakeStrategyPluggable(); err != nil {
 					return nil, err
@@ -533,14 +492,11 @@ func (o *operatorService) ListMarketExternalAddresses(
 	ctx context.Context,
 	req Market,
 ) ([]string, error) {
-	// check the asset strings
-	err := validateAssetString(req.BaseAsset)
-	if err != nil {
+	if err := validateAssetString(req.BaseAsset); err != nil {
 		return nil, domain.ErrMarketInvalidBaseAsset
 	}
 
-	err = validateAssetString(req.QuoteAsset)
-	if err != nil {
+	if err := validateAssetString(req.QuoteAsset); err != nil {
 		return nil, domain.ErrMarketInvalidQuoteAsset
 	}
 
@@ -548,18 +504,18 @@ func (o *operatorService) ListMarketExternalAddresses(
 		return nil, domain.ErrMarketInvalidBaseAsset
 	}
 
-	market, _, err := o.repoManager.MarketRepository().GetMarketByAsset(ctx, req.QuoteAsset)
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(ctx, req.QuoteAsset)
 	if err != nil {
 		return nil, err
 	}
 
-	if market == nil {
+	if accountIndex < 0 {
 		return nil, ErrMarketNotExist
 	}
 
 	allInfo, err := o.repoManager.VaultRepository().GetAllDerivedExternalAddressesInfoForAccount(
 		ctx,
-		market.AccountIndex,
+		accountIndex,
 	)
 	if err != nil {
 		return nil, err
@@ -568,7 +524,7 @@ func (o *operatorService) ListMarketExternalAddresses(
 	return allInfo.Addresses(), nil
 }
 
-//ListMarket a set of informations about all the markets.
+// ListMarket a set of informations about all the markets.
 func (o *operatorService) ListMarket(
 	ctx context.Context,
 ) ([]MarketInfo, error) {
@@ -577,10 +533,9 @@ func (o *operatorService) ListMarket(
 		return nil, err
 	}
 
-	marketInfos := make([]MarketInfo, 0, len(markets))
-
+	marketInfo := make([]MarketInfo, 0, len(markets))
 	for _, market := range markets {
-		marketInfos = append(marketInfos, MarketInfo{
+		marketInfo = append(marketInfo, MarketInfo{
 			AccountIndex: uint64(market.AccountIndex),
 			Market: Market{
 				BaseAsset:  market.BaseAsset,
@@ -595,7 +550,7 @@ func (o *operatorService) ListMarket(
 		})
 	}
 
-	return marketInfos, nil
+	return marketInfo, nil
 }
 
 func (o *operatorService) GetCollectedMarketFee(
@@ -1018,8 +973,6 @@ func (o *operatorService) claimDeposit(
 				AssetBlinder:    unconfidential.AssetBlinder,
 				ScriptPubKey:    txOut.Script,
 				Nonce:           txOut.Nonce,
-				RangeProof:      txOut.RangeProof,
-				SurjectionProof: txOut.SurjectionProof,
 				Address:         info.Address,
 				Confirmed:       true,
 			}

--- a/internal/core/application/operator_service_test.go
+++ b/internal/core/application/operator_service_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,8 @@ func TestAccountManagement(t *testing.T) {
 			}), true)
 	}
 
+	time.Sleep(50 * time.Millisecond)
+
 	mktAddressesAndKeys, err := operatorSvc.DepositMarket(ctx, "", "", 2)
 	require.NoError(t, err)
 
@@ -63,6 +66,8 @@ func TestAccountManagement(t *testing.T) {
 				ValueBlinder: randomBytes(32),
 			}), true)
 	}
+
+	time.Sleep(50 * time.Millisecond)
 
 	application.BlinderManager = mockedBlinderManager
 

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -1,0 +1,342 @@
+package application_test
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tdex-network/tdex-daemon/internal/core/application"
+	"github.com/tdex-network/tdex-daemon/internal/core/domain"
+	"github.com/tdex-network/tdex-daemon/pkg/explorer"
+	"github.com/tdex-network/tdex-daemon/pkg/explorer/esplora"
+	"github.com/tdex-network/tdex-daemon/pkg/trade"
+	pbswap "github.com/tdex-network/tdex-protobuf/generated/go/swap"
+)
+
+var (
+	tradeExpiryDuration = 120 * time.Second
+	tradePriceSlippage  = decimal.NewFromFloat(0.1)
+
+	tradeFeeOutpoints = []application.TxOutpoint{
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+	}
+	tradeMktOutpoints = []application.TxOutpoint{
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+		{Hash: randomHex(32), Index: 0},
+	}
+)
+
+func TestMarketTrading(t *testing.T) {
+	tradeSvc, err := newTradeService()
+	require.NoError(t, err)
+
+	markets, err := tradeSvc.GetTradableMarkets(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, markets)
+
+	market := markets[0].Market
+	balances, err := tradeSvc.GetMarketBalance(ctx, market)
+	require.NoError(t, err)
+	require.NotNil(t, balances)
+	require.True(t, balances.Balance.BaseAmount > 0)
+	require.True(t, balances.Balance.QuoteAmount > 0)
+
+	t.Run("buy LBTC fixed LBTC", func(t *testing.T) {
+		t.Parallel()
+		marketOrder(t, tradeSvc, market, application.TradeBuy, 0.1, marketBaseAsset)
+	})
+	t.Run("buy LBTC fixed USDT", func(t *testing.T) {
+		t.Parallel()
+		marketOrder(t, tradeSvc, market, application.TradeBuy, 900.0, marketQuoteAsset)
+	})
+	t.Run("sell LBTC fixed LBTC", func(t *testing.T) {
+		t.Parallel()
+		marketOrder(t, tradeSvc, market, application.TradeSell, 0.1, marketBaseAsset)
+	})
+	t.Run("sell LBTC fixed USDT", func(t *testing.T) {
+		t.Parallel()
+		marketOrder(t, tradeSvc, market, application.TradeSell, 900.0, marketQuoteAsset)
+	})
+}
+
+func newTradeService() (application.TradeService, error) {
+	repoManager, explorerSvc, bcListener := newServices()
+
+	v, err := repoManager.VaultRepository().GetOrCreateVault(
+		ctx, mnemonic, passphrase, regtest,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	unspents := make([]domain.Unspent, 0)
+	for _, outpoint := range tradeFeeOutpoints {
+		info, _ := v.DeriveNextExternalAddressForAccount(domain.FeeAccount)
+		script, _ := hex.DecodeString(info.Script)
+		unspents = append(unspents, domain.Unspent{
+			TxID:            outpoint.Hash,
+			VOut:            uint32(outpoint.Index),
+			Value:           uint64(1000),
+			AssetHash:       marketBaseAsset,
+			ValueCommitment: randomValueCommitment(),
+			AssetCommitment: randomAssetCommitment(),
+			ValueBlinder:    randomBytes(32),
+			AssetBlinder:    randomBytes(32),
+			ScriptPubKey:    script,
+			Nonce:           randomBytes(32),
+			Address:         info.Address,
+			Confirmed:       true,
+		})
+	}
+
+	oLen := len(tradeMktOutpoints)
+	mktOutpointsWithAsset := make([]domain.OutpointWithAsset, oLen, oLen)
+	for i, outpoint := range tradeMktOutpoints {
+		info, _ := v.DeriveNextExternalAddressForAccount(domain.MarketAccountStart)
+		script, _ := hex.DecodeString(info.Script)
+		assetHash := marketBaseAsset
+		value := uint64(5000000)
+		if i > (oLen/2 - 1) {
+			assetHash = marketQuoteAsset
+			value = 50000000000
+		}
+		mktOutpointsWithAsset[i] = domain.OutpointWithAsset{
+			Asset: assetHash,
+			Txid:  outpoint.Hash,
+			Vout:  outpoint.Index,
+		}
+
+		unspents = append(unspents, domain.Unspent{
+			TxID:            outpoint.Hash,
+			VOut:            uint32(outpoint.Index),
+			Value:           value,
+			AssetHash:       assetHash,
+			ValueCommitment: randomValueCommitment(),
+			AssetCommitment: randomAssetCommitment(),
+			ValueBlinder:    randomBytes(32),
+			AssetBlinder:    randomBytes(32),
+			ScriptPubKey:    script,
+			Nonce:           randomBytes(32),
+			Address:         info.Address,
+			Confirmed:       true,
+		})
+		explorerSvc.(*mockExplorer).On("GetTransaction", outpoint.Hash).
+			Return(randomTxs(info.Address)[0], nil)
+	}
+
+	mkt, err := repoManager.MarketRepository().GetOrCreateMarket(
+		ctx,
+		&domain.Market{
+			AccountIndex: domain.MarketAccountStart,
+			Fee:          marketFee,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := repoManager.MarketRepository().UpdateMarket(ctx, mkt.AccountIndex, func(m *domain.Market) (*domain.Market, error) {
+		m.FundMarket(mktOutpointsWithAsset, marketBaseAsset)
+		m.MakeTradable()
+		return m, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := repoManager.VaultRepository().UpdateVault(ctx, func(_ *domain.Vault) (*domain.Vault, error) {
+		return v, nil
+	}); err != nil {
+		return nil, err
+	}
+	if err := repoManager.UnspentRepository().AddUnspents(ctx, unspents); err != nil {
+		return nil, err
+	}
+
+	mockedTradeManager := newMockedTradeManager()
+	mockedTradeManager.
+		On("FillProposal", mock.AnythingOfType("application.FillProposalOpts")).
+		Return(&application.FillProposalResult{
+			PsetBase64:         randomBase64(),
+			SelectedUnspents:   randomSelection(unspents, mockedTradeManager.counter),
+			InputBlindingKeys:  nil,
+			OutputBlindingKeys: nil,
+		}, nil)
+
+	application.TradeManager = mockedTradeManager
+
+	explorerSvc.(*mockExplorer).
+		On("GetTransactionStatus", mock.AnythingOfType("string")).
+		Return(map[string]interface{}{
+			"confirmed":  true,
+			"block_time": randomIntInRange(100000, 1000000),
+			"block_hash": randomHex(32),
+		}, nil)
+	explorerSvc.(*mockExplorer).
+		On("GetTransactionHex", mock.AnythingOfType("string")).
+		Return(randomHex(1000), nil)
+	explorerSvc.(*mockExplorer).
+		On("BroadcastTx", mock.AnythingOfType("string")).
+		Return(randomHex(32), nil)
+
+	return application.NewTradeService(
+		repoManager,
+		explorerSvc,
+		bcListener,
+		marketBaseAsset,
+		tradeExpiryDuration,
+		tradePriceSlippage,
+		regtest,
+	), nil
+}
+
+func marketOrder(
+	t *testing.T,
+	tradeSvc application.TradeService,
+	market application.Market,
+	tradeType int,
+	btcAmount float64,
+	asset string,
+) {
+	amount := uint64(btcAmount * math.Pow10(8))
+	preview, err := tradeSvc.GetMarketPrice(ctx, market, tradeType, amount, asset)
+	require.NoError(t, err)
+	require.NotNil(t, preview)
+
+	wallet, err := trade.NewRandomWallet(regtest)
+	require.NoError(t, err)
+	require.NotNil(t, wallet)
+	_, script := wallet.Script()
+
+	assetToSend := asset
+	amountToSend := amount
+	assetToReceive := preview.Asset
+	amountToReceive := preview.Amount
+	if tradeType == application.TradeSell && asset == marketQuoteAsset {
+		assetToSend, assetToReceive = assetToReceive, assetToSend
+		amountToSend, amountToReceive = amountToReceive, amountToSend
+	}
+	if tradeType == application.TradeBuy && asset == marketBaseAsset {
+		assetToSend, assetToReceive = assetToReceive, assetToSend
+		amountToSend, amountToReceive = amountToReceive, amountToSend
+	}
+
+	unspents := []explorer.Utxo{
+		esplora.NewWitnessUtxo(
+			randomHex(32),
+			uint32(randomIntInRange(0, 15)),
+			amountToSend,
+			assetToSend,
+			randomValueCommitment(),
+			randomAssetCommitment(),
+			randomBytes(32),
+			randomBytes(32),
+			script,
+			randomBytes(32),
+			randomBytes(100),
+			randomBytes(100),
+			true,
+		),
+	}
+
+	psetBase64, _ := trade.NewSwapTx(
+		unspents,
+		assetToSend,
+		amountToSend,
+		assetToReceive,
+		amountToReceive,
+		script,
+	)
+
+	blindingKeyMap := map[string][]byte{
+		hex.EncodeToString(script): wallet.BlindingKey(),
+	}
+
+	swapRequest := &pbswap.SwapRequest{
+		Id:                randomId(),
+		AssetP:            assetToSend,
+		AmountP:           amountToSend,
+		AssetR:            assetToReceive,
+		AmountR:           amountToReceive,
+		Transaction:       psetBase64,
+		InputBlindingKey:  blindingKeyMap,
+		OutputBlindingKey: blindingKeyMap,
+	}
+
+	swapAccept, swapFail, expiryTimestamp, err := tradeSvc.TradePropose(ctx, market, tradeType, swapRequest)
+	require.NoError(t, err)
+	require.Nil(t, swapFail)
+	require.NotNil(t, swapAccept)
+	require.True(t, time.Now().Before(time.Unix(int64(expiryTimestamp), 0)))
+
+	var swapCompletePtr *domain.SwapComplete
+	var swapComplete domain.SwapComplete
+	swapComplete = &pbswap.SwapComplete{
+		Id:          randomId(),
+		AcceptId:    swapAccept.GetId(),
+		Transaction: swapAccept.GetTransaction(),
+	}
+	swapCompletePtr = &swapComplete
+
+	time.Sleep(2 * time.Second)
+	_, _, err = tradeSvc.TradeComplete(ctx, swapCompletePtr, nil)
+	require.NoError(t, err)
+}
+
+func randomBase64() string {
+	return base64.StdEncoding.EncodeToString(randomBytes(100))
+}
+
+func randomSelection(list []domain.Unspent, counter int) []explorer.Utxo {
+	selectedUtxos := make([]explorer.Utxo, 3, 3)
+	for i := 0; i < 3; i++ {
+		selectedIndex := counter*3 + i
+		selectedUtxos[i] = list[selectedIndex].ToUtxo()
+	}
+	return selectedUtxos
+}

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -127,6 +127,8 @@ func newWalletService(
 	if vault, err := w.repoManager.VaultRepository().GetOrCreateVault(
 		context.Background(), nil, "", nil,
 	); err == nil {
+		log.Info("Restoring internal wallet's utxo set. This could take a while...")
+
 		info := vault.AllDerivedAddressesInfo()
 		if err := fetchAndAddUnspents(
 			w.explorerService,
@@ -136,8 +138,8 @@ func newWalletService(
 		); err != nil {
 			return nil, err
 		}
-
 		w.setInitialized(true)
+		log.Info("Done.")
 	}
 	return w, nil
 }

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -826,8 +826,6 @@ func (w *walletService) restoreUnspentsForAddress(
 			AssetBlinder:    u.AssetBlinder(),
 			ScriptPubKey:    u.Script(),
 			Nonce:           u.Nonce(),
-			RangeProof:      u.RangeProof(),
-			SurjectionProof: u.SurjectionProof(),
 			Confirmed:       u.IsConfirmed(),
 			Address:         addr,
 		}
@@ -1120,8 +1118,6 @@ func fetchUnspents(explorerSvc explorer.Service, info domain.AddressesInfo) ([]d
 			AssetBlinder:    u.AssetBlinder(),
 			ScriptPubKey:    u.Script(),
 			Nonce:           u.Nonce(),
-			RangeProof:      u.RangeProof(),
-			SurjectionProof: u.SurjectionProof(),
 			Confirmed:       u.IsConfirmed(),
 			Address:         addr,
 		}
@@ -1187,7 +1183,8 @@ func spendUnspentsAsync(
 
 func startObserveUnconfirmedUnspents(
 	bcListener BlockchainListener,
-	unspents []domain.Unspent) {
+	unspents []domain.Unspent,
+) {
 	count := 0
 	for _, u := range unspents {
 		if !u.IsConfirmed() {
@@ -1266,8 +1263,6 @@ func extractUnspentsFromTx(
 				AssetBlinder:    unconfidential.AssetBlinder,
 				ScriptPubKey:    out.Script,
 				Nonce:           out.Nonce,
-				RangeProof:      out.RangeProof,
-				SurjectionProof: out.SurjectionProof,
 				Address:         info.Address,
 				Confirmed:       false,
 			})

--- a/internal/core/application/wallet_service_test.go
+++ b/internal/core/application/wallet_service_test.go
@@ -243,7 +243,6 @@ func newServices() (
 		crawlerSvc,
 		repoManager,
 		marketBaseAsset,
-		feeBalanceThreshold,
 		regtest,
 	)
 	return repoManager, explorerSvc, bcListener

--- a/internal/core/domain/mocks_test.go
+++ b/internal/core/domain/mocks_test.go
@@ -50,8 +50,8 @@ func (m mockSwapParser) SerializeAccept(acc domain.AcceptArgs) (string, []byte, 
 	return sres, bres, err
 }
 
-func (m mockSwapParser) SerializeComplete(reqMsg, accMsg []byte, tx string) (string, []byte, *domain.SwapError) {
-	args := m.Called(reqMsg, accMsg, tx)
+func (m mockSwapParser) SerializeComplete(accMsg []byte, tx string) (string, []byte, *domain.SwapError) {
+	args := m.Called(accMsg, tx)
 
 	var sres string
 	if a := args.Get(0); a != nil {

--- a/internal/core/domain/trade_service.go
+++ b/internal/core/domain/trade_service.go
@@ -117,7 +117,6 @@ func (t *Trade) Complete(psetBase64 string) (*CompleteResult, error) {
 	}
 
 	swapCompleteID, swapCompleteMsg, err := SwapParserManager.SerializeComplete(
-		t.SwapRequest.Message,
 		t.SwapAccept.Message,
 		psetBase64,
 	)

--- a/internal/core/domain/trade_service_test.go
+++ b/internal/core/domain/trade_service_test.go
@@ -223,7 +223,6 @@ func TestTradeComplete(t *testing.T) {
 		mockedSwapParser := mockSwapParser{}
 		mockedSwapParser.On(
 			"SerializeComplete",
-			tt.trade.SwapRequest.Message,
 			tt.trade.SwapAccept.Message,
 			tx,
 		).Return(randomID(), randomBytes(100), nil)
@@ -252,7 +251,6 @@ func TestFailingTradeComplete(t *testing.T) {
 		mockedSwapParser := mockSwapParser{}
 		mockedSwapParser.On(
 			"SerializeComplete",
-			trade.SwapRequest.Message,
 			trade.SwapAccept.Message,
 			tx,
 		).Return(nil, nil, mockedErr)

--- a/internal/core/domain/unspent_model.go
+++ b/internal/core/domain/unspent_model.go
@@ -24,8 +24,6 @@ type Unspent struct {
 	AssetBlinder    []byte
 	ScriptPubKey    []byte
 	Nonce           []byte
-	RangeProof      []byte
-	SurjectionProof []byte
 	Address         string
 	Spent           bool
 	Locked          bool

--- a/internal/core/domain/unspent_service.go
+++ b/internal/core/domain/unspent_service.go
@@ -88,8 +88,8 @@ func (u *Unspent) ToUtxo() explorer.Utxo {
 		u.AssetBlinder,
 		u.ScriptPubKey,
 		u.Nonce,
-		u.RangeProof,
-		u.SurjectionProof,
+		nil,
+		nil,
 		u.Confirmed,
 	)
 }

--- a/internal/infrastructure/storage/db/badger/trade_repository_impl.go
+++ b/internal/infrastructure/storage/db/badger/trade_repository_impl.go
@@ -125,10 +125,20 @@ func (t tradeRepositoryImpl) getOrCreateTrade(
 	ID *uuid.UUID,
 ) (*domain.Trade, error) {
 	if ID != nil {
-		return t.getTrade(ctx, *ID)
+		tr, err := t.getTrade(ctx, *ID)
+		if err != nil {
+			return nil, err
+		}
+		if tr != nil {
+			return tr, nil
+		}
 	}
 
 	trade := domain.NewTrade()
+	if ID != nil {
+		trade.ID = *ID
+	}
+
 	if err := t.insertTrade(ctx, *trade); err != nil {
 		return nil, err
 	}
@@ -174,7 +184,7 @@ func (t tradeRepositoryImpl) getTrade(
 	}
 	if err != nil {
 		if err == badgerhold.ErrNotFound {
-			return nil, ErrTradeNotFound
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/internal/infrastructure/storage/db/inmemory/trade_memory_repository_impl.go
+++ b/internal/infrastructure/storage/db/inmemory/trade_memory_repository_impl.go
@@ -116,22 +116,19 @@ func (r tradeRepositoryImpl) UpdateTrade(
 }
 
 func (r tradeRepositoryImpl) getOrCreateTrade(tradeID *uuid.UUID) (*domain.Trade, error) {
-	createTrade := func() (*domain.Trade, error) {
-		t := domain.NewTrade()
-		r.store.trades[t.ID] = *t
-		return t, nil
+	if tradeID != nil {
+		tr, ok := r.store.trades[*tradeID]
+		if ok {
+			return &tr, nil
+		}
 	}
 
-	if tradeID == nil {
-		return createTrade()
+	trade := domain.NewTrade()
+	if tradeID != nil {
+		trade.ID = *tradeID
 	}
-
-	currentTrade, ok := r.store.trades[*tradeID]
-	if !ok {
-		return nil, ErrTradeNotFound
-	}
-
-	return &currentTrade, nil
+	r.store.trades[trade.ID] = *trade
+	return trade, nil
 }
 
 func (r tradeRepositoryImpl) getAllTrades() ([]*domain.Trade, error) {

--- a/internal/infrastructure/storage/db/test/unspent_repository_impl_test.go
+++ b/internal/infrastructure/storage/db/test/unspent_repository_impl_test.go
@@ -570,8 +570,6 @@ func mockUnspent(addr, asset *string, spent, confirmed bool) domain.Unspent {
 		AssetBlinder:    randomBytes(32),
 		ScriptPubKey:    make([]byte, 20),
 		Nonce:           make([]byte, 33),
-		RangeProof:      make([]byte, 100),
-		SurjectionProof: make([]byte, 67),
 		Address:         mockedAddress,
 		Spent:           spent,
 		Confirmed:       confirmed,

--- a/internal/interfaces/grpc/handler/trade.go
+++ b/internal/interfaces/grpc/handler/trade.go
@@ -120,11 +120,11 @@ func (t traderHandler) balances(
 	balancesWithFee := make([]*types.BalanceWithFee, 0)
 	balancesWithFee = append(balancesWithFee, &types.BalanceWithFee{
 		Balance: &types.Balance{
-			BaseAmount:  balance.BaseAmount,
-			QuoteAmount: balance.QuoteAmount,
+			BaseAmount:  balance.Balance.BaseAmount,
+			QuoteAmount: balance.Balance.QuoteAmount,
 		},
 		Fee: &types.Fee{
-			BasisPoint: balance.BasisPoint,
+			BasisPoint: balance.Fee.BasisPoint,
 		},
 	})
 
@@ -154,7 +154,7 @@ func (t traderHandler) marketPrice(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	price, err := t.traderSvc.GetMarketPrice(
+	preview, err := t.traderSvc.GetMarketPrice(
 		ctx,
 		application.Market{
 			BaseAsset:  market.GetBaseAsset(),
@@ -168,8 +168,8 @@ func (t traderHandler) marketPrice(
 		return nil, err
 	}
 
-	basePrice, _ := price.BasePrice.Float64()
-	quotePrice, _ := price.QuotePrice.Float64()
+	basePrice, _ := preview.Price.BasePrice.Float64()
+	quotePrice, _ := preview.Price.QuotePrice.Float64()
 
 	return &pb.MarketPriceReply{
 		Prices: []*pbtypes.PriceWithFee{
@@ -179,10 +179,10 @@ func (t traderHandler) marketPrice(
 					QuotePrice: float32(quotePrice),
 				},
 				Fee: &pbtypes.Fee{
-					BasisPoint: price.BasisPoint,
+					BasisPoint: preview.Fee.BasisPoint,
 				},
-				Amount: price.Amount,
-				Asset:  price.Asset,
+				Amount: preview.Amount,
+				Asset:  preview.Asset,
 			},
 		},
 	}, nil

--- a/pkg/explorer/esplora/types.go
+++ b/pkg/explorer/esplora/types.go
@@ -295,7 +295,7 @@ func (wu witnessUtxo) Parse() (*transaction.TxInput, *transaction.TxOutput, erro
 	input := transaction.NewTxInput(inHash, wu.UIndex)
 
 	var witnessUtxo *transaction.TxOutput
-	if len(wu.URangeProof) != 0 && len(wu.USurjectionProof) != 0 {
+	if wu.IsConfidential() {
 		assetCommitment, err := bufferutil.CommitmentToBytes(wu.UAssetCommitment)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/swap/accept.go
+++ b/pkg/swap/accept.go
@@ -17,7 +17,7 @@ type AcceptOpts struct {
 }
 
 // Accept takes a AcceptOpts and returns the id of the SwapAccept entity and
-//its serialized version
+// its serialized version
 func Accept(accept AcceptOpts) (string, []byte, error) {
 	var msgRequest pb.SwapRequest
 	err := proto.Unmarshal(accept.Message, &msgRequest)
@@ -32,10 +32,6 @@ func Accept(accept AcceptOpts) (string, []byte, error) {
 		Transaction:       accept.PsetBase64,
 		InputBlindingKey:  accept.InputBlindingKeys,
 		OutputBlindingKey: accept.OutputBlindingKeys,
-	}
-
-	if err := compareMessagesAndTransaction(&msgRequest, msgAccept); err != nil {
-		return "", nil, err
 	}
 
 	msgAcceptSerialized, err := proto.Marshal(msgAccept)

--- a/pkg/swap/accept_test.go
+++ b/pkg/swap/accept_test.go
@@ -9,8 +9,8 @@ const initialPsbtOfBob = "cHNldP8BAP1lAQIAAAAAAu1FUTUGQ6cvcZgqyRmduZP/jCOJf6CiVj
 func TestCore_Accept(t *testing.T) {
 	t.Run("Bob can import a SwapRequest and create a SwapAccept message", func(t *testing.T) {
 		messageRequest, err := Request(RequestOpts{
-			AssetToBeSent:   USDT,
-			AmountToBeSent:  30000000000,
+			AssetToSend:     USDT,
+			AmountToSend:    30000000000,
 			AssetToReceive:  LBTC,
 			AmountToReceive: 5000000,
 			PsetBase64:      initialPsbtOfAlice,

--- a/pkg/swap/complete_test.go
+++ b/pkg/swap/complete_test.go
@@ -9,8 +9,8 @@ const finalPsbtOfAlice = "cHNldP8BAP1lAQIAAAAAAu1FUTUGQ6cvcZgqyRmduZP/jCOJf6CiVj
 func TestSwap_Complete(t *testing.T) {
 	t.Run("Alice can import a SwapAccept message and create a SwapComplete message", func(t *testing.T) {
 		messageRequest, _ := Request(RequestOpts{
-			AssetToBeSent:   USDT,
-			AmountToBeSent:  30000000000,
+			AssetToSend:     USDT,
+			AmountToSend:    30000000000,
 			AssetToReceive:  LBTC,
 			AmountToReceive: 5000000,
 			PsetBase64:      initialPsbtOfAlice,

--- a/pkg/swap/request.go
+++ b/pkg/swap/request.go
@@ -8,8 +8,9 @@ import (
 
 // RequestOpts is the struct to be given to the Request method
 type RequestOpts struct {
-	AssetToBeSent      string
-	AmountToBeSent     uint64
+	Id                 string
+	AssetToSend        string
+	AmountToSend       uint64
 	AssetToReceive     string
 	AmountToReceive    uint64
 	PsetBase64         string
@@ -17,23 +18,17 @@ type RequestOpts struct {
 	OutputBlindingKeys map[string][]byte
 }
 
-// ParseSwapRequest checks whether the given swap request is well formed and
-// returns its byte serialization
-func ParseSwapRequest(request *pb.SwapRequest) ([]byte, error) {
-	if err := compareMessagesAndTransaction(request, nil); err != nil {
-		return nil, err
-	}
-	return proto.Marshal(request)
-}
-
 // Request takes a RequestOpts struct and returns a serialized protobuf message.
 func Request(opts RequestOpts) ([]byte, error) {
-	randomID := randstr.Hex(8)
+	id := opts.Id
+	if len(id) <= 0 {
+		id = randstr.Hex(8)
+	}
 	msg := &pb.SwapRequest{
-		Id: randomID,
+		Id: id,
 		// Proposer
-		AssetP:  opts.AssetToBeSent,
-		AmountP: opts.AmountToBeSent,
+		AssetP:  opts.AssetToSend,
+		AmountP: opts.AmountToSend,
 		// Receiver
 		AssetR:  opts.AssetToReceive,
 		AmountR: opts.AmountToReceive,
@@ -44,5 +39,5 @@ func Request(opts RequestOpts) ([]byte, error) {
 		OutputBlindingKey: opts.InputBlindingKeys,
 	}
 
-	return ParseSwapRequest(msg)
+	return proto.Marshal(msg)
 }

--- a/pkg/swap/request_test.go
+++ b/pkg/swap/request_test.go
@@ -1,10 +1,9 @@
 package swap
 
 import (
-	"testing"
 	"encoding/hex"
+	"testing"
 )
-
 
 const USDT = "2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3"
 const LBTC = "5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225"
@@ -31,8 +30,8 @@ func TestCore_Request(t *testing.T) {
 		{
 			"Alice can create a Swap Request message",
 			args{RequestOpts{
-				AssetToBeSent:   USDT,
-				AmountToBeSent:  30000000000,
+				AssetToSend:     USDT,
+				AmountToSend:    30000000000,
 				AssetToReceive:  LBTC,
 				AmountToReceive: 5000000,
 				PsetBase64:      initialPsbtOfAlice,
@@ -43,11 +42,11 @@ func TestCore_Request(t *testing.T) {
 		{
 			"Alice can create Swap request message (legacy inputs)",
 			args{RequestOpts{
-				AssetToBeSent: LBTC,
-				AmountToBeSent: 100000000,
-				AssetToReceive: altcoin,
-				AmountToReceive: 10000000000,
-				PsetBase64: initialPsetOfAliceLegacyInputs,
+				AssetToSend:       LBTC,
+				AmountToSend:      100000000,
+				AssetToReceive:    altcoin,
+				AmountToReceive:   10000000000,
+				PsetBase64:        initialPsetOfAliceLegacyInputs,
 				InputBlindingKeys: inBlindKeys,
 			}},
 			make([]byte, 12656),

--- a/pkg/trade/buy.go
+++ b/pkg/trade/buy.go
@@ -180,8 +180,8 @@ func (t *Trade) marketOrderRequest(
 	}
 
 	swapRequestMsg, err := swap.Request(swap.RequestOpts{
-		AssetToBeSent:      preview.AssetToSend,
-		AmountToBeSent:     preview.AmountToSend,
+		AssetToSend:        preview.AssetToSend,
+		AmountToSend:       preview.AmountToSend,
 		AssetToReceive:     preview.AssetToReceive,
 		AmountToReceive:    preview.AmountToReceive,
 		PsetBase64:         psetBase64,

--- a/pkg/transactionutil/transactionutil.go
+++ b/pkg/transactionutil/transactionutil.go
@@ -23,15 +23,24 @@ func UnblindOutput(
 	utxo *transaction.TxOutput,
 	blindKey []byte,
 ) (*UnblindedResult, bool) {
-	revealed, err := confidential.UnblindOutputWithKey(utxo, blindKey)
-	if err != nil {
-		return nil, false
+	if utxo.IsConfidential() {
+		revealed, err := confidential.UnblindOutputWithKey(utxo, blindKey)
+		if err != nil {
+			return nil, false
+		}
+		return &UnblindedResult{
+			AssetHash:    hex.EncodeToString(elementsutil.ReverseBytes(revealed.Asset)),
+			Value:        revealed.Value,
+			AssetBlinder: revealed.AssetBlindingFactor,
+			ValueBlinder: revealed.ValueBlindingFactor,
+		}, true
 	}
+
 	return &UnblindedResult{
-		AssetHash:    hex.EncodeToString(elementsutil.ReverseBytes(revealed.Asset)),
-		Value:        revealed.Value,
-		AssetBlinder: revealed.AssetBlindingFactor,
-		ValueBlinder: revealed.ValueBlindingFactor,
+		AssetHash:    bufferutil.AssetHashFromBytes(utxo.Asset),
+		Value:        bufferutil.ValueFromBytes(utxo.Value),
+		AssetBlinder: make([]byte, 32),
+		ValueBlinder: make([]byte, 32),
 	}, true
 }
 

--- a/pkg/wallet/errors.go
+++ b/pkg/wallet/errors.go
@@ -90,6 +90,8 @@ var (
 	ErrInvalidInputAssetBlinder = errors.New("asset blinder must be a 32-byte array")
 	// ErrInvalidInputAmountBlinder ...
 	ErrInvalidInputAmountBlinder = errors.New("amount blinder must be a 32-byte array")
+	// ErrInvalidInBlindingKey ...
+	ErrInvalidInBlindingKey = errors.New("unable to recover blinding data with provided key")
 
 	// ErrEmptyDerivationPaths ...
 	ErrEmptyDerivationPaths = errors.New("derivation path list must not be empty")
@@ -115,4 +117,7 @@ var (
 	ErrReachedMaxBlindingAttempts = errors.New(
 		"max number of attempts reached for blinding the transaction",
 	)
+
+	// ErrMissingInBlindingKey ...
+	ErrMissingInBlindingKey = errors.New("missing blinding key for input")
 )


### PR DESCRIPTION
This adds the component tests for the trade service, making sure that the daemon is able to serve multiple concurrent trade proposals.
I found out that for some reason the in-memory vault repo isn't trade-safe, therefore it wouldn't be possible to run trade tests in parallel. To quickly solve this, I opted for tweaking a bit the existing badger repo manager and allow to create all stores in memory. Pure in-memory repositories will be used again in tests when we'll move to a weak consistency approach eventually.

This also enforces strong consistency at the application level: basically, the repoManager has been removed from the grpc interface, where it was living only to run manual db transactions (strong consistency) when required, ie. whenever an application RPC causes cross repo changes. This operation is now done by the app services if required.

BONUS:
* remove range and surjection proof from unspent domain
* because of above, blind txs with blinding data instead of keys
* trade repo creates a trade if not found (both impls)
* return blinding data also in case of unconf output in `trasactionutil.UnblindOutput`
* remove checks in pkg/swap involving unblinding of tx ins/outs.
* increase verbosity of wallet service when is restoring utxo set after daemon restart
* polish bc listener removing all its deprecated fields

Closes #305.
Closes #327.
Closes #328.
Closes #329.

Please @tiero review this.
