### PR TITLE
Rethink fee calculation in wallet.UpdateTx & Support multiple extra IPs/domains

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -30,18 +30,18 @@ import (
 
 var (
 	// General config
-	logLevel               = config.GetInt(config.LogLevelKey)
-	network                = config.GetNetwork()
-	profilerEnabled        = config.GetBool(config.EnableProfilerKey)
-	datadir                = config.GetDatadir()
-	dbDir                  = filepath.Join(datadir, config.DbLocation)
-	profilerDir            = filepath.Join(datadir, config.ProfilerLocation)
-	noMacaroons            = config.GetBool(config.NoMacaroonsKey)
-	statsIntervalInSeconds = config.GetDuration(config.StatsIntervalKey) * time.Second
-	tradeTLSKey            = config.GetString(config.TradeTLSKeyKey)
-	tradeTLSCert           = config.GetString(config.TradeTLSCertKey)
-	operatorTLSExtraIP     = config.GetString(config.OperatorExtraIP)
-	operatorTLSExtraDomain = config.GetString(config.OperatorExtraDomain)
+	logLevel                = config.GetInt(config.LogLevelKey)
+	network                 = config.GetNetwork()
+	profilerEnabled         = config.GetBool(config.EnableProfilerKey)
+	datadir                 = config.GetDatadir()
+	dbDir                   = filepath.Join(datadir, config.DbLocation)
+	profilerDir             = filepath.Join(datadir, config.ProfilerLocation)
+	noMacaroons             = config.GetBool(config.NoMacaroonsKey)
+	statsIntervalInSeconds  = config.GetDuration(config.StatsIntervalKey) * time.Second
+	tradeTLSKey             = config.GetString(config.TradeTLSKeyKey)
+	tradeTLSCert            = config.GetString(config.TradeTLSCertKey)
+	operatorTLSExtraIPs     = config.GetStringSlice(config.OperatorExtraIP)
+	operatorTLSExtraDomains = config.GetStringSlice(config.OperatorExtraDomain)
 	// App services config
 	marketsFee                    = int64(config.GetFloat(config.DefaultFeeKey) * 100)
 	marketsBaseAsset              = config.GetString(config.BaseAssetKey)
@@ -140,16 +140,16 @@ func main() {
 
 	// Init gRPC interfaces.
 	opts := grpcinterface.ServiceOpts{
-		NoMacaroons:         noMacaroons,
-		Datadir:             datadir,
-		DBLocation:          config.DbLocation,
-		TLSLocation:         config.TLSLocation,
-		MacaroonsLocation:   config.MacaroonsLocation,
-		OperatorExtraIP:     operatorTLSExtraIP,
-		OperatorExtraDomain: operatorTLSExtraDomain,
-		WalletSvc:           walletSvc,
-		OperatorSvc:         operatorSvc,
-		TradeSvc:            tradeSvc,
+		NoMacaroons:          noMacaroons,
+		Datadir:              datadir,
+		DBLocation:           config.DbLocation,
+		TLSLocation:          config.TLSLocation,
+		MacaroonsLocation:    config.MacaroonsLocation,
+		OperatorExtraIPs:     operatorTLSExtraIPs,
+		OperatorExtraDomains: operatorTLSExtraDomains,
+		WalletSvc:            walletSvc,
+		OperatorSvc:          operatorSvc,
+		TradeSvc:             tradeSvc,
 	}
 	svc, err := grpcinterface.NewService(opts)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -134,6 +134,10 @@ func GetFloat(key string) float64 {
 	return vip.GetFloat64(key)
 }
 
+func GetStringSlice(key string) []string {
+	return vip.GetStringSlice(key)
+}
+
 //GetDuration ...
 func GetDuration(key string) time.Duration {
 	return vip.GetDuration(key)


### PR DESCRIPTION
* With this, it is possible to provide multiple IPs or domains to the env vars `TDEX_OPERATOR_EXTRA_IP` and `TDEX_OPERATOR_EXTRA_DOMAIN` as strings of space separated elems. Example:
```
TDEX_OPERATOR_EXTRA_DOMAIN="my.provider.network my.provider.io" TDEX_OPERATOR_EXTRA_IP="" tdexd 
```

* A `DummyFeeAmount` has been introduced, used only for selecting unspents for paying network fees. Its value is set to `700` vB/sat.
After the coins have been selected, the real fee amount calculated from the tx size is returned, while the difference `DummyFeeAmoun - feeAmount` is added to the change.

This closes #384.
This closes #385.

Please @tiero review this.