### PR TITLE
[CLI] Auto create state file if not existing

### DIFF
--- a/cmd/tdex/config.go
+++ b/cmd/tdex/config.go
@@ -19,26 +19,31 @@ const (
 )
 
 var (
-	daemonDatadir        = btcutil.AppDataDir("tdex-daemon", false)
+	daemonDatadir = btcutil.AppDataDir("tdex-daemon", false)
+
+	defaultNetwork       = network.Liquid.Name
+	defaultExplorer      = "https://blockstream.info/liquid/api"
+	defaultRPCServer     = "localhost:9000"
+	defaultMacaroonsAuth = false
 	defaultTLSCertPath   = filepath.Join(daemonDatadir, "tls", "cert.pem")
 	defaultMacaroonsPath = filepath.Join(daemonDatadir, "macaroons", "admin.macaroon")
 
 	networkFlag = cli.StringFlag{
 		Name:  "network, n",
 		Usage: "the network tdexd is running on: liquid or regtest",
-		Value: network.Liquid.Name,
+		Value: defaultNetwork,
 	}
 
 	explorerUrlFlag = cli.StringFlag{
 		Name:  "explorer_url",
 		Usage: "explorer url for the current network",
-		Value: "https://blockstream.info/liquid/api",
+		Value: defaultExplorer,
 	}
 
 	rpcFlag = cli.StringFlag{
 		Name:  "rpcserver",
 		Usage: "tdexd daemon address host:port",
-		Value: "localhost:9000",
+		Value: defaultRPCServer,
 	}
 
 	tlsCertFlag = cli.StringFlag{
@@ -50,7 +55,7 @@ var (
 	noMacaroonsFlag = cli.BoolFlag{
 		Name:  noMacaroonsKey,
 		Usage: "used to start the daemon without macaroon auth",
-		Value: false,
+		Value: defaultMacaroonsAuth,
 	}
 
 	macaroonsFlag = cli.StringFlag{

--- a/cmd/tdex/config.go
+++ b/cmd/tdex/config.go
@@ -21,12 +21,12 @@ const (
 var (
 	daemonDatadir = btcutil.AppDataDir("tdex-daemon", false)
 
-	defaultNetwork       = network.Liquid.Name
-	defaultExplorer      = "https://blockstream.info/liquid/api"
-	defaultRPCServer     = "localhost:9000"
-	defaultMacaroonsAuth = false
-	defaultTLSCertPath   = filepath.Join(daemonDatadir, "tls", "cert.pem")
-	defaultMacaroonsPath = filepath.Join(daemonDatadir, "macaroons", "admin.macaroon")
+	defaultNetwork         = network.Liquid.Name
+	defaultExplorer        = "https://blockstream.info/liquid/api"
+	defaultRPCServer       = "localhost:9000"
+	defaultNoMacaroonsAuth = false
+	defaultTLSCertPath     = filepath.Join(daemonDatadir, "tls", "cert.pem")
+	defaultMacaroonsPath   = filepath.Join(daemonDatadir, "macaroons", "admin.macaroon")
 
 	networkFlag = cli.StringFlag{
 		Name:  "network, n",
@@ -55,7 +55,7 @@ var (
 	noMacaroonsFlag = cli.BoolFlag{
 		Name:  noMacaroonsKey,
 		Usage: "used to start the daemon without macaroon auth",
-		Value: defaultMacaroonsAuth,
+		Value: defaultNoMacaroonsAuth,
 	}
 
 	macaroonsFlag = cli.StringFlag{

--- a/cmd/tdex/main.go
+++ b/cmd/tdex/main.go
@@ -34,6 +34,15 @@ var (
 
 	tdexDataDir = btcutil.AppDataDir("tdex-operator", false)
 	statePath   = filepath.Join(tdexDataDir, "state.json")
+
+	initialState = map[string]string{
+		"network":        defaultNetwork,
+		"explorer_url":   defaultExplorer,
+		"rpcserver":      defaultRPCServer,
+		"no_macaroons":   strconv.FormatBool(defaultMacaroonsAuth),
+		"tls_cert_path":  defaultTLSCertPath,
+		"macaroons_path": defaultMacaroonsPath,
+	}
 )
 
 func init() {
@@ -87,12 +96,18 @@ func main() {
 }
 
 func getState() (map[string]string, error) {
-	data := map[string]string{}
-
 	file, err := ioutil.ReadFile(statePath)
 	if err != nil {
-		return nil, errors.New("get config state error: try 'config init'")
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		if err := setState(initialState); err != nil {
+			return nil, err
+		}
+		return initialState, nil
 	}
+
+	data := map[string]string{}
 	json.Unmarshal(file, &data)
 
 	return data, nil

--- a/cmd/tdex/main.go
+++ b/cmd/tdex/main.go
@@ -39,7 +39,7 @@ var (
 		"network":        defaultNetwork,
 		"explorer_url":   defaultExplorer,
 		"rpcserver":      defaultRPCServer,
-		"no_macaroons":   strconv.FormatBool(defaultMacaroonsAuth),
+		"no_macaroons":   strconv.FormatBool(defaultNoMacaroonsAuth),
 		"tls_cert_path":  defaultTLSCertPath,
 		"macaroons_path": defaultMacaroonsPath,
 	}


### PR DESCRIPTION
This makes the previously mandatory step `config init [--network, ...]` optional.

Now, when the `getState` function is in charge of creating a state.json file with all default values in case it doesn't exist instead of returning an error that mentions to run `config init`.

This closes #341.

Please @tiero review this.