### PR TITLE
Hotfix: prevent panicking within isValidTradePrice

### DIFF
--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -1117,22 +1117,21 @@ func isValidTradePrice(
 	unspents []domain.Unspent,
 	slippage decimal.Decimal,
 ) bool {
-	// TODO: parallelize the 2 ways of calculating and validating the preview
-	// amount to speed up the process.
 	amount := swapRequest.GetAmountR()
 	if tradeType == TradeSell {
 		amount = swapRequest.GetAmountP()
 	}
 
-	preview, _ := previewForMarket(
+	preview, err := previewForMarket(
 		unspents,
 		market,
 		tradeType,
 		amount,
 		market.BaseAsset,
 	)
-
-	if preview != nil {
+	if err != nil {
+		log.Debugf("preview failed for reason: %s", err)
+	} else {
 		if isPriceInRange(swapRequest, tradeType, preview.amount, true, slippage) {
 			return true
 		}
@@ -1143,7 +1142,7 @@ func isValidTradePrice(
 		amount = swapRequest.GetAmountR()
 	}
 
-	preview, _ = previewForMarket(
+	preview, err = previewForMarket(
 		unspents,
 		market,
 		tradeType,
@@ -1151,7 +1150,8 @@ func isValidTradePrice(
 		market.QuoteAsset,
 	)
 
-	if preview == nil {
+	if err != nil {
+		log.Debugf("preview failed for reason: %s", err)
 		return false
 	}
 

--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -1132,8 +1132,10 @@ func isValidTradePrice(
 		market.BaseAsset,
 	)
 
-	if isPriceInRange(swapRequest, tradeType, preview.amount, true, slippage) {
-		return true
+	if preview != nil {
+		if isPriceInRange(swapRequest, tradeType, preview.amount, true, slippage) {
+			return true
+		}
 	}
 
 	amount = swapRequest.GetAmountP()
@@ -1148,6 +1150,10 @@ func isValidTradePrice(
 		amount,
 		market.QuoteAsset,
 	)
+
+	if preview == nil {
+		return false
+	}
 
 	return isPriceInRange(swapRequest, tradeType, preview.amount, false, slippage)
 }

--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -1117,21 +1117,22 @@ func isValidTradePrice(
 	unspents []domain.Unspent,
 	slippage decimal.Decimal,
 ) bool {
+	// TODO: parallelize the 2 ways of calculating and validating the preview
+	// amount to speed up the process.
 	amount := swapRequest.GetAmountR()
 	if tradeType == TradeSell {
 		amount = swapRequest.GetAmountP()
 	}
 
-	preview, err := previewForMarket(
+	preview, _ := previewForMarket(
 		unspents,
 		market,
 		tradeType,
 		amount,
 		market.BaseAsset,
 	)
-	if err != nil {
-		log.Debugf("preview failed for reason: %s", err)
-	} else {
+
+	if preview != nil {
 		if isPriceInRange(swapRequest, tradeType, preview.amount, true, slippage) {
 			return true
 		}
@@ -1142,7 +1143,7 @@ func isValidTradePrice(
 		amount = swapRequest.GetAmountR()
 	}
 
-	preview, err = previewForMarket(
+	preview, _ = previewForMarket(
 		unspents,
 		market,
 		tradeType,
@@ -1150,8 +1151,7 @@ func isValidTradePrice(
 		market.QuoteAsset,
 	)
 
-	if err != nil {
-		log.Debugf("preview failed for reason: %s", err)
+	if preview == nil {
 		return false
 	}
 


### PR DESCRIPTION
This prevents the daemon to panic when checking the validity of a trade proposal's price.

This closes #387.