### PR TITLE
Fix preview of MarketPrice & fix error message

### DIFF
--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -186,8 +186,7 @@ func (t *tradeService) GetMarketPrice(
 
 	preview, err := previewForMarket(unspents, mkt, tradeType, amount, asset)
 	if err != nil {
-		log.Debugf("error while making preview: %s", err)
-		return nil, ErrServiceUnavailable
+		return nil, err
 	}
 
 	return &PriceWithFee{
@@ -865,6 +864,17 @@ func previewForMarket(
 	amount uint64,
 	asset string,
 ) (*preview, error) {
+	isBaseAsset := asset == market.BaseAsset
+	if isBaseAsset {
+		if amount < uint64(market.FixedFee.BaseFee) {
+			return nil, errors.New("provided amount is too small")
+		}
+	} else {
+		if amount < uint64(market.FixedFee.QuoteFee) {
+			return nil, errors.New("provided amount is too small")
+		}
+	}
+
 	balances := getBalanceByAsset(unspents)
 	marketBalance := Balance{
 		BaseAmount:  balances[market.BaseAsset],


### PR DESCRIPTION
This adds a sanity check on the amount provided to the MarketPrice request, in order to make sure that it is big enough to calculate the expected counter-amount.

With this, all daemons that provide markets with fixed fees set will start rejecting requests in case their amounts are smaller than the respective fixed fee.

This closes #366.

BONUS: Prior this, the error returned when calculating the preview was incorrectly overwritten by the ErrServiceUnavailable one. Not anymore from now on.

Please @tiero, review this.