### PR TITLE
Allow receiving tx hexes in TradeComplete RPC

### DIFF
--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -400,10 +400,10 @@ func (t *tradeService) tradeComplete(
 		return
 	}
 
-	psetBase64 := swapComplete.GetTransaction()
+	tx := swapComplete.GetTransaction()
 
 	// here we manipulate the trade to reach the Complete status
-	res, err := trade.Complete(psetBase64)
+	res, err := trade.Complete(tx)
 	if err != nil {
 		return
 	}

--- a/internal/core/domain/trade_model.go
+++ b/internal/core/domain/trade_model.go
@@ -130,8 +130,8 @@ func (p swapParser) SerializeAccept(args AcceptArgs) (string, []byte, *SwapError
 
 func (p swapParser) SerializeComplete(accMsg []byte, tx string) (string, []byte, *SwapError) {
 	id, msg, err := pkgswap.Complete(pkgswap.CompleteOpts{
-		Message:    accMsg,
-		PsetBase64: tx,
+		Message:     accMsg,
+		Transaction: tx,
 	})
 	if err != nil {
 		return "", nil, &SwapError{err, int(pkgswap.ErrCodeFailedToComplete)}

--- a/internal/core/domain/trade_service_test.go
+++ b/internal/core/domain/trade_service_test.go
@@ -198,22 +198,30 @@ func TestFailingTradeAccept(t *testing.T) {
 }
 
 func TestTradeComplete(t *testing.T) {
-	tx := randomBase64(100)
 	tests := []struct {
 		name  string
 		trade *domain.Trade
+		tx    string
 	}{
 		{
-			name:  "with_trade_accepted",
+			name:  "with_trade_accepted_psetBase64",
 			trade: newTradeAccepted(),
+			tx:    randomBase64(100),
+		},
+		{
+			name:  "with_trade_accepted_txHex",
+			trade: newTradeAccepted(),
+			tx:    randomHex(100),
 		},
 		{
 			name:  "with_trade_completed",
 			trade: newTradeCompleted(),
+			tx:    randomBase64(100),
 		},
 		{
 			name:  "with_trade_settled",
 			trade: newTradeSettled(),
+			tx:    randomBase64(100),
 		},
 	}
 
@@ -224,17 +232,17 @@ func TestTradeComplete(t *testing.T) {
 		mockedSwapParser.On(
 			"SerializeComplete",
 			tt.trade.SwapAccept.Message,
-			tx,
+			tt.tx,
 		).Return(randomID(), randomBytes(100), nil)
 		domain.SwapParserManager = mockedSwapParser
 
 		mockedPsetParser := mockPsetParser{}
-		mockedPsetParser.On("GetTxID", tx).Return(randomHex(32), nil)
-		mockedPsetParser.On("GetTxHex", tx).Return(randomHex(32), nil)
+		mockedPsetParser.On("GetTxID", tt.tx).Return(randomHex(32), nil)
+		mockedPsetParser.On("GetTxHex", tt.tx).Return(randomHex(32), nil)
 		domain.PsetParserManager = mockedPsetParser
 
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := tt.trade.Complete(tx)
+			res, err := tt.trade.Complete(tt.tx)
 			require.NoError(t, err)
 			require.NotNil(t, res)
 			require.True(t, res.OK)

--- a/pkg/swap/complete_test.go
+++ b/pkg/swap/complete_test.go
@@ -20,8 +20,8 @@ func TestSwap_Complete(t *testing.T) {
 			PsetBase64: initialPsbtOfBob,
 		})
 		_, got, err := Complete(CompleteOpts{
-			Message:    messageAccept,
-			PsetBase64: finalPsbtOfAlice,
+			Message:     messageAccept,
+			Transaction: finalPsbtOfAlice,
 		})
 		if err != nil {
 			t.Errorf("Swap.Complete() error = %v ", err)

--- a/pkg/trade/buy.go
+++ b/pkg/trade/buy.go
@@ -216,8 +216,8 @@ func (t *Trade) marketOrderComplete(swapAcceptMsg []byte, w *Wallet) (string, er
 	}
 
 	_, swapCompleteMsg, err := swap.Complete(swap.CompleteOpts{
-		Message:    swapAcceptMsg,
-		PsetBase64: signedPset,
+		Message:     swapAcceptMsg,
+		Transaction: signedPset,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This adds some little changes in order to allow the daemon to receive not just psets in base64 format, but also already extracted raw txs in hex format.

Please @tiero, review this.