### PR TITLE
Market fees backward compatibility

### DIFF
--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -208,7 +208,7 @@ func (o *operatorService) DepositMarket(
 				ctx,
 				&domain.Market{
 					AccountIndex: accountIndex,
-					Fee:          domain.Fee{BasisPoint: o.marketFee},
+					Fee:          o.marketFee,
 				},
 			); err != nil {
 				return nil, err
@@ -403,7 +403,11 @@ func (o *operatorService) UpdateMarketPercentageFee(
 			BaseAsset:  mkt.BaseAsset,
 			QuoteAsset: mkt.QuoteAsset,
 		},
-		Fee: Fee(mkt.Fee),
+		Fee: Fee{
+			BasisPoint:    mkt.Fee,
+			FixedBaseFee:  mkt.FixedFee.BaseFee,
+			FixedQuoteFee: mkt.FixedFee.QuoteFee,
+		},
 	}, nil
 }
 
@@ -455,7 +459,11 @@ func (o *operatorService) UpdateMarketFixedFee(
 			BaseAsset:  mkt.BaseAsset,
 			QuoteAsset: mkt.QuoteAsset,
 		},
-		Fee: Fee(mkt.Fee),
+		Fee: Fee{
+			BasisPoint:    mkt.Fee,
+			FixedBaseFee:  mkt.FixedFee.BaseFee,
+			FixedQuoteFee: mkt.FixedFee.QuoteFee,
+		},
 	}, nil
 }
 
@@ -627,10 +635,14 @@ func (o *operatorService) ListMarket(
 				BaseAsset:  market.BaseAsset,
 				QuoteAsset: market.QuoteAsset,
 			},
-			Fee:          Fee(market.Fee),
 			Tradable:     market.Tradable,
 			StrategyType: market.Strategy.Type,
 			Price:        market.Price,
