### PR TITLE
Fix docker container daemon datadir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,8 @@ RUN cp /tdex-daemon/unlockerd .
 FROM debian:buster
 
 # TDEX environment variables 
-# default data directory path is overwrite
 # others ENV variables are initialized to empty values: viper will initialize them.
-ENV TDEX_DATA_DIR_PATH="/.tdex-daemon" \
+ENV TDEX_DATA_DIR_PATH= \
     TDEX_EXPLORER_ENDPOINT= \
     TDEX_LOG_LEVEL= \
     TDEX_DEFAULT_FEE= \
@@ -55,6 +54,10 @@ COPY --from=builder /build/unlockerd /
 
 RUN install /tdex /bin
 RUN install /unlockerd /bin
+# Prevents `VOLUME $HOME/.tdex-daemon/` being created as owned by `root`
+RUN useradd -ms /bin/bash user
+USER user
+RUN mkdir -p "$HOME/.tdex-daemon/"
 
 # expose trader and operator interface ports
 EXPOSE 9945


### PR DESCRIPTION
This adds a user `user` to the debian image used for tdexd in order to prevent [cutomizing&hardcoding](https://github.com/TDex-network/tdex-daemon/blob/master/Dockerfile#L35) the daemon's datadir in a path different from the default one (in the appdata folder).

The previous image was also problematic for other binaries (tdex and unlockerd) whose defaulted to daemon's datadir `/root/.tdex-daemon` instead of the correct one `$HOME/.tdex-daemon`. This is now fixed and nor the CLI, nor the unlocker embedded in the image require to explicitly set tls/macaroons paths.

This closes #400.

Please @tiero review this.