### PR TITLE
Create or load TLS key + Add balance to ACCOUNT_WITHDRAW event payload

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -176,7 +176,7 @@ func main() {
 
 func stop(
 	repoManager ports.RepoManager,
-	pubsubSvc application.SecurePubSub,
+	pubsubSvc ports.SecurePubSub,
 	blockchainListener application.BlockchainListener,
 	svc interfaces.Service,
 	cancelStats context.CancelFunc,
@@ -207,7 +207,7 @@ func stop(
 
 func newWebhookPubSubService(
 	datadir string, reqTimeout time.Duration,
-) (application.SecurePubSub, error) {
+) (ports.SecurePubSub, error) {
 	secureStore, err := boltsecurestore.NewSecureStorage(datadir, "pubsub.db")
 	if err != nil {
 		return nil, err

--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -67,11 +67,16 @@ func main() {
 	// Init services to be used by those of the application layer.
 	repoManager, err := dbbadger.NewRepoManager(dbDir, log.New())
 	if err != nil {
-		log.WithError(err).Panic("error while opening db")
+		log.Errorf("error while opening db: %s", err)
+		return
 	}
+
 	explorerSvc, err := config.GetExplorer()
 	if err != nil {
-		log.WithError(err).Panic("error while setting up explorer service")
+		repoManager.Close()
+
+		log.Errorf("error while setting up explorer service: %s", err)
+		return
 	}
 	crawlerSvc := crawler.NewService(crawler.Opts{
 		ExplorerSvc:        explorerSvc,
@@ -84,9 +89,11 @@ func main() {
 		dbDir, config.GetDuration(config.ExplorerRequestTimeoutKey),
 	)
 	if err != nil {
-		log.WithError(err).Panic(
-			"an error occured while setting up webhook pubsub service",
-		)
+		crawlerSvc.Stop()
+		repoManager.Close()
+
+		log.Errorf("error while setting up webhook pubsub service: %s", err)
+		return
 	}
 	blockchainListener := application.NewBlockchainListener(
 		crawlerSvc,
@@ -124,7 +131,11 @@ func main() {
 		marketsBaseAsset,
 	)
 	if err != nil {
-		log.WithError(err).Panic("error while setting up wallet service")
+		crawlerSvc.Stop()
+		repoManager.Close()
+
+		log.Errorf("error while setting up wallet service: %s", err)
+		return
 	}
 
 	// Init gRPC interfaces.
@@ -142,7 +153,11 @@ func main() {
 	}
 	svc, err := grpcinterface.NewService(opts)
 	if err != nil {
-		log.WithError(err).Panic("an error occured while setting up gRPC service")
+		crawlerSvc.Stop()
+		repoManager.Close()
+
+		log.Errorf("error while setting up gRPC service: %s", err)
+		return
 	}
 
 	log.Info("starting daemon")
@@ -161,7 +176,8 @@ func main() {
 	operatorAddress := fmt.Sprintf(":%+v", operatorSvcPort)
 
 	if err := svc.Start(operatorAddress, tradeAddress, tradeTLSKey, tradeTLSCert); err != nil {
-		log.WithError(err).Panic("an error occured while starting daemon")
+		log.Errorf("error while starting daemon: %s", err)
+		return
 	}
 
 	log.Info("trade interface is listening on " + tradeAddress)

--- a/config/config.go
+++ b/config/config.go
@@ -109,11 +109,11 @@ func init() {
 	vip.SetDefault(NoMacaroonsKey, false)
 
 	if err := validate(); err != nil {
-		log.WithError(err).Panic("error while validating config")
+		log.Fatalf("error while validating config: %s", err)
 	}
 
 	if err := initDatadir(); err != nil {
-		log.WithError(err).Panic("error while creating datadir")
+		log.Fatalf("error while creating datadir: %s", err)
 	}
 
 	vip.Set(MnemonicKey, "")

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -28,14 +28,14 @@ type BlockchainListener interface {
 	StartObserveTx(txid string)
 	StopObserveTx(txid string)
 
-	PubSubService() SecurePubSub
+	PubSubService() ports.SecurePubSub
 }
 
 type blockchainListener struct {
 	crawlerSvc         crawler.Service
 	explorerSvc        explorer.Service
 	repoManager        ports.RepoManager
-	pubsubSvc          SecurePubSub
+	pubsubSvc          ports.SecurePubSub
 	started            bool
 	pendingObservables []crawler.Observable
 	marketBaseAsset    string
@@ -48,7 +48,7 @@ type blockchainListener struct {
 func NewBlockchainListener(
 	crawlerSvc crawler.Service,
 	repoManager ports.RepoManager,
-	pubsubSvc SecurePubSub,
+	pubsubSvc ports.SecurePubSub,
 	marketBaseAsset string,
 	net *network.Network,
 ) BlockchainListener {
@@ -64,7 +64,7 @@ func NewBlockchainListener(
 func newBlockchainListener(
 	crawlerSvc crawler.Service,
 	repoManager ports.RepoManager,
-	pubsubSvc SecurePubSub,
+	pubsubSvc ports.SecurePubSub,
 	marketBaseAsset string,
 	net *network.Network,
 ) *blockchainListener {
@@ -148,7 +148,7 @@ func (b *blockchainListener) StopObserveTx(txid string) {
 	b.crawlerSvc.RemoveObservable(&crawler.TransactionObservable{TxID: txid})
 }
 
-func (b *blockchainListener) PubSubService() SecurePubSub {
+func (b *blockchainListener) PubSubService() ports.SecurePubSub {
 	return b.pubsubSvc
 }
 

--- a/internal/core/application/errors.go
+++ b/internal/core/application/errors.go
@@ -26,7 +26,23 @@ var (
 	// AddWebhook or RemoveWebhook RPCs without having initialized the pubsub
 	// service at the start up.
 	ErrPubSubServiceNotInitialized = errors.New("pubsub service is not initialized")
-	// ErrInvalidActionType is returns if the attempting to register a webhook
+	// ErrInvalidActionType is returned if the attempting to register a webhook
 	// for an invalid action type.
 	ErrInvalidActionType = errors.New("action type is unknown")
+	// ErrMarketBaseBalanceTooLow is returned when the balance of the base asset
+	// of a market is below 0.
+	ErrMarketBaseBalanceTooLow = errors.New("market base balance is too low")
+	// ErrMarketQuoteBalanceTooLow is returned when the balance of the quote asset
+	// of a market is below 0.
+	ErrMarketQuoteBalanceTooLow = errors.New("market quote balance is too low")
+	// ErrWithdrawBaseAmountTooBig is returned when attempting to withdraw more
+	// than the total amount of base asset of a market.
+	ErrWithdrawBaseAmountTooBig = errors.New(
+		"base amount to withdraw exceeds the market base balance",
+	)
+	// ErrWithdrawQuoteAmountTooBig is returned when attempting to withdraw more
+	// than the total amount of quote asset of a market.
+	ErrWithdrawQuoteAmountTooBig = errors.New(
+		"quote amount to withdraw is too big",
+	)
 )

--- a/internal/core/ports/pubsub.go
+++ b/internal/core/ports/pubsub.go
@@ -1,4 +1,4 @@
-package application
+package ports
 
 type Topic interface {
 	Code() int

--- a/internal/infrastructure/pubsub/webhook/service_test.go
+++ b/internal/infrastructure/pubsub/webhook/service_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/tdex-network/tdex-daemon/internal/core/application"
+	"github.com/tdex-network/tdex-daemon/internal/core/ports"
 	webhookpubsub "github.com/tdex-network/tdex-daemon/internal/infrastructure/pubsub/webhook"
 	"github.com/tdex-network/tdex-daemon/pkg/explorer/esplora"
 	"github.com/tdex-network/tdex-daemon/pkg/securestore"
@@ -117,7 +117,7 @@ func TestWebhookPubSubService(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func newTestService() (application.SecurePubSub, error) {
+func newTestService() (ports.SecurePubSub, error) {
 	store, err := newTestSecureStorage(datadir, filename)
 	if err != nil {
 		return nil, err

--- a/internal/infrastructure/pubsub/webhook/webhook.go
+++ b/internal/infrastructure/pubsub/webhook/webhook.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 
 	"github.com/google/uuid"
-	"github.com/tdex-network/tdex-daemon/internal/core/application"
+	"github.com/tdex-network/tdex-daemon/internal/core/ports"
 )
 
 type Webhook struct {
@@ -35,7 +35,7 @@ func NewWebhookFromBytes(buf []byte) (*Webhook, error) {
 	return h, nil
 }
 
-func (h *Webhook) Topic() application.Topic {
+func (h *Webhook) Topic() ports.Topic {
 	return h.ActionType
 }
 

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -75,7 +75,11 @@ func main() {
 		fmt.Println(err)
 		return
 	}
-	defer stopDaemon()
+	defer func() {
+		// Give the daemon the time to finish its pending tasks
+		time.Sleep(30 * time.Second)
+		stopDaemon()
+	}()
 
 	// build the CLI binary
 	runCommand("make", "build-cli")


### PR DESCRIPTION
This contains some little fixes to improve the behaviour of the daemon:
1. If using macaroon auth, now the TLS key is loaded from file or created depending whether it exists or not. The certificate is created if not existing. If Only the TLS cert exists in the datadir, an error is returned suggesting to delete it to create a new pair.
2. Market balance has been added to the payload of the outgoing request for the event ACCOUNT_WITHDRAW
3. Stop panicking in case of error. This improves the readability of error messages.
4. Minor: the definition of PubSub interface and related have been moved from _application_ to _ports_

This closes #376.
This closes #377.
This closes #378.

Please @tiero review this.