+			Fee: Fee{
+				BasisPoint:    market.Fee,
+				FixedBaseFee:  market.FixedFee.BaseFee,
+				FixedQuoteFee: market.FixedFee.QuoteFee,
+			},
 		})
 	}
 

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -213,7 +213,7 @@ func newTradeService(withFixedFee bool) (application.TradeService, error) {
 		ctx,
 		&domain.Market{
 			AccountIndex: domain.MarketAccountStart,
-			Fee:          domain.Fee{BasisPoint: marketFee},
+			Fee:          marketFee,
 		},
 	)
 	if err != nil {

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -60,7 +60,11 @@ type Market struct {
 	QuoteAsset string
 }
 
-type Fee domain.Fee
+type Fee struct {
+	BasisPoint    int64
+	FixedBaseFee  int64
+	FixedQuoteFee int64
+}
 
 type MarketWithFee struct {
 	Market

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -658,7 +658,7 @@ func (w *walletService) restoreMarket(
 ) (*domain.Market, error) {
 	market, err := w.repoManager.MarketRepository().GetOrCreateMarket(ctx, &domain.Market{
 		AccountIndex: accountIndex,
-		Fee:          domain.Fee{BasisPoint: w.marketFee},
+		Fee:          w.marketFee,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/core/domain/market_model.go
+++ b/internal/core/domain/market_model.go
@@ -6,10 +6,9 @@ import (
 	"github.com/tdex-network/tdex-daemon/pkg/marketmaking/formula"
 )
 
-type Fee struct {
-	BasisPoint    int64
-	FixedBaseFee  int64
-	FixedQuoteFee int64
+type FixedFee struct {
+	BaseFee  int64
+	QuoteFee int64
 }
 
 // Market defines the Market entity data structure for holding an asset pair state
@@ -19,10 +18,8 @@ type Market struct {
 	BaseAsset    string
 	QuoteAsset   string
 	// Each Market has a different fee expressed in basis point of each swap.
-	// A fixed fee amount for both assets might be defined to discourage
-	// low-amount trades on the market and to be reimbursed for paying network
-	// fees.
-	Fee Fee
+	Fee      int64
+	FixedFee FixedFee
 	// if curretly open for trades
 	Tradable bool
 	// Market Making strategy
@@ -62,7 +59,7 @@ func NewMarket(positiveAccountIndex int, feeInBasisPoint int64) (*Market, error)
 
 	return &Market{
 		AccountIndex: positiveAccountIndex,
-		Fee:          Fee{BasisPoint: feeInBasisPoint},
+		Fee:          feeInBasisPoint,
 		Strategy:     mm.NewStrategyFromFormula(formula.BalancedReserves{}),
 	}, nil
 }

--- a/internal/core/domain/market_model_test.go
+++ b/internal/core/domain/market_model_test.go
@@ -17,9 +17,9 @@ func TestNewMarket(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	require.Equal(t, accountIndex, m.AccountIndex)
-	require.Equal(t, fee, m.Fee.BasisPoint)
-	require.Zero(t, m.Fee.FixedBaseFee)
-	require.Zero(t, m.Fee.FixedQuoteFee)
+	require.Equal(t, fee, m.Fee)
+	require.Zero(t, m.FixedFee.BaseFee)
+	require.Zero(t, m.FixedFee.QuoteFee)
 	require.False(t, m.IsStrategyPluggable())
 }
 

--- a/internal/core/domain/market_service.go
+++ b/internal/core/domain/market_service.go
@@ -20,20 +20,12 @@ func (p Prices) AreZero() bool {
 	return decimal.Decimal(p.BasePrice).Equal(decimal.NewFromInt(0)) && decimal.Decimal(p.QuotePrice).Equal(decimal.NewFromInt(0))
 }
 
-func (f Fee) validate() error {
-	if f.BasisPoint < 0 {
-		return ErrMarketFeeTooLow
-	}
-
-	if f.BasisPoint > 9999 {
-		return ErrMarketFeeTooHigh
-	}
-
-	if f.FixedBaseFee < 0 || f.FixedQuoteFee < 0 {
+func (f FixedFee) validate() error {
+	if f.BaseFee < 0 || f.QuoteFee < 0 {
 		return ErrInvalidFixedFee
 	}
 
-	if (f.FixedBaseFee > 0 && f.FixedQuoteFee == 0) || (f.FixedQuoteFee > 0 && f.FixedBaseFee == 0) {
+	if (f.BaseFee > 0 && f.QuoteFee == 0) || (f.QuoteFee > 0 && f.BaseFee == 0) {
 		return ErrMissingFixedFee
 	}
 
@@ -178,7 +170,7 @@ func (m *Market) ChangeFeeBasisPoint(fee int64) error {
 		return err
 	}
 
-	m.Fee.BasisPoint = fee
+	m.Fee = fee
 	return nil
 }
 
@@ -196,8 +188,8 @@ func (m *Market) ChangeFixedFee(baseFee, quoteFee int64) error {
 		return err
 	}
 
-	m.Fee.FixedBaseFee = baseFee
-	m.Fee.FixedQuoteFee = quoteFee
+	m.FixedFee.BaseFee = baseFee
+	m.FixedFee.QuoteFee = quoteFee
 	return nil
 }
 

--- a/internal/core/domain/market_service_test.go
+++ b/internal/core/domain/market_service_test.go
@@ -207,7 +207,7 @@ func TestChangeFeeBasisPoint(t *testing.T) {
 
 	err := m.ChangeFeeBasisPoint(newFee)
 	require.NoError(t, err)
-	require.Equal(t, newFee, m.Fee.BasisPoint)
+	require.Equal(t, newFee, m.Fee)
 }
 
 func TestFailingChangeFeeBasisPoint(t *testing.T) {
@@ -262,8 +262,8 @@ func TestChangeFixedFee(t *testing.T) {
 
 	err := m.ChangeFixedFee(baseFee, quoteFee)
 	require.NoError(t, err)
-	require.Equal(t, baseFee, m.Fee.FixedBaseFee)
-	require.Equal(t, quoteFee, m.Fee.FixedQuoteFee)
+	require.Equal(t, baseFee, m.FixedFee.BaseFee)
+	require.Equal(t, quoteFee, m.FixedFee.QuoteFee)
 }
 
 func TestFailingChangeFixedFee(t *testing.T) {

--- a/internal/core/domain/trade_service.go
+++ b/internal/core/domain/trade_service.go
@@ -12,7 +12,7 @@ import (
 func (t *Trade) Propose(
 	swapRequest SwapRequest,
 	marketQuoteAsset string,
-	marketFee Fee,
+	marketFee, fixedBaseFee, fixedQuoteFee int64,
 	traderPubkey []byte,
 ) (bool, error) {
 	if t.Status.Code >= Proposal {
@@ -41,9 +41,9 @@ func (t *Trade) Propose(
 
 	t.SwapRequest.Message = msg
 	t.MarketPrice = price
-	t.MarketFee = marketFee.BasisPoint
-	t.MarketFixedBaseFee = marketFee.FixedBaseFee
-	t.MarketFixedQuoteFee = marketFee.FixedQuoteFee
+	t.MarketFee = marketFee
+	t.MarketFixedBaseFee = fixedBaseFee
+	t.MarketFixedQuoteFee = fixedQuoteFee
 	return true, nil
 }
 

--- a/internal/core/domain/trade_service_test.go
+++ b/internal/core/domain/trade_service_test.go
@@ -22,7 +22,7 @@ var mockedErr = &domain.SwapError{
 func TestTradePropose(t *testing.T) {
 	swapRequest := newMockedSwapRequest()
 	marketAsset := swapRequest.GetAssetR()
-	marketFee := domain.Fee{BasisPoint: int64(25)}
+	marketFee := int64(25)
 	traderPubkey := []byte{}
 	mockedSwapParser := mockSwapParser{}
 	mockedSwapParser.On("SerializeRequest", swapRequest).Return(randomBytes(100), nil)
@@ -60,7 +60,7 @@ func TestTradePropose(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := tt.trade.Propose(swapRequest, marketAsset, marketFee, traderPubkey)
+			ok, err := tt.trade.Propose(swapRequest, marketAsset, marketFee, 0, 0, traderPubkey)
 			require.NoError(t, err)
 			require.True(t, ok)
 
@@ -75,7 +75,7 @@ func TestTradePropose(t *testing.T) {
 func TestFailingTradePropose(t *testing.T) {
 	swapRequest := newMockedSwapRequest()
 	marketAsset := swapRequest.GetAssetR()
-	marketFee := domain.Fee{BasisPoint: int64(25)}
+	marketFee := int64(25)
 	traderPubkey := []byte{}
 	mockedSwapParser := mockSwapParser{}
 	mockedSwapParser.On("SerializeRequest", swapRequest).Return(nil, mockedErr)
@@ -90,7 +90,7 @@ func TestFailingTradePropose(t *testing.T) {
 	t.Run("failing_because_invalid_request", func(t *testing.T) {
 		trade := newTradeEmpty()
 
-		ok, err := trade.Propose(swapRequest, marketAsset, marketFee, traderPubkey)
+		ok, err := trade.Propose(swapRequest, marketAsset, marketFee, 0, 0, traderPubkey)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.True(t, trade.IsProposal())

--- a/internal/infrastructure/storage/db/badger/market_repository_impl.go
+++ b/internal/infrastructure/storage/db/badger/market_repository_impl.go
@@ -199,7 +199,7 @@ func (m marketRepositoryImpl) getOrCreateMarket(
 
 	if mkt == nil {
 		accountIndex := market.AccountIndex
-		fee := market.Fee.BasisPoint
+		fee := market.Fee
 
 		mkt, err = domain.NewMarket(accountIndex, fee)
 		if err != nil {

--- a/internal/infrastructure/storage/db/inmemory/market_memory_repository_impl.go
+++ b/internal/infrastructure/storage/db/inmemory/market_memory_repository_impl.go
@@ -198,7 +198,7 @@ func (r MarketRepositoryImpl) getOrCreateMarket(market *domain.Market) (*domain.
 	// override mkt into the if statement.
 	mkt, err := r.getMarketByAccount(market.AccountIndex)
 	if mkt == nil {
-		mkt, err = domain.NewMarket(market.AccountIndex, market.Fee.BasisPoint)
+		mkt, err = domain.NewMarket(market.AccountIndex, market.Fee)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/infrastructure/storage/db/test/market_repository_impl_test.go
+++ b/internal/infrastructure/storage/db/test/market_repository_impl_test.go
@@ -17,7 +17,7 @@ var (
 	readOnly = true
 	ctx      = context.Background()
 
-	fee = domain.Fee{BasisPoint: int64(25)}
+	fee = int64(25)
 )
 
 func TestMarketRepositoryImplementations(t *testing.T) {

--- a/internal/interfaces/grpc/handler/operator.go
+++ b/internal/interfaces/grpc/handler/operator.go
@@ -371,7 +371,7 @@ func (o operatorHandler) updateMarketPercentageFee(
 				QuoteAsset: result.QuoteAsset,
 			},
 			Fee: &pbtypes.Fee{
-				BasisPoint: result.BasisPoint,
+				BasisPoint: result.Fee.BasisPoint,
 				Fixed: &pbtypes.Fixed{
 					BaseFee:  result.FixedBaseFee,
 					QuoteFee: result.FixedQuoteFee,


### PR DESCRIPTION
This makes the previous changes to the market fees backward compatible with previous versions of the daemon.

Plus, this moves the lock of the unspents of an accepted trade outside the go routine.

Please @tiero review this.