### PR TITLE
Move preview to domain level

### DIFF
--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -39,6 +39,14 @@ var (
 	ErrInvalidFixedFee = errors.New("fixed fee must be a positive value")
 	// ErrMissingFixedFee ...
 	ErrMissingFixedFee = errors.New("fixed fee requires both base and quote amounts to be defined")
+	// ErrMarketPreviewAmountTooLow is returned when a preview fails because
+	// the provided amount makes the previewed amount to be too low (lower than
+	// the optional fixed fee).
+	ErrMarketPreviewAmountTooLow = errors.New("provided amount is too low")
+	// ErrMarketPreviewAmountTooBig is returned when a preview fails because
+	// the provided amount makes the previewed amount to be too big (greater than
+	// the overall balance).
+	ErrMarketPreviewAmountTooBig = errors.New("provided amount is too big")
 )
 
 // Unspent errors

--- a/internal/core/domain/market_model.go
+++ b/internal/core/domain/market_model.go
@@ -46,6 +46,14 @@ type Prices struct {
 // StrategyType is the Market making strategy type
 type StrategyType int32
 
+// PreviewInfo contains info about a price preview based on the market's current
+// strategy.
+type PreviewInfo struct {
+	Price  Prices
+	Amount uint64
+	Asset  string
+}
+
 // NewMarket returns an empty market with a reference to an account index.
 // It is also mandatory to define a fee (in BP) for the market.
 func NewMarket(positiveAccountIndex int, feeInBasisPoint int64) (*Market, error) {

--- a/internal/core/domain/market_service.go
+++ b/internal/core/domain/market_service.go
@@ -275,18 +275,14 @@ func (m *Market) formula(
 	formula := m.getStrategySafe().Formula()
 	if isBuy {
 		if isBaseAsset {
-			// fmt.Println("InGivenOut")
 			return formula.InGivenOut
 		}
-		// fmt.Println("OutGivenIn")
 		return formula.OutGivenIn
 	}
 
 	if isBaseAsset {
-		// fmt.Println("OutGivenIn")
 		return formula.OutGivenIn
 	}
-	// fmt.Println("InGivenOut")
 	return formula.InGivenOut
 }
 

--- a/internal/core/domain/market_service.go
+++ b/internal/core/domain/market_service.go
@@ -57,8 +57,10 @@ func (m *Market) QuoteAssetPrice() decimal.Decimal {
 }
 
 // IsStrategyPluggable returns true if the the startegy isn't automated.
+// For backward compatibility it returns whether the strategy is zero-ed or,
+// on the contrary, its type is extaclty PluggableStrategyType.
 func (m *Market) IsStrategyPluggable() bool {
-	return m.Strategy.IsZero()
+	return m.Strategy.IsZero() || m.Strategy.Type == PluggableStrategyType
 }
 
 // IsStrategyPluggableInitialized returns true if the prices have been set.
@@ -137,7 +139,7 @@ func (m *Market) MakeStrategyPluggable() error {
 		return ErrMarketMustBeClosed
 	}
 
-	m.Strategy = mm.MakingStrategy{}
+	m.Strategy = mm.NewStrategyFromFormula(PluggableStrategy{})
 	m.ChangeBasePrice(decimal.NewFromInt(0))
 	m.ChangeQuotePrice(decimal.NewFromInt(0))
 
@@ -217,6 +219,180 @@ func (m *Market) ChangeQuotePrice(price decimal.Decimal) error {
 	return nil
 }
 
+func (m *Market) Preview(
+	baseBalance, quoteBalance, amount uint64,
+	isBaseAsset, isBuy bool,
+) (*PreviewInfo, error) {
+	if !m.IsTradable() {
+		return nil, ErrMarketIsClosed
+	}
+
+	if isBaseAsset {
+		if amount < uint64(m.FixedFee.BaseFee) {
+			return nil, ErrMarketPreviewAmountTooLow
+		}
+	} else {
+		if amount < uint64(m.FixedFee.QuoteFee) {
+			return nil, ErrMarketPreviewAmountTooLow
+		}
+	}
+
+	formula := m.formula(isBaseAsset, isBuy)
+	args := m.formulaOpts(baseBalance, quoteBalance, isBaseAsset, isBuy)
+
+	price, err := m.priceForStrategy(baseBalance, quoteBalance)
+	if err != nil {
+		return nil, err
+	}
+
+	previewAmount, err := formula(args, amount)
+	if err != nil {
+		return nil, err
+	}
+
+	previewAmount, err = m.chargeFixedFees(
+		baseBalance, quoteBalance, previewAmount, isBaseAsset, isBuy,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	previewAsset := m.BaseAsset
+	if isBaseAsset {
+		previewAsset = m.QuoteAsset
+	}
+
+	return &PreviewInfo{
+		Price:  price,
+		Amount: previewAmount,
+		Asset:  previewAsset,
+	}, nil
+}
+
+func (m *Market) formula(
+	isBaseAsset, isBuy bool,
+) func(interface{}, uint64) (uint64, error) {
+	formula := m.getStrategySafe().Formula()
+	if isBuy {
+		if isBaseAsset {
+			// fmt.Println("InGivenOut")
+			return formula.InGivenOut
+		}
+		// fmt.Println("OutGivenIn")
+		return formula.OutGivenIn
+	}
+
+	if isBaseAsset {
+		// fmt.Println("OutGivenIn")
+		return formula.OutGivenIn
+	}
+	// fmt.Println("InGivenOut")
+	return formula.InGivenOut
+}
+
+func (m *Market) formulaOpts(
+	baseBalance, quoteBalance uint64, isBaseAsset, isBuy bool,
+) interface{} {
+	balanceIn := baseBalance
+	balanceOut := quoteBalance
+	if isBuy {
+		balanceIn = quoteBalance
+		balanceOut = baseBalance
+	}
+
+	if m.IsStrategyPluggable() {
+		price := m.BaseAssetPrice()
+		if isBaseAsset {
+			price = m.QuoteAssetPrice()
+		}
+
+		return PluggableStrategyOpts{
+			BalanceIn:  balanceIn,
+			BalanceOut: balanceOut,
+			Price:      price,
+			Fee:        uint64(m.Fee),
+		}
+	}
+
+	return formula.BalancedReservesOpts{
+		BalanceIn:           balanceIn,
+		BalanceOut:          balanceOut,
+		Fee:                 uint64(m.Fee),
+		ChargeFeeOnTheWayIn: true,
+	}
+}
+
+func (m *Market) priceForStrategy(baseBalance, quoteBalance uint64) (Prices, error) {
+	if m.IsStrategyPluggable() {
+		return m.Price, nil
+	}
+
+	return m.priceFromBalances(baseBalance, quoteBalance)
+}
+
+func (m *Market) priceFromBalances(
+	baseBalance, quoteBalance uint64,
+) (price Prices, err error) {
+	toIface := func(o formula.BalancedReservesOpts) interface{} {
+		return o
+	}
+
+	basePrice, err := m.getStrategySafe().Formula().SpotPrice(
+		toIface(formula.BalancedReservesOpts{
+			BalanceIn:  quoteBalance,
+			BalanceOut: baseBalance,
+		}),
+	)
+	if err != nil {
+		return
+	}
+	quotePrice, err := m.getStrategySafe().Formula().SpotPrice(
+		toIface(formula.BalancedReservesOpts{
+			BalanceIn:  baseBalance,
+			BalanceOut: quoteBalance,
+		}),
+	)
+	if err != nil {
+		return
+	}
+
+	price = Prices{
+		BasePrice:  basePrice,
+		QuotePrice: quotePrice,
+	}
+	return
+}
+
+func (m *Market) chargeFixedFees(
+	baseBalance, quoteBalance, amount uint64,
+	isBaseAsset, isBuy bool,
+) (uint64, error) {
+	if isBuy {
+		if isBaseAsset {
+			return amount + uint64(m.FixedFee.QuoteFee), nil
+		}
+		return safeSubtractFeesFromAmount(
+			amount, uint64(m.FixedFee.BaseFee), baseBalance,
+		)
+	}
+
+	if isBaseAsset {
+		return safeSubtractFeesFromAmount(
+			amount, uint64(m.FixedFee.QuoteFee), quoteBalance,
+		)
+	}
+	return amount + uint64(m.FixedFee.BaseFee), nil
+}
+
+// getStrategySafe is a backward compatible method that returns the current
+// strategy as the implementation of the mm.MakingFormula interface.
+func (m *Market) getStrategySafe() mm.MakingStrategy {
+	if m.IsStrategyPluggable() {
+		return mm.NewStrategyFromFormula(PluggableStrategy{})
+	}
+	return m.Strategy
+}
+
 func validateFee(basisPoint int64) error {
 	if basisPoint < 0 {
 		return ErrMarketFeeTooLow
@@ -245,4 +421,16 @@ func getLatestPrice(pt Prices) (decimal.Decimal, decimal.Decimal) {
 	}
 
 	return pt.BasePrice, pt.QuotePrice
+}
+
+func safeSubtractFeesFromAmount(amount, fee, balance uint64) (uint64, error) {
+	amountLessFees := amount
+	if amountLessFees <= uint64(fee) {
+		return 0, ErrMarketPreviewAmountTooLow
+	}
+	amountLessFees -= uint64(fee)
+	if amountLessFees >= balance {
+		return 0, ErrMarketPreviewAmountTooBig
+	}
+	return amountLessFees, nil
 }

--- a/internal/core/domain/market_service_test.go
+++ b/internal/core/domain/market_service_test.go
@@ -1,7 +1,6 @@
 package domain_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -666,9 +665,6 @@ func TestFailingPreview(t *testing.T) {
 				preview, err := market.Preview(
 					tt.baseBalance, tt.quoteBalance, tt.amount, tt.isBaseAsset, tt.isBuy,
 				)
-				if preview != nil {
-					fmt.Println(preview)
-				}
 				require.EqualError(t, err, tt.expectedErr.Error())
 				require.Nil(t, preview)
 			})
@@ -789,9 +785,6 @@ func TestFailingPreview(t *testing.T) {
 				preview, err := market.Preview(
 					tt.baseBalance, tt.quoteBalance, tt.amount, tt.isBaseAsset, tt.isBuy,
 				)
-				if preview != nil {
-					fmt.Println(preview)
-				}
 				require.EqualError(t, err, tt.expectedErr.Error())
 				require.Nil(t, preview)
 			})
@@ -910,9 +903,6 @@ func TestFailingPreview(t *testing.T) {
 				preview, err := market.Preview(
 					tt.baseBalance, tt.quoteBalance, tt.amount, tt.isBaseAsset, tt.isBuy,
 				)
-				if preview != nil {
-					fmt.Println(preview)
-				}
 				require.EqualError(t, err, tt.expectedErr.Error())
 				require.Nil(t, preview)
 			})
@@ -1054,9 +1044,6 @@ func TestFailingPreview(t *testing.T) {
 				preview, err := market.Preview(
 					tt.baseBalance, tt.quoteBalance, tt.amount, tt.isBaseAsset, tt.isBuy,
 				)
-				if preview != nil {
-					fmt.Println(preview)
-				}
 				require.EqualError(t, err, tt.expectedErr.Error())
 				require.Nil(t, preview)
 			})

--- a/internal/core/domain/pluggable_strategy.go
+++ b/internal/core/domain/pluggable_strategy.go
@@ -1,0 +1,58 @@
+package domain
+
+import (
+	"errors"
+
+	"github.com/shopspring/decimal"
+	"github.com/tdex-network/tdex-daemon/pkg/mathutil"
+)
+
+const PluggableStrategyType = 255
+
+type PluggableStrategyOpts struct {
+	BalanceIn  uint64
+	BalanceOut uint64
+	Price      decimal.Decimal
+	Fee        uint64
+}
+
+type PluggableStrategy struct{}
+
+func (s PluggableStrategy) SpotPrice(_opts interface{}) (spotPrice decimal.Decimal, err error) {
+	return
+}
+
+func (s PluggableStrategy) OutGivenIn(_opts interface{}, amountIn uint64) (uint64, error) {
+	opts, ok := _opts.(PluggableStrategyOpts)
+	if !ok {
+		return 0, errors.New("opts must be of type PluggableStrategyOpts")
+	}
+	if amountIn == 0 {
+		return 0, ErrMarketPreviewAmountTooLow
+	}
+
+	amountR := decimal.NewFromInt(int64(amountIn)).Mul(opts.Price).BigInt().Uint64()
+	amountR, _ = mathutil.LessFee(amountR, opts.Fee)
+	return amountR, nil
+}
+
+func (s PluggableStrategy) InGivenOut(_opts interface{}, amountOut uint64) (uint64, error) {
+	opts, ok := _opts.(PluggableStrategyOpts)
+	if !ok {
+		return 0, errors.New("opts must be of type PluggableStrategyOpts")
+	}
+	if amountOut == 0 {
+		return 0, ErrMarketPreviewAmountTooLow
+	}
+	if amountOut >= opts.BalanceOut {
+		return 0, ErrMarketPreviewAmountTooBig
+	}
+
+	amountP := decimal.NewFromInt(int64(amountOut)).Mul(opts.Price).BigInt().Uint64()
+	amountP, _ = mathutil.PlusFee(amountP, opts.Fee)
+	return amountP, nil
+}
+
+func (s PluggableStrategy) FormulaType() int {
+	return PluggableStrategyType
+}

--- a/internal/core/domain/pluggable_strategy.go
+++ b/internal/core/domain/pluggable_strategy.go
@@ -33,6 +33,9 @@ func (s PluggableStrategy) OutGivenIn(_opts interface{}, amountIn uint64) (uint6
 
 	amountR := decimal.NewFromInt(int64(amountIn)).Mul(opts.Price).BigInt().Uint64()
 	amountR, _ = mathutil.LessFee(amountR, opts.Fee)
+	if amountR == 0 {
+		return 0, ErrMarketPreviewAmountTooLow
+	}
 	return amountR, nil
 }
 
@@ -50,6 +53,9 @@ func (s PluggableStrategy) InGivenOut(_opts interface{}, amountOut uint64) (uint
 
 	amountP := decimal.NewFromInt(int64(amountOut)).Mul(opts.Price).BigInt().Uint64()
 	amountP, _ = mathutil.PlusFee(amountP, opts.Fee)
+	if amountP == 0 {
+		return 0, ErrMarketPreviewAmountTooLow
+	}
 	return amountP, nil
 }
 

--- a/pkg/marketmaking/formula/balanced_reserves.go
+++ b/pkg/marketmaking/formula/balanced_reserves.go
@@ -74,9 +74,6 @@ func (BalancedReserves) OutGivenIn(_opts interface{}, amountIn uint64) (uint64, 
 	if amountIn == 0 {
 		return 0, ErrAmountTooLow
 	}
-	if amountIn >= opts.BalanceIn {
-		return 0, ErrAmountTooBig
-	}
 
 	amount := amountIn
 	if opts.ChargeFeeOnTheWayIn {

--- a/pkg/marketmaking/formula/balanced_reserves_test.go
+++ b/pkg/marketmaking/formula/balanced_reserves_test.go
@@ -108,35 +108,9 @@ func TestBalancedReserves_OutGivenIn(t *testing.T) {
 					Fee:                 25,
 					ChargeFeeOnTheWayIn: true,
 				}),
-				amountIn: 1,
-			},
-			formula.ErrAmountTooLow,
-		},
-		{
-			"calculated amount too low",
-			args{
-				opts: toInterface(formula.BalancedReservesOpts{
-					BalanceIn:           650000000000,
-					BalanceOut:          100000000,
-					Fee:                 25,
-					ChargeFeeOnTheWayIn: true,
-				}),
 				amountIn: 3259,
 			},
 			formula.ErrAmountTooLow,
-		},
-		{
-			"provided amount too big",
-			args{
-				opts: toInterface(formula.BalancedReservesOpts{
-					BalanceIn:           650000000000,
-					BalanceOut:          100000000,
-					Fee:                 25,
-					ChargeFeeOnTheWayIn: true,
-				}),
-				amountIn: 650000000000,
-			},
-			formula.ErrAmountTooBig,
 		},
 	}
 
@@ -228,19 +202,6 @@ func TestBalancedReserves_InGivenOut(t *testing.T) {
 					ChargeFeeOnTheWayIn: true,
 				}),
 				amountOut: 100000000,
-			},
-			formula.ErrAmountTooBig,
-		},
-		{
-			"calculated amount too big",
-			args{
-				opts: toInterface(formula.BalancedReservesOpts{
-					BalanceIn:           650000000000,
-					BalanceOut:          100000000,
-					Fee:                 5000,
-					ChargeFeeOnTheWayIn: true,
-				}),
-				amountOut: 50000000,
 			},
 			formula.ErrAmountTooBig,
 		},

--- a/pkg/marketmaking/formula/balanced_reserves_test.go
+++ b/pkg/marketmaking/formula/balanced_reserves_test.go
@@ -1,37 +1,37 @@
-package formula
+package formula_test
 
 import (
 	"testing"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
-	"github.com/tdex-network/tdex-daemon/pkg/marketmaking"
+	"github.com/tdex-network/tdex-daemon/pkg/marketmaking/formula"
 	"github.com/tdex-network/tdex-daemon/pkg/mathutil"
 )
 
 func TestBalancedReserves_SpotPrice(t *testing.T) {
 	type args struct {
-		opts *marketmaking.FormulaOpts
+		opts interface{}
 	}
 	tests := []struct {
 		name          string
-		b             BalancedReserves
+		b             formula.BalancedReserves
 		args          args
 		wantSpotPrice decimal.Decimal
 	}{
 		{
 			"OutGivenIn",
-			BalancedReserves{},
+			formula.BalancedReserves{},
 			args{
-				opts: &marketmaking.FormulaOpts{
+				opts: toInterface(formula.BalancedReservesOpts{
 					BalanceIn:  2 * mathutil.BigOne,
 					BalanceOut: 2 * 9760 * mathutil.BigOne,
-				},
+				}),
 			},
 			decimal.NewFromInt(9760),
 		},
 	}
-	b := &BalancedReserves{}
+	b := &formula.BalancedReserves{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotSpotPrice, err := b.SpotPrice(tt.args.opts)
@@ -45,7 +45,7 @@ func TestBalancedReserves_SpotPrice(t *testing.T) {
 
 func TestBalancedReserves_OutGivenIn(t *testing.T) {
 	type args struct {
-		opts     *marketmaking.FormulaOpts
+		opts     interface{}
 		amountIn uint64
 	}
 	tests := []struct {
@@ -54,30 +54,30 @@ func TestBalancedReserves_OutGivenIn(t *testing.T) {
 		wantAmountOut uint64
 	}{
 		{
-			"OutGivenIn with fee taken on the input",
+			"with fee taken on the input",
 			args{
-				opts: &marketmaking.FormulaOpts{
+				opts: toInterface(formula.BalancedReservesOpts{
 					BalanceIn:           100000000,
 					BalanceOut:          650000000000,
 					Fee:                 25,
 					ChargeFeeOnTheWayIn: true,
-				},
+				}),
 				amountIn: 10000,
 			},
 			64831000,
 		},
 		{
-			"OutGivenIn with the fee taken on the output",
+			"with the fee taken on the output",
 			args{
-				opts: &marketmaking.FormulaOpts{
+				opts: toInterface(formula.BalancedReservesOpts{
 					BalanceIn:           100000000,
 					BalanceOut:          650000000000,
 					Fee:                 25,
 					ChargeFeeOnTheWayIn: false,
-				},
+				}),
 				amountIn: 10000,
 			},
-			65156000,
+			64831016,
 		},
 	}
 
@@ -87,21 +87,60 @@ func TestBalancedReserves_OutGivenIn(t *testing.T) {
 		wantError error
 	}{
 		{
-			"OutGivenIn fails if provided amount is 0",
+			"provided amount is zero",
 			args{
-				opts: &marketmaking.FormulaOpts{
+				opts: toInterface(formula.BalancedReservesOpts{
 					BalanceIn:           100000000,
 					BalanceOut:          650000000000,
 					Fee:                 25,
 					ChargeFeeOnTheWayIn: true,
-				},
+				}),
 				amountIn: 0,
 			},
-			ErrAmountTooLow,
+			formula.ErrAmountTooLow,
+		},
+		{
+			"provided amount too low",
+			args{
+				opts: toInterface(formula.BalancedReservesOpts{
+					BalanceIn:           650000000000,
+					BalanceOut:          100000000,
+					Fee:                 25,
+					ChargeFeeOnTheWayIn: true,
+				}),
+				amountIn: 1,
+			},
+			formula.ErrAmountTooLow,
+		},
+		{
+			"calculated amount too low",
+			args{
+				opts: toInterface(formula.BalancedReservesOpts{
+					BalanceIn:           650000000000,
+					BalanceOut:          100000000,
+					Fee:                 25,
+					ChargeFeeOnTheWayIn: true,
+				}),
+				amountIn: 3259,
+			},
+			formula.ErrAmountTooLow,
+		},
+		{
+			"provided amount too big",
+			args{
+				opts: toInterface(formula.BalancedReservesOpts{
+					BalanceIn:           650000000000,
+					BalanceOut:          100000000,
+					Fee:                 25,
+					ChargeFeeOnTheWayIn: true,
+				}),
+				amountIn: 650000000000,
+			},
+			formula.ErrAmountTooBig,
 		},
 	}
 
-	b := BalancedReserves{}
+	b := formula.BalancedReserves{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotAmountOut, err := b.OutGivenIn(tt.args.opts, tt.args.amountIn)
@@ -122,42 +161,42 @@ func TestBalancedReserves_OutGivenIn(t *testing.T) {
 
 func TestBalancedReserves_InGivenOut(t *testing.T) {
 	type args struct {
-		opts      *marketmaking.FormulaOpts
+		opts      interface{}
 		amountOut uint64
 	}
 	tests := []struct {
 		name         string
-		b            BalancedReserves
+		b            formula.BalancedReserves
 		args         args
 		wantAmountIn uint64
 	}{
 		{
-			"InGivenOut with fee taken on the input",
-			BalancedReserves{},
+			"with fees taken on the input",
+			formula.BalancedReserves{},
 			args{
-				opts: &marketmaking.FormulaOpts{
+				opts: toInterface(formula.BalancedReservesOpts{
 					BalanceIn:           650000000000,
 					BalanceOut:          100000000,
 					Fee:                 25,
 					ChargeFeeOnTheWayIn: true,
-				},
+				}),
 				amountOut: 10000,
 			},
-			64844388,
+			65169016,
 		},
 		{
-			"InGivenOut with fee taken on the output",
-			BalancedReserves{},
+			"with fees taken on the output",
+			formula.BalancedReserves{},
 			args{
-				opts: &marketmaking.FormulaOpts{
+				opts: toInterface(formula.BalancedReservesOpts{
 					BalanceIn:           650000000000,
 					BalanceOut:          100000000,
 					Fee:                 25,
 					ChargeFeeOnTheWayIn: false,
-				},
+				}),
 				amountOut: 10000,
 			},
-			65169423,
+			65169000,
 		},
 	}
 
@@ -167,34 +206,47 @@ func TestBalancedReserves_InGivenOut(t *testing.T) {
 		wantError error
 	}{
 		{
-			"InGivenOut fails if provided amount is 0",
+			"provided amount is zero",
 			args{
-				opts: &marketmaking.FormulaOpts{
-					BalanceIn:           100000000,
-					BalanceOut:          650000000000,
+				opts: toInterface(formula.BalancedReservesOpts{
+					BalanceIn:           650000000000,
+					BalanceOut:          100000000,
 					Fee:                 25,
 					ChargeFeeOnTheWayIn: true,
-				},
+				}),
 				amountOut: 0,
 			},
-			ErrAmountTooLow,
+			formula.ErrAmountTooLow,
 		},
 		{
-			"InGivenOut fails if provided amount is equal or exceeds the balance",
+			"provided amount too big",
 			args{
-				opts: &marketmaking.FormulaOpts{
-					BalanceIn:           100000000,
-					BalanceOut:          650000000000,
-					Fee:                 25,
+				opts: toInterface(formula.BalancedReservesOpts{
+					BalanceIn:           650000000000,
+					BalanceOut:          100000000,
+					Fee:                 5000,
 					ChargeFeeOnTheWayIn: true,
-				},
-				amountOut: 650000000000,
+				}),
+				amountOut: 100000000,
 			},
-			ErrAmountTooBig,
+			formula.ErrAmountTooBig,
+		},
+		{
+			"calculated amount too big",
+			args{
+				opts: toInterface(formula.BalancedReservesOpts{
+					BalanceIn:           650000000000,
+					BalanceOut:          100000000,
+					Fee:                 5000,
+					ChargeFeeOnTheWayIn: true,
+				}),
+				amountOut: 50000000,
+			},
+			formula.ErrAmountTooBig,
 		},
 	}
 
-	b := BalancedReserves{}
+	b := formula.BalancedReserves{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotAmountIn, err := b.InGivenOut(tt.args.opts, tt.args.amountOut)
@@ -211,4 +263,8 @@ func TestBalancedReserves_InGivenOut(t *testing.T) {
 			assert.Equal(t, tt.wantError, err)
 		})
 	}
+}
+
+func toInterface(o formula.BalancedReservesOpts) interface{} {
+	return o
 }

--- a/pkg/marketmaking/market_making.go
+++ b/pkg/marketmaking/market_making.go
@@ -10,23 +10,11 @@ type MakingStrategy struct {
 	formula MakingFormula
 }
 
-//FormulaOpts defines the parameters needed to calculate the spot price
-type FormulaOpts struct {
-	BalanceIn  uint64
-	BalanceOut uint64
-	WeightIn   uint64
-	WeightOut  uint64
-	// The fee should be in satoshis and represents the calculated fee to take out from the swap.
-	Fee uint64
-	// Defines if the fee should be charged on the way in (ie. on )
-	ChargeFeeOnTheWayIn bool
-}
-
 // MakingFormula defines the interface for implementing the formula to derive the spot price
 type MakingFormula interface {
-	SpotPrice(spotPriceOpts *FormulaOpts) (spotPrice decimal.Decimal, err error)
-	OutGivenIn(outGivenInOpts *FormulaOpts, amountIn uint64) (amountOut uint64, err error)
-	InGivenOut(inGivenOutOpts *FormulaOpts, amountOut uint64) (amountIn uint64, err error)
+	SpotPrice(spotPriceOpts interface{}) (spotPrice decimal.Decimal, err error)
+	OutGivenIn(outGivenInOpts interface{}, amountIn uint64) (amountOut uint64, err error)
+	InGivenOut(inGivenOutOpts interface{}, amountOut uint64) (amountIn uint64, err error)
 	FormulaType() int
 }
 
@@ -34,7 +22,6 @@ type MakingFormula interface {
 func NewStrategyFromFormula(
 	formula MakingFormula,
 ) MakingStrategy {
-
 	strategy := MakingStrategy{
 		Type:    formula.FormulaType(),
 		formula: formula,


### PR DESCRIPTION
This moves the whole price preview logic to the domain level, with the purpose to abstract the handling of a preview based on the market strategy at with a simple `market.Preview()` invocation at application level.

With this, a new `PluggableStrategy` data type is defined along with its method to make it compliant with the `mm.MakingFormula` interface.

The methods InGivenOut and OutGivenIn of the interface just mentioned have been slightly changed so that they accept opts of any type by expecting `interface{}`. It is then responsibility of the implementation to make sure that the opts are of the correct type by checking whether the interface casting succeeds or not.

Within the _balanced_ AMM formulas, the usage of the ChargeFeesOnThe WayIn has been fixed: before this that bool was basically a charge/discount fee flag. Now, the fees are **always charged**, and the bool states whether to apply fees on the given amount or the calculated one. The daemon charges fees always on the input amount.

This closes #368.

Please @tiero, review this.