### PR TITLE
Let the operator to configure CLI datadir

### DIFF
--- a/cmd/tdex/main.go
+++ b/cmd/tdex/main.go
@@ -31,7 +31,7 @@ var (
 )
 
 func init() {
-	dataDir := os.Getenv("TDEX_CLI_DATADIR")
+	dataDir := os.Getenv("TDEX_OPERATOR_DATADIR")
 	if len(dataDir) <= 0 {
 		return
 	}

--- a/cmd/tdex/main.go
+++ b/cmd/tdex/main.go
@@ -30,6 +30,19 @@ var (
 	statePath   = path.Join(tdexDataDir, "state.json")
 )
 
+func init() {
+	dataDir := os.Getenv("TDEX_CLI_DATADIR")
+	if len(dataDir) <= 0 {
+		return
+	}
+
+	if !path.IsAbs(dataDir) {
+		fatal(errors.New("cli datadir must be an absolute path"))
+	}
+	tdexDataDir = dataDir
+	statePath = path.Join(tdexDataDir, "state.json")
+}
+
 func main() {
 	app := cli.NewApp()
 


### PR DESCRIPTION
This lets the user of the CLI to define its datadir by setting the env variable `TDEX_OPERATOR_DATADIR`. If not set it defaults to the usual appdata/tdex-operator.

Please @tiero review this.