### PR TITLE
Add circuit breaker to observables

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -78,7 +78,7 @@ const (
 	// CBFailingRatioKey is used in combo with MaxFailingRequests to set the
 	// failing ratio over which the circuit breaker service to change its
 	// internal state and stop making network calls.
-	CBFailingRatioKey = "CB_FAILING_RATIO"
+	CBFailingRatioKey = "FAILING_RATIO"
 
 	DbLocation        = "db"
 	TLSLocation       = "tls"

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -233,6 +234,15 @@ func validate() error {
 	explorerEndpoint := GetString(ExplorerEndpointKey)
 	if _, err := url.Parse(explorerEndpoint); err != nil {
 		return fmt.Errorf("explorer endpoint is not a valid url: %s", err)
+	}
+
+	maxFailingReq := GetString(CBMaxFailingRequestsKey)
+	if _, err := strconv.Atoi(maxFailingReq); err != nil {
+		return fmt.Errorf("%s must be a valid number", CBMaxFailingRequestsKey)
+	}
+	failingRatio := GetString(CBFailingRatioKey)
+	if _, err := strconv.ParseFloat(failingRatio, 64); err != nil {
+		return fmt.Errorf("%s must be a value in range (0, 1)", CBFailingRatioKey)
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -74,7 +74,7 @@ const (
 	// CBMaxFailingRequestsKey is used in combo with FailingRatio to set the max
 	// number of failing request for the circuit breaker service to change its
 	// internal state and stop making network calls.
-	CBMaxFailingRequestsKey = "CB_MAX_FAILING_REQUESTS"
+	CBMaxFailingRequestsKey = "MAX_FAILING_REQUESTS"
 	// CBFailingRatioKey is used in combo with MaxFailingRequests to set the
 	// failing ratio over which the circuit breaker service to change its
 	// internal state and stop making network calls.

--- a/config/config.go
+++ b/config/config.go
@@ -59,18 +59,26 @@ const (
 	CrawlLimitKey = "CRAWL_LIMIT"
 	// CrawlTokenBurst represents number of bursts tokens permitted from
 	//crawler to explorer
-	CrawlTokenBurst = "CRAWL_TOKEN"
+	CrawlTokenBurstKey = "CRAWL_TOKEN"
 	// NoMacaroonsKey is used to start the daemon without using macaroons auth
 	// service.
 	NoMacaroonsKey = "NO_MACAROONS"
 	// OperatorExtraIP is used to add an extra ip address to the self-signed TLS
 	// certificate for the Operator gRPC interface.
-	OperatorExtraIP = "OPERATOR_EXTRA_IP"
+	OperatorExtraIPKey = "OPERATOR_EXTRA_IP"
 	// OperatorExtraDomain is used to add an extra domain to the self signed TLS
 	// certificate for the Operator gRPC interface. This is useful to add the
 	// onion endpoint in case the daemon is served as a TOR hidden service for
 	// example.
-	OperatorExtraDomain = "OPERATOR_EXTRA_DOMAIN"
+	OperatorExtraDomainKey = "OPERATOR_EXTRA_DOMAIN"
+	// CBMaxFailingRequestsKey is used in combo with FailingRatio to set the max
+	// number of failing request for the circuit breaker service to change its
+	// internal state and stop making network calls.
+	CBMaxFailingRequestsKey = "CB_MAX_FAILING_REQUESTS"
+	// CBFailingRatioKey is used in combo with MaxFailingRequests to set the
+	// failing ratio over which the circuit breaker service to change its
+	// internal state and stop making network calls.
+	CBFailingRatioKey = "CB_FAILING_RATIO"
 
 	DbLocation        = "db"
 	TLSLocation       = "tls"
@@ -105,8 +113,10 @@ func init() {
 	vip.SetDefault(EnableProfilerKey, false)
 	vip.SetDefault(StatsIntervalKey, 600)
 	vip.SetDefault(CrawlLimitKey, 10)
-	vip.SetDefault(CrawlTokenBurst, 1)
+	vip.SetDefault(CrawlTokenBurstKey, 1)
 	vip.SetDefault(NoMacaroonsKey, false)
+	vip.SetDefault(CBMaxFailingRequestsKey, 20)
+	vip.SetDefault(CBFailingRatioKey, 0.7)
 
 	if err := validate(); err != nil {
 		log.Fatalf("error while validating config: %s", err)

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -112,11 +112,7 @@ func (b *blockchainListener) StartObserveAddress(
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	observable := &crawler.AddressObservable{
-		AccountIndex: accountIndex,
-		Address:      addr,
-		BlindingKey:  blindKey,
-	}
+	observable := crawler.NewAddressObservable(accountIndex, addr, blindKey)
 
 	if !b.started {
 		b.pendingObservables = append(b.pendingObservables, observable)
@@ -129,7 +125,7 @@ func (b *blockchainListener) StartObserveTx(txid string) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	observable := &crawler.TransactionObservable{TxID: txid}
+	observable := crawler.NewTransactionObservable(txid)
 
 	if !b.started {
 		b.pendingObservables = append(b.pendingObservables, observable)

--- a/pkg/circuitbreaker/circuitbreaker.go
+++ b/pkg/circuitbreaker/circuitbreaker.go
@@ -1,0 +1,24 @@
+package circuitbreaker
+
+import "github.com/sony/gobreaker"
+
+var (
+	// MaxNumOfFailingRequests ...
+	MaxNumOfFailingRequests = 10
+	// FailingRatio ...
+	FailingRatio = 0.6
+)
+
+// NewCircuitBreaker is a factory function returning a *gobreaker.CircuitBreaker
+// with a default state-changing function that activates if the overall number
+// of failing requests have reached a tweakable MaxNumOfFailingRequests cap and
+// the failing ratio has met the FailingRatio.
+func NewCircuitBreaker() *gobreaker.CircuitBreaker {
+	return gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		Name: "circuitbreaker",
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			ratio := float64(counts.TotalFailures) / float64(counts.Requests)
+			return int(counts.Requests) > MaxNumOfFailingRequests && ratio >= FailingRatio
+		},
+	})
+}

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -12,14 +12,14 @@ type Event interface {
 
 // Observable represent object that can be observe on the blockchain.
 type Observable interface {
-	observe(
+	Observe(
 		explorerSvc explorer.Service,
 		errChan chan error,
 		eventChan chan Event,
 		observableStatus *observableStatus,
 		rateLimiter *rate.Limiter,
 	)
-	key() string
+	Key() string
 }
 
 // Service is the interface for Crawler

--- a/pkg/crawler/observable.go
+++ b/pkg/crawler/observable.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/time/rate"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/sony/gobreaker"
 	"github.com/tdex-network/tdex-daemon/internal/core/domain"
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
 )
@@ -18,38 +19,25 @@ const (
 	Processed Status = "PROCESSED"
 )
 
-type Status string
-
-type observableStatus struct {
-	sync.RWMutex
-	status Status
-}
-
-func NewObservableStatus() *observableStatus {
-	return &observableStatus{
-		status: New,
-	}
-}
-
-func (o *observableStatus) Get() Status {
-	o.RLock()
-	defer o.RUnlock()
-	return o.status
-}
-
-func (o *observableStatus) Set(status Status) {
-	o.Lock()
-	defer o.Unlock()
-	o.status = status
-}
-
 type AddressObservable struct {
 	AccountIndex int
 	Address      string
 	BlindingKey  []byte
+	cb           *gobreaker.CircuitBreaker
 }
 
-func (a *AddressObservable) observe(
+func NewAddressObservable(
+	accountIndex int, address string, blindKey []byte,
+) Observable {
+	return &AddressObservable{
+		AccountIndex: accountIndex,
+		Address:      address,
+		BlindingKey:  blindKey,
+		cb:           newCircuitBreaker(),
+	}
+}
+
+func (a *AddressObservable) Observe(
 	explorerSvc explorer.Service,
 	errChan chan error,
 	eventChan chan Event,
@@ -66,11 +54,14 @@ func (a *AddressObservable) observe(
 		return
 	}
 
-	unspents, err := explorerSvc.GetUnspents(a.Address, [][]byte{a.BlindingKey})
+	iUnspents, err := a.cb.Execute(func() (interface{}, error) {
+		return explorerSvc.GetUnspents(a.Address, [][]byte{a.BlindingKey})
+	})
 	if err != nil {
 		errChan <- err
 		return
 	}
+	unspents := iUnspents.([]explorer.Utxo)
 
 	observableStatus.Set(Processed)
 
@@ -90,16 +81,24 @@ func (a *AddressObservable) observe(
 	eventChan <- event
 }
 
-func (a *AddressObservable) key() string {
+func (a *AddressObservable) Key() string {
 	return a.Address
 }
 
 type TransactionObservable struct {
 	TxID  string
 	TxHex string
+	cb    *gobreaker.CircuitBreaker
 }
 
-func (t *TransactionObservable) observe(
+func NewTransactionObservable(txid string) Observable {
+	return &TransactionObservable{
+		TxID: txid,
+		cb:   newCircuitBreaker(),
+	}
+}
+
+func (t *TransactionObservable) Observe(
 	explorerSvc explorer.Service,
 	errChan chan error,
 	eventChan chan Event,
@@ -116,15 +115,22 @@ func (t *TransactionObservable) observe(
 		return
 	}
 
-	txStatus, err := explorerSvc.GetTransactionStatus(t.TxID)
+	iTxStatus, err := t.cb.Execute(func() (interface{}, error) {
+		return explorerSvc.GetTransactionStatus(t.TxID)
+	})
 	if err != nil {
 		errChan <- err
 		return
 	}
+	txStatus := iTxStatus.(map[string]interface{})
+
 	if len(t.TxHex) <= 0 {
-		txHex, err := explorerSvc.GetTransactionHex(t.TxID)
+
+		iTxHex, err := t.cb.Execute(func() (interface{}, error) {
+			return explorerSvc.GetTransactionHex(t.TxID)
+		})
 		if err == nil {
-			t.TxHex = txHex
+			t.TxHex = iTxHex.(string)
 		}
 	}
 
@@ -168,8 +174,33 @@ func (t *TransactionObservable) observe(
 	eventChan <- event
 }
 
-func (t *TransactionObservable) key() string {
+func (t *TransactionObservable) Key() string {
 	return t.TxID
+}
+
+type Status string
+
+type observableStatus struct {
+	sync.RWMutex
+	status Status
+}
+
+func newObservableStatus() *observableStatus {
+	return &observableStatus{
+		status: New,
+	}
+}
+
+func (o *observableStatus) Get() Status {
+	o.RLock()
+	defer o.RUnlock()
+	return o.status
+}
+
+func (o *observableStatus) Set(status Status) {
+	o.Lock()
+	defer o.Unlock()
+	o.status = status
 }
 
 type observableHandler struct {
@@ -204,7 +235,7 @@ func newObservableHandler(
 		eventChan,
 		errChan,
 		stopChan,
-		NewObservableStatus(),
+		newObservableStatus(),
 		rateLimiter,
 	}
 }
@@ -216,7 +247,7 @@ func (oh *observableHandler) start() {
 		select {
 		case <-oh.ticker.C:
 			if oh.observableStatus.Get() != Waiting {
-				oh.observable.observe(
+				oh.observable.Observe(
 					oh.explorerSvc,
 					oh.errChan,
 					oh.eventChan,
@@ -242,8 +273,29 @@ func (oh *observableHandler) logAction(action string) {
 	obs := oh.observable
 	switch obs.(type) {
 	case *AddressObservable:
-		log.Debugf("%s observing address: %v", action, obs.key())
+		log.Debugf("%s observing address: %v", action, obs.Key())
 	case *TransactionObservable:
-		log.Debugf("%s observing tx: %v", action, obs.key())
+		log.Debugf("%s observing tx: %v", action, obs.Key())
 	}
+}
+
+func newCircuitBreaker() *gobreaker.CircuitBreaker {
+	return gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		Name: "observable",
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			failureRatio := float64(counts.TotalFailures) / float64(counts.Requests)
+			return counts.Requests > 20 && failureRatio >= 0.7
+		},
+		OnStateChange: func(name string, from, to gobreaker.State) {
+			if to == gobreaker.StateOpen {
+				log.Debug("cannot complete observation, will retry later")
+			}
+			if from == gobreaker.StateOpen && to == gobreaker.StateHalfOpen {
+				log.Debug("check observation status")
+			}
+			if from == gobreaker.StateHalfOpen && to == gobreaker.StateClosed {
+				log.Debug("restart observation")
+			}
+		},
+	})
 }

--- a/pkg/crawler/service.go
+++ b/pkg/crawler/service.go
@@ -96,7 +96,7 @@ func (bc *blockchainCrawler) AddObservable(observable Observable) {
 	bc.mutex.Lock()
 	defer bc.mutex.Unlock()
 
-	if _, ok := bc.observables[observable.key()]; !ok {
+	if _, ok := bc.observables[observable.Key()]; !ok {
 		obsHandler := newObservableHandler(
 			observable,
 			bc.explorerSvc,
@@ -107,7 +107,7 @@ func (bc *blockchainCrawler) AddObservable(observable Observable) {
 			bc.rateLimiter,
 		)
 
-		bc.observables[observable.key()] = obsHandler
+		bc.observables[observable.Key()] = obsHandler
 		go obsHandler.start()
 	}
 }
@@ -117,10 +117,9 @@ func (bc *blockchainCrawler) RemoveObservable(observable Observable) {
 	bc.mutex.Lock()
 	defer bc.mutex.Unlock()
 
-	if obsHandler, ok := bc.observables[observable.key()]; ok {
-
+	if obsHandler, ok := bc.observables[observable.Key()]; ok {
 		obsHandler.stop()
-		delete(bc.observables, observable.key())
+		delete(bc.observables, observable.Key())
 	}
 }
 

--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -63,9 +63,7 @@ func removeObservableAfterTimeout(crawler Service) {
 		Address:      "101",
 	})
 	time.Sleep(400 * time.Millisecond)
-	crawler.RemoveObservable(&TransactionObservable{
-		TxID: "102",
-	})
+	crawler.RemoveObservable(NewTransactionObservable("102"))
 }
 
 func addObservableAfterTimeout(crawler Service) {
@@ -75,9 +73,7 @@ func addObservableAfterTimeout(crawler Service) {
 		Address:      "101",
 	})
 	time.Sleep(300 * time.Millisecond)
-	crawler.AddObservable(&TransactionObservable{
-		TxID: "102",
-	})
+	crawler.AddObservable(NewTransactionObservable("102"))
 }
 
 // MOCK //

--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -68,10 +68,7 @@ func removeObservableAfterTimeout(crawler Service) {
 
 func addObservableAfterTimeout(crawler Service) {
 	time.Sleep(2 * time.Second)
-	crawler.AddObservable(&AddressObservable{
-		AccountIndex: 0,
-		Address:      "101",
-	})
+	crawler.AddObservable(NewAddressObservable(0, "101", nil))
 	time.Sleep(300 * time.Millisecond)
 	crawler.AddObservable(NewTransactionObservable("102"))
 }


### PR DESCRIPTION
This adds the circuit breaker strategy to the crawler's `Observable` components in order to retry failing network calls instead of returning error immediately in case any occur.

Closes #380.

Please @tiero review this.