### PR TITLE
Hotfix: Restore proofs

### DIFF
--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -1002,6 +1002,8 @@ func (o *operatorService) claimDeposit(
 				AssetBlinder:    unconfidential.AssetBlinder,
 				ScriptPubKey:    txOut.Script,
 				Nonce:           txOut.Nonce,
+				RangeProof:      make([]byte, 1),
+				SurjectionProof: make([]byte, 1),
 				Address:         info.Address,
 				Confirmed:       true,
 			}

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -130,6 +130,8 @@ func newTradeService() (application.TradeService, error) {
 			AssetBlinder:    randomBytes(32),
 			ScriptPubKey:    script,
 			Nonce:           randomBytes(32),
+			RangeProof:      make([]byte, 1),
+			SurjectionProof: make([]byte, 1),
 			Address:         info.Address,
 			Confirmed:       true,
 		})
@@ -163,6 +165,8 @@ func newTradeService() (application.TradeService, error) {
 			AssetBlinder:    randomBytes(32),
 			ScriptPubKey:    script,
 			Nonce:           randomBytes(32),
+			RangeProof:      make([]byte, 1),
+			SurjectionProof: make([]byte, 1),
 			Address:         info.Address,
 			Confirmed:       true,
 		})

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -837,6 +837,8 @@ func (w *walletService) restoreUnspentsForAddress(
 			AssetBlinder:    u.AssetBlinder(),
 			ScriptPubKey:    u.Script(),
 			Nonce:           u.Nonce(),
+			RangeProof:      make([]byte, 1),
+			SurjectionProof: make([]byte, 1),
 			Confirmed:       u.IsConfirmed(),
 			Address:         addr,
 		}
@@ -1129,6 +1131,8 @@ func fetchUnspents(explorerSvc explorer.Service, info domain.AddressesInfo) ([]d
 			AssetBlinder:    u.AssetBlinder(),
 			ScriptPubKey:    u.Script(),
 			Nonce:           u.Nonce(),
+			RangeProof:      make([]byte, 1),
+			SurjectionProof: make([]byte, 1),
 			Confirmed:       u.IsConfirmed(),
 			Address:         addr,
 		}
@@ -1274,6 +1278,8 @@ func extractUnspentsFromTx(
 				AssetBlinder:    unconfidential.AssetBlinder,
 				ScriptPubKey:    out.Script,
 				Nonce:           out.Nonce,
+				RangeProof:      make([]byte, 1),
+				SurjectionProof: make([]byte, 1),
 				Address:         info.Address,
 				Confirmed:       false,
 			})

--- a/internal/core/domain/unspent_model.go
+++ b/internal/core/domain/unspent_model.go
@@ -24,6 +24,8 @@ type Unspent struct {
 	AssetBlinder    []byte
 	ScriptPubKey    []byte
 	Nonce           []byte
+	RangeProof      []byte
+	SurjectionProof []byte
 	Address         string
 	Spent           bool
 	Locked          bool

--- a/internal/core/domain/unspent_service.go
+++ b/internal/core/domain/unspent_service.go
@@ -88,8 +88,8 @@ func (u *Unspent) ToUtxo() explorer.Utxo {
 		u.AssetBlinder,
 		u.ScriptPubKey,
 		u.Nonce,
-		nil,
-		nil,
+		u.RangeProof,
+		u.SurjectionProof,
 		u.Confirmed,
 	)
 }

--- a/internal/infrastructure/storage/db/test/unspent_repository_impl_test.go
+++ b/internal/infrastructure/storage/db/test/unspent_repository_impl_test.go
@@ -570,6 +570,8 @@ func mockUnspent(addr, asset *string, spent, confirmed bool) domain.Unspent {
 		AssetBlinder:    randomBytes(32),
 		ScriptPubKey:    make([]byte, 20),
 		Nonce:           make([]byte, 33),
+		RangeProof:      make([]byte, 1),
+		SurjectionProof: make([]byte, 1),
 		Address:         mockedAddress,
 		Spent:           spent,
 		Confirmed:       confirmed,


### PR DESCRIPTION
The last commit introduced a bug in the trade flow, and traders using the mobile app were experiencing an issue when the completing a swap. With that commit, the daemon didn't store range and surjection proofs of unspents anymore, causing the upset inputs of the swaps to have null proofs. This is likely to be the cause of the bug. The app, which uses liquidjs, is able to deserialize empty proofs, but it doesn't properly encode them in case they're empty.

This addresses the problem by restoring the proofs in the unspent domain, but keeping them always zeroed ([0x00]), as it's done in the Elements protocol for an output nonce when the output itself is uncofnidential: the nonce is zeroed, that means it contains a single 0 byte, instead of being null.

I made sure that go and js clients are able to complete swaps on regtest network, please try to replicate the same by yourself.

Please @tiero review this.