### PR TITLE
Update explorer's Faucet,Mint methods & Make e2e test run in CI

### DIFF
--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -199,8 +199,8 @@ func (m *mockExplorer) BroadcastTransaction(txhex string) (string, error) {
 	return res, args.Error(1)
 }
 
-func (m *mockExplorer) Faucet(addr string, amount int) (string, error) {
-	args := m.Called(addr)
+func (m *mockExplorer) Faucet(addr string, amount float64, asset string) (string, error) {
+	args := m.Called(addr, amount, asset)
 
 	var res string
 	if a := args.Get(0); a != nil {
@@ -209,7 +209,7 @@ func (m *mockExplorer) Faucet(addr string, amount int) (string, error) {
 	return res, args.Error(1)
 }
 
-func (m *mockExplorer) Mint(addr string, amount int) (string, string, error) {
+func (m *mockExplorer) Mint(addr string, amount float64) (string, string, error) {
 	args := m.Called(addr, amount)
 
 	var res string

--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -140,10 +140,10 @@ func (m mockExplorer) GetTransactionsForAddress(addr string, blindingKey []byte)
 func (m mockExplorer) BroadcastTransaction(txHex string) (string, error) {
 	return "", errors.New("implement me")
 }
-func (m mockExplorer) Faucet(addr string, amount int) (string, error) {
+func (m mockExplorer) Faucet(addr string, amount float64, asset string) (string, error) {
 	return "", errors.New("implement me")
 }
-func (m mockExplorer) Mint(addr string, amount int) (string, string, error) {
+func (m mockExplorer) Mint(addr string, amount float64) (string, string, error) {
 	return "", "", errors.New("implement me")
 }
 

--- a/pkg/explorer/elements/transaction.go
+++ b/pkg/explorer/elements/transaction.go
@@ -3,7 +3,6 @@ package elements
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"sync"
 
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
@@ -180,9 +179,8 @@ func (e *elements) Faucet(addr string, amount float64, asset string) (string, er
 		asset = net.AssetID
 	}
 
-	btcAmount := float64(amount) / math.Pow10(8)
 	r, err := e.client.call("sendtoaddress", []interface{}{
-		addr, btcAmount, "", "", false, false, 1, "UNSET", asset,
+		addr, amount, "", "", false, false, 1, "UNSET", asset,
 	})
 	if err = handleError(err, &r); err != nil {
 		return "", fmt.Errorf("send: %w", err)

--- a/pkg/explorer/elements/transaction_test.go
+++ b/pkg/explorer/elements/transaction_test.go
@@ -18,7 +18,7 @@ func TestGetTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txid, err := elementsSvc.Faucet(addr, oneLbtc)
+	txid, err := elementsSvc.Faucet(addr, oneLbtc, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func TestGetTransactionHex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txid, err := elementsSvc.Faucet(addr, oneLbtc)
+	txid, err := elementsSvc.Faucet(addr, oneLbtc, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestIsTransactionConfirmed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txid, err := elementsSvc.Faucet(addr, oneLbtc)
+	txid, err := elementsSvc.Faucet(addr, oneLbtc, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestGetTransactionStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txid, err := elementsSvc.Faucet(addr, oneLbtc)
+	txid, err := elementsSvc.Faucet(addr, oneLbtc, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := elementsSvc.Faucet(addr, oneLbtc); err != nil {
+	if _, err := elementsSvc.Faucet(addr, oneLbtc, ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := elementsSvc.Mint(addr, 10); err != nil {

--- a/pkg/explorer/elements/unspents_test.go
+++ b/pkg/explorer/elements/unspents_test.go
@@ -1,7 +1,6 @@
 package elements
 
 import (
-	"math"
 	"os"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 	"github.com/vulpemventures/go-elements/payment"
 )
 
-var oneLbtc = int(math.Pow10(8))
+var oneLbtc = float64(1)
 
 func TestGetUnspents(t *testing.T) {
 	elementsSvc, err := newService()
@@ -25,7 +24,7 @@ func TestGetUnspents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := elementsSvc.Faucet(address, oneLbtc); err != nil {
+	if _, err := elementsSvc.Faucet(address, oneLbtc, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -59,7 +58,7 @@ func TestGetUnspentsForAddresses(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := elementsSvc.Faucet(addr1, oneLbtc); err != nil {
+	if _, err := elementsSvc.Faucet(addr1, oneLbtc, ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := elementsSvc.Mint(addr2, 100); err != nil {

--- a/pkg/explorer/esplora/transaction.go
+++ b/pkg/explorer/esplora/transaction.go
@@ -3,7 +3,6 @@ package esplora
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"sync"
 
@@ -70,10 +69,9 @@ func (e *esplora) BroadcastTransaction(txHex string) (string, error) {
 	return resp, nil
 }
 
-func (e *esplora) Faucet(address string, amount int) (string, error) {
-	btcAmount := float64(amount) / math.Pow10(8)
+func (e *esplora) Faucet(address string, amount float64, asset string) (string, error) {
 	url := fmt.Sprintf("%s/faucet", e.apiURL)
-	payload := map[string]interface{}{"address": address, "amount": btcAmount}
+	payload := map[string]interface{}{"address": address, "amount": amount, "asset": asset}
 	body, _ := json.Marshal(payload)
 	bodyString := string(body)
 	headers := map[string]string{
@@ -96,7 +94,7 @@ func (e *esplora) Faucet(address string, amount int) (string, error) {
 	return rr["txId"], nil
 }
 
-func (e *esplora) Mint(address string, amount int) (string, string, error) {
+func (e *esplora) Mint(address string, amount float64) (string, string, error) {
 	url := fmt.Sprintf("%s/mint", e.apiURL)
 	payload := map[string]interface{}{"address": address, "quantity": amount}
 	body, _ := json.Marshal(payload)

--- a/pkg/explorer/esplora/transaction_test.go
+++ b/pkg/explorer/esplora/transaction_test.go
@@ -19,7 +19,8 @@ func TestGetTransaction(t *testing.T) {
 	}
 
 	// Fund sender address.
-	txID, err := explorerSvc.Faucet(addr, oneLbtc)
+	// Empty asset hash defaults to LBTC.
+	txID, err := explorerSvc.Faucet(addr, oneLbtc, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +46,7 @@ func TestGetTransactionStatus(t *testing.T) {
 	}
 
 	// Fund sender address.
-	txID, err := explorerSvc.Faucet(addr, oneLbtc)
+	txID, err := explorerSvc.Faucet(addr, oneLbtc, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +80,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 	}
 
 	// Fund sender address.
-	if _, err := explorerSvc.Faucet(addr, oneLbtc); err != nil {
+	if _, err := explorerSvc.Faucet(addr, oneLbtc, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/explorer/esplora/unspents_test.go
+++ b/pkg/explorer/esplora/unspents_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vulpemventures/go-elements/payment"
 )
 
-var oneLbtc = 100000000
+var oneLbtc = float64(1)
 
 func TestGetUnspents(t *testing.T) {
 	address, blindKey, err := newTestData()
@@ -25,7 +25,7 @@ func TestGetUnspents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = explorerSvc.Faucet(address, oneLbtc)
+	_, err = explorerSvc.Faucet(address, oneLbtc, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestSelectUnspents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := explorerSvc.Faucet(addr, oneLbtc); err != nil {
+	if _, err := explorerSvc.Faucet(addr, oneLbtc, ""); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(5 * time.Second)

--- a/pkg/explorer/explorer.go
+++ b/pkg/explorer/explorer.go
@@ -63,11 +63,11 @@ type Service interface {
 	// BroadcastTransaction attempts to add the given tx in hex format to the
 	// mempool and returns its tx hash.
 	BroadcastTransaction(txhex string) (txid string, err error)
-	/**** REGTEST ONLY ****/
-	// Faucet funds the given address with 1 LBTC
-	Faucet(address string, amount int) (txid string, err error)
-	// Mint funds the given address with a certain amount of a new issued asset.
-	Mint(address string, amount int) (txid string, asset string, err error)
 	// GetBlockHeight returns the the number of block of the blockchain.
 	GetBlockHeight() (int, error)
+	/**** REGTEST ONLY ****/
+	// Faucet funds the given address with the amount (in BTC) of provided asset
+	Faucet(address string, amount float64, asset string) (txid string, err error)
+	// Mint funds the given address with a certain amount (in BTC) of a new issued asset.
+	Mint(address string, amount float64) (txid string, asset string, err error)
 }


### PR DESCRIPTION
This updates the e2e test so that it doesn't make use of nigiri CLI since this is not installed in CI (we use a lighter version without installing the nigiri binary and CLI).

For this, the explorer interface has been updated so that an asset string argument is added to the Faucet method.
The amount type of this and also the Mint methods were source of mistakes in other tests, therefore they've changed from uint (sats) to float (BTC).

This closes #354.
This closes #345.

Please @tiero review this.