### PR TITLE
[Unlockerd] Trim spaces and EOL in file provider & unify goreleaser unlocker builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,30 +54,18 @@ builds:
     binary: tdex-darwin
 
   # unlocker
-  - id: "unlockerd-linux"
+  - id: "unlockerd"
     main: ./cmd/unlockerd
     ldflags:
       - -s -w
     env:
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     goos:
       - linux
-    goarch:
-      - amd64
-    binary: unlockerd-linux
-
-  - id: "unlockerd-darwin"
-    main: ./cmd/unlockerd
-    ldflags:
-      - -s -w
-    env:
-      - CGO_ENABLED=1
-    goos:
       - darwin
     goarch:
       - amd64
-    binary: unlockerd-darwin
-
+    binary: unlockerd
 ## flag the semver v**.**.**-<tag>.* as pre-release on Github
 release:
   prerelease: auto

--- a/cmd/unlockerd/fileprovider.go
+++ b/cmd/unlockerd/fileprovider.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -54,7 +55,13 @@ func NewFileProvider() (provider, error) {
 }
 
 func (fp *fileProvider) Password() ([]byte, error) {
-	return ioutil.ReadFile(fp.pwdPath)
+	pwd, err := ioutil.ReadFile(fp.pwdPath)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.TrimFunc(pwd, func(r rune) bool {
+		return r == 10 || r == 32
+	}), nil
 }
 
 func (fp *fileProvider) TLSCertificate() ([]byte, error) {


### PR DESCRIPTION
This makes the unlocker's file provider smart enough to trim leading and ending spaces or EOL (`\n`) when reading the password from file.

This also enhances the goreleaser YAML file by unifying the 2 unlocker's builds in one single entry.

Please @tiero review this.