### PR TITLE
Add extraIP/extraDomain to Operator TLS cert & refactor macaroon permissons/files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.2
+          go-version: 1.16.1
         id: go
 
       - name: Check out code into the Go module directory

--- a/cmd/tdex/config.go
+++ b/cmd/tdex/config.go
@@ -32,7 +32,7 @@ var (
 
 	tlsCertFlag = cli.StringFlag{
 		Name:  "tls_cert_path",
-		Usage: fmt.Sprintf("the directory where to fing the %s file", tlsCertFile),
+		Usage: "the path of the TLS certificate file to use",
 		Value: "",
 	}
 
@@ -44,7 +44,7 @@ var (
 
 	macaroonsFlag = cli.StringFlag{
 		Name:  "macaroons_path",
-		Usage: fmt.Sprintf("the directory where to find the %s file", adminMacaroonFile),
+		Usage: "the path of the macaroons file to use",
 		Value: "",
 	}
 )

--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -40,6 +40,8 @@ var (
 	statsIntervalInSeconds = config.GetDuration(config.StatsIntervalKey) * time.Second
 	tradeTLSKey            = config.GetString(config.TradeTLSKeyKey)
 	tradeTLSCert           = config.GetString(config.TradeTLSCertKey)
+	operatorTLSExtraIP     = config.GetString(config.OperatorExtraIP)
+	operatorTLSExtraDomain = config.GetString(config.OperatorExtraDomain)
 	// App services config
 	marketsFee                    = int64(config.GetFloat(config.DefaultFeeKey) * 100)
 	marketsBaseAsset              = config.GetString(config.BaseAssetKey)
@@ -127,14 +129,16 @@ func main() {
 
 	// Init gRPC interfaces.
 	opts := grpcinterface.ServiceOpts{
-		NoMacaroons:       noMacaroons,
-		Datadir:           datadir,
-		DBLocation:        config.DbLocation,
-		TLSLocation:       config.TLSLocation,
-		MacaroonsLocation: config.MacaroonsLocation,
-		WalletSvc:         walletSvc,
-		OperatorSvc:       operatorSvc,
-		TradeSvc:          tradeSvc,
+		NoMacaroons:         noMacaroons,
+		Datadir:             datadir,
+		DBLocation:          config.DbLocation,
+		TLSLocation:         config.TLSLocation,
+		MacaroonsLocation:   config.MacaroonsLocation,
+		OperatorExtraIP:     operatorTLSExtraIP,
+		OperatorExtraDomain: operatorTLSExtraDomain,
+		WalletSvc:           walletSvc,
+		OperatorSvc:         operatorSvc,
+		TradeSvc:            tradeSvc,
 	}
 	svc, err := grpcinterface.NewService(opts)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,14 @@ const (
 	// NoMacaroonsKey is used to start the daemon without using macaroons auth
 	// service.
 	NoMacaroonsKey = "NO_MACAROONS"
+	// OperatorExtraIP is used to add an extra ip address to the self-signed TLS
+	// certificate for the Operator gRPC interface.
+	OperatorExtraIP = "OPERATOR_EXTRA_IP"
+	// OperatorExtraDomain is used to add an extra domain to the self signed TLS
+	// certificate for the Operator gRPC interface. This is useful to add the
+	// onion endpoint in case the daemon is served as a TOR hidden service for
+	// example.
+	OperatorExtraDomain = "OPERATOR_EXTRA_DOMAIN"
 
 	DbLocation        = "db"
 	TLSLocation       = "tls"

--- a/internal/interfaces/grpc/handler/trade.go
+++ b/internal/interfaces/grpc/handler/trade.go
@@ -89,6 +89,10 @@ func (t traderHandler) markets(
 			},
 			Fee: &types.Fee{
 				BasisPoint: v.BasisPoint,
+				Fixed: &pbtypes.Fixed{
+					BaseFee:  v.FixedBaseFee,
+					QuoteFee: v.FixedQuoteFee,
+				},
 			},
 		}
 		marketsWithFee = append(marketsWithFee, m)

--- a/internal/interfaces/grpc/permissions/permissions.go
+++ b/internal/interfaces/grpc/permissions/permissions.go
@@ -1,50 +1,104 @@
 package permissions
 
 import (
-	"github.com/tdex-network/tdex-daemon/pkg/macaroons"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
 const (
 	EntityOperator = "operator"
-	EntityTrader   = "trader"
+	EntityTrade    = "trade"
+	EntityMarket   = "market"
+	EntityPrice    = "price"
+	EntityUnlocker = "unlocker"
+	EntityWallet   = "wallet"
+	EntityWebhook  = "webhook"
 )
 
+// MarketPermissions returns the permissions of the macaroon market.macaroon.
+// This grants access to all actions for the market and price entities.
 func MarketPermissions() []bakery.Op {
 	return []bakery.Op{
 		{
-			Entity: macaroons.PermissionEntityCustomURI,
-			Action: "/Operator/OpenMarket",
+			Entity: EntityMarket,
+			Action: "read",
 		},
 		{
-			Entity: macaroons.PermissionEntityCustomURI,
-			Action: "/Operator/CloseMarket",
+			Entity: EntityMarket,
+			Action: "write",
 		},
 		{
-			Entity: macaroons.PermissionEntityCustomURI,
-			Action: "/Operator/UpdateMarketStrategy",
+			Entity: EntityPrice,
+			Action: "write",
 		},
 	}
 }
 
+// PricePermissions returns the permissions of the macaroon price.macaroon.
+// This grants access to all actions for the price entity.
 func PricePermissions() []bakery.Op {
 	return []bakery.Op{
 		{
-			Entity: macaroons.PermissionEntityCustomURI,
-			Action: "/Operator/UpdateMarketPrice",
+			Entity: EntityPrice,
+			Action: "write",
 		},
 	}
 }
 
+// ReadOnlyPermissions returns the permissions of the macaroon readonly.macaroon.
+// This grants access to the read action for all entities.
 func ReadOnlyPermissions() []bakery.Op {
 	return []bakery.Op{
 		{
 			Entity: EntityOperator,
 			Action: "read",
 		},
+		{
+			Entity: EntityMarket,
+			Action: "read",
+		},
+		{
+			Entity: EntityWallet,
+			Action: "read",
+		},
+		{
+			Entity: EntityWebhook,
+			Action: "read",
+		},
 	}
 }
 
+// WalletPermissions returns the permissions of the macaroon wallet.macaroon.
+// This grants access to the all actions for the wallet entity.
+func WalletPermissions() []bakery.Op {
+	return []bakery.Op{
+		{
+			Entity: EntityWallet,
+			Action: "read",
+		},
+		{
+			Entity: EntityWallet,
+			Action: "write",
+		},
+	}
+}
+
+// WebhookPermissions returns the permissions of the macaroon webhook.macaroon.
+// This grants access to the all actions for the webhook entity.
+func WebhookPermissions() []bakery.Op {
+	return []bakery.Op{
+		{
+			Entity: EntityWebhook,
+			Action: "read",
+		},
+		{
+			Entity: EntityWebhook,
+			Action: "write",
+		},
+	}
+}
+
+// AdminPermissions returns the permissions of the macaroon admin.macaroon.
+// This grants access to the all actions for all entities.
 func AdminPermissions() []bakery.Op {
 	return []bakery.Op{
 		{
@@ -55,45 +109,75 @@ func AdminPermissions() []bakery.Op {
 			Entity: EntityOperator,
 			Action: "write",
 		},
+		{
+			Entity: EntityMarket,
+			Action: "read",
+		},
+		{
+			Entity: EntityMarket,
+			Action: "write",
+		},
+		{
+			Entity: EntityPrice,
+			Action: "write",
+		},
+		{
+			Entity: EntityWebhook,
+			Action: "read",
+		},
+		{
+			Entity: EntityWebhook,
+			Action: "write",
+		},
+		{
+			Entity: EntityWallet,
+			Action: "read",
+		},
+		{
+			Entity: EntityWallet,
+			Action: "write",
+		},
 	}
 }
 
+// Whitelist returns the list of all whitelisted methods with the relative
+// entity and action.
 func Whitelist() map[string][]bakery.Op {
 	return map[string][]bakery.Op{
 		"/Wallet/GenSeed": {{
-			Entity: EntityOperator,
+			Entity: EntityUnlocker,
 			Action: "read",
 		}},
 		"/Wallet/InitWallet": {{
-			Entity: EntityOperator,
+			Entity: EntityUnlocker,
 			Action: "write",
 		}},
 		"/Wallet/UnlockWallet": {{
-			Entity: EntityOperator,
+			Entity: EntityUnlocker,
 			Action: "write",
 		}},
 		"/Wallet/ChangePassword": {{
-			Entity: EntityOperator,
+			Entity: EntityUnlocker,
 			Action: "write",
 		}},
 		"/Trade/Markets": {{
-			Entity: EntityTrader,
+			Entity: EntityTrade,
 			Action: "read",
 		}},
 		"/Trade/Balances": {{
-			Entity: EntityTrader,
+			Entity: EntityTrade,
 			Action: "read",
 		}},
 		"/Trade/MarketPrice": {{
-			Entity: EntityTrader,
+			Entity: EntityTrade,
 			Action: "read",
 		}},
 		"/Trade/TradePropose": {{
-			Entity: EntityTrader,
+			Entity: EntityTrade,
 			Action: "write",
 		}},
 		"/Trade/TradeComplete": {{
-			Entity: EntityTrader,
+			Entity: EntityTrade,
 			Action: "write",
 		}},
 	}
@@ -104,88 +188,80 @@ func Whitelist() map[string][]bakery.Op {
 func AllPermissionsByMethod() map[string][]bakery.Op {
 	return map[string][]bakery.Op{
 		"/Wallet/WalletAddress": {{
-			Entity: EntityOperator,
+			Entity: EntityWallet,
 			Action: "write",
 		}},
 		"/Wallet/SendToMany": {{
-			Entity: EntityOperator,
+			Entity: EntityWallet,
 			Action: "write",
 		}},
 		"/Wallet/WalletBalance": {{
-			Entity: EntityOperator,
+			Entity: EntityWallet,
 			Action: "read",
 		}},
 		"/Operator/DepositMarket": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
 			Action: "write",
 		}},
 		"/Operator/DepositFeeAccount": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
 			Action: "write",
 		}},
 		"/Operator/ClaimMarketDeposit": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
 			Action: "write",
 		}},
 		"/Operator/ClaimFeeDeposit": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
 			Action: "write",
 		}},
 		"/Operator/OpenMarket": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
 			Action: "write",
 		}},
 		"/Operator/CloseMarket": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
 			Action: "write",
 		}},
 		"/Operator/UpdateMarketPercentageFee": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
 			Action: "write",
 		}},
 		"/Operator/UpdateMarketFixedFee": {{
-			Entity: EntityOperator,
-			Action: "write",
-		}},
-		"/Operator/UpdateMarketPrice": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
 			Action: "write",
 		}},
 		"/Operator/UpdateMarketStrategy": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
+			Action: "write",
+		}},
+		"/Operator/ListMarket": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/ListDepositMarket": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/BalanceFeeAccount": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/DropMarket": {{
+			Entity: EntityMarket,
+			Action: "write",
+		}},
+		"/Operator/UpdateMarketPrice": {{
+			Entity: EntityPrice,
 			Action: "write",
 		}},
 		"/Operator/WithdrawMarket": {{
 			Entity: EntityOperator,
 			Action: "write",
 		}},
-		"/Operator/DropMarket": {{
-			Entity: EntityOperator,
-			Action: "write",
-		}},
 		"/Operator/ReloadUtxos": {{
 			Entity: EntityOperator,
 			Action: "write",
-		}},
-		"/Operator/AddWebhook": {{
-			Entity: EntityOperator,
-			Action: "write",
-		}},
-		"/Operator/RemoveWebhook": {{
-			Entity: EntityOperator,
-			Action: "write",
-		}},
-		"/Operator/ListMarket": {{
-			Entity: EntityOperator,
-			Action: "read",
-		}},
-		"/Operator/ListDepositMarket": {{
-			Entity: EntityOperator,
-			Action: "read",
-		}},
-		"/Operator/BalanceFeeAccount": {{
-			Entity: EntityOperator,
-			Action: "read",
 		}},
 		"/Operator/ListTrades": {{
 			Entity: EntityOperator,
@@ -195,8 +271,16 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Entity: EntityOperator,
 			Action: "read",
 		}},
+		"/Operator/AddWebhook": {{
+			Entity: EntityWebhook,
+			Action: "write",
+		}},
+		"/Operator/RemoveWebhook": {{
+			Entity: EntityWebhook,
+			Action: "write",
+		}},
 		"/Operator/ListWebhooks": {{
-			Entity: EntityOperator,
+			Entity: EntityWebhook,
 			Action: "read",
 		}},
 	}

--- a/internal/interfaces/grpc/service.go
+++ b/internal/interfaces/grpc/service.go
@@ -27,9 +27,11 @@ import (
 	interfaces "github.com/tdex-network/tdex-daemon/internal/interfaces"
 	grpchandler "github.com/tdex-network/tdex-daemon/internal/interfaces/grpc/handler"
 	"github.com/tdex-network/tdex-daemon/internal/interfaces/grpc/interceptor"
+	"github.com/tdex-network/tdex-daemon/internal/interfaces/grpc/permissions"
 	"github.com/tdex-network/tdex-daemon/pkg/macaroons"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	pboperator "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/operator"
 	pbwallet "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/wallet"
@@ -59,6 +61,9 @@ const (
 	// PriceMacaroonFile is the name of the macaroon allowing to update only the
 	// prices of markets.
 	PriceMacaroonFile = "price.macaroon"
+	// WalletMacaroonFile is the name of the macaroon allowing to manage the
+	// so called "Wallet" subaccount of the daemon's wallet.
+	WalletMacaroonFile = "wallet.macaroon"
 	// WebhookMacaroonFile is the name of the macaroon allowing to add, remove or
 	// list webhooks.
 	WebhookMacaroonFile = "webhook.macaroon"
@@ -66,6 +71,15 @@ const (
 
 var (
 	serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
+
+	Macaroons = map[string][]bakery.Op{
+		AdminMacaroonFile:    permissions.AdminPermissions(),
+		ReadOnlyMacaroonFile: permissions.ReadOnlyPermissions(),
+		MarketMacaroonFile:   permissions.MarketPermissions(),
+		PriceMacaroonFile:    permissions.PricePermissions(),
+		WebhookMacaroonFile:  permissions.WebhookPermissions(),
+		WalletMacaroonFile:   permissions.WalletPermissions(),
+	}
 )
 
 type service struct {


### PR DESCRIPTION
This adds 2 new env vars TDEX_OPERATOR_EXTRA_IP and TDEX_OPERATOR_EXTRA_DOMAIN in order to add an IP address or a DNS domain to the Operator TLS certificate. This becomes useful when running dockerized daemons, or serving them as TOR hidden services.

The macaroons permissions have been modified in order to have more than just the operator and trade entities. Other entities have been added: _market_, _price_, _wallet_, _webhook_ and _unlocker_. This way, defining permissions becomes smoother and instead of defining permissions for each RPC method, it's possible to define actions for entities.
With this, 2 new macaroons `wallet.macaroon` and `webhook.macaroon` in addition to the others.

For what concerns the CLI, the hardcoded filenames for the macaroons file and the TLS certificate have been removed and now it's up to the operator to specify the name of those files within `macaroons_path` and `tls_cert_path` respectively.

Info about the market balances have been added to the payload for TRADE_SETTLED event-registered webhooks.

BONUS: The reply of the Trade.Markets RPC have been fixed returning also the fixed fee info.

This closes #373 
This closes #372.

Please @tiero review this.

