### PR TITLE
Watch outpoints instead of transaction ids when a proposal is accepted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.2
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gogo/protobuf v1.2.1
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4

--- a/go.sum
+++ b/go.sum
@@ -91,7 +91,6 @@ github.com/dgraph-io/badger/v2 v2.2007.2 h1:EjjK0KqwaFMlPin1ajhP943VPENHJdEz1KLI
 github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -122,6 +121,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -27,6 +28,9 @@ type BlockchainListener interface {
 
 	StartObserveTx(txid string)
 	StopObserveTx(txid string)
+
+	StartObserveOutpoints(outpoints []explorer.Utxo, tradeID string)
+	StopObserveOutpoints(outpoints []crawler.Outpoint)
 
 	PubSubService() ports.SecurePubSub
 }
@@ -114,11 +118,7 @@ func (b *blockchainListener) StartObserveAddress(
 
 	observable := crawler.NewAddressObservable(accountIndex, addr, blindKey)
 
-	if !b.started {
-		b.pendingObservables = append(b.pendingObservables, observable)
-		return
-	}
-	b.crawlerSvc.AddObservable(observable)
+	b.addOrQueueObservable(observable)
 }
 
 func (b *blockchainListener) StartObserveTx(txid string) {
@@ -127,11 +127,25 @@ func (b *blockchainListener) StartObserveTx(txid string) {
 
 	observable := crawler.NewTransactionObservable(txid)
 
-	if !b.started {
-		b.pendingObservables = append(b.pendingObservables, observable)
-		return
+	b.addOrQueueObservable(observable)
+}
+
+func (b *blockchainListener) StartObserveOutpoints(
+	utxos []explorer.Utxo, tradeID string,
+) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	outs := make([]crawler.Outpoint, 0, len(utxos))
+	for _, u := range utxos {
+		outs = append(outs, u)
 	}
-	b.crawlerSvc.AddObservable(observable)
+	extraData := map[string]interface{}{
+		"tradeid": tradeID,
+	}
+	observable := crawler.NewOutpointsObservable(outs, extraData)
+
+	b.addOrQueueObservable(observable)
 }
 
 func (b *blockchainListener) StopObserveAddress(addr string) {
@@ -142,6 +156,12 @@ func (b *blockchainListener) StopObserveAddress(addr string) {
 
 func (b *blockchainListener) StopObserveTx(txid string) {
 	b.crawlerSvc.RemoveObservable(&crawler.TransactionObservable{TxID: txid})
+}
+
+func (b *blockchainListener) StopObserveOutpoints(outs []crawler.Outpoint) {
+	b.crawlerSvc.RemoveObservable(&crawler.OutpointsObservable{
+		Outpoints: outs,
+	})
 }
 
 func (b *blockchainListener) PubSubService() ports.SecurePubSub {
@@ -171,85 +191,66 @@ func (b *blockchainListener) listenToEventChannel() {
 				break
 			}
 
-			if err := b.settleTrade(&trade.ID, e); err != nil {
+			if err := b.settleTrade(&trade.ID, e.BlockTime, e.TxHex); err != nil {
 				log.Warnf("trying to settle trade with id %s: %v", trade.ID, err)
 				break
 			}
-			if err := b.confirmOrAddUnspents(e.TxHex, e.TxID, trade.MarketQuoteAsset); err != nil {
+			if err := b.updateUtxoSet(
+				e.TxHex, e.TxID, trade.MarketQuoteAsset, true,
+			); err != nil {
 				log.Warnf("trying to confirm or add unspents: %v", err)
 				break
 			}
 
 			// Publish message for topic TradeSettled to pubsub service.
-			if b.pubsubSvc != nil {
-				go func() {
-					ctx := context.Background()
-					mkt, mktAccount, err := b.repoManager.MarketRepository().GetMarketByAsset(
-						ctx, trade.MarketQuoteAsset,
-					)
-					if err != nil {
-						log.WithError(err).Warn("an error occured while retrieving market")
-						return
-					}
-
-					info, err := b.repoManager.VaultRepository().GetAllDerivedAddressesInfoForAccount(
-						ctx, mktAccount,
-					)
-					if err != nil {
-						log.WithError(err).Warn("an error occured while retrieving market addresses")
-						return
-					}
-					addresses := info.Addresses()
-					baseBalance, err := b.repoManager.UnspentRepository().GetBalance(
-						ctx, addresses, mkt.BaseAsset,
-					)
-					if err != nil {
-						log.WithError(err).Warn("an error occured while retrieving base balance")
-						return
-					}
-					quoteBalance, err := b.repoManager.UnspentRepository().GetBalance(
-						ctx, addresses, mkt.QuoteAsset,
-					)
-					if err != nil {
-						log.WithError(err).Warn("an error occured while retrieving quote balance")
-						return
-					}
-
-					payload := map[string]interface{}{
-						"txid": trade.TxID,
-						"swap": map[string]interface{}{
-							"amount_p": trade.SwapRequestMessage().GetAmountP(),
-							"asset_p":  trade.SwapRequestMessage().GetAssetP(),
-							"amount_r": trade.SwapRequestMessage().GetAmountR(),
-							"asset_r":  trade.SwapRequestMessage().GetAssetR(),
-						},
-						"price": map[string]string{
-							"base_price":  trade.MarketPrice.BasePrice.String(),
-							"quote_price": trade.MarketPrice.QuotePrice.String(),
-						},
-						"market": map[string]string{
-							"base_asset":  mkt.BaseAsset,
-							"quote_asset": trade.MarketQuoteAsset,
-						},
-						"balance": map[string]uint64{
-							"base_balance":  baseBalance,
-							"quote_balance": quoteBalance,
-						},
-					}
-					message, _ := json.Marshal(payload)
-					topics := b.pubsubSvc.TopicsByCode()
-					topic := topics[TradeSettled]
-
-					if err := b.pubsubSvc.Publish(topic.Label(), string(message)); err != nil {
-						log.WithError(err).Warnf(
-							"an error occured while publishing message for topic %s",
-							topic.Label(),
-						)
-					}
-				}()
-			}
+			go b.publishTradeSettledEvent(trade)
 			// stop watching for a tx after it's confirmed
 			b.StopObserveTx(e.TxID)
+		case crawler.OutpointsSpentAndUnconfirmed, crawler.OutpointsSpentAndConfirmed:
+			e := event.(crawler.OutpointsEvent)
+
+			txIsConfirmed := event.Type() == crawler.OutpointsSpentAndConfirmed
+
+			tradeID, err := extractTradeID(e.ExtraData)
+			if err != nil {
+				log.WithError(err).Warn(
+					"an error occured while retrieving tradeID from event",
+				)
+				break
+			}
+
+			trade, err := b.repoManager.TradeRepository().GetOrCreateTrade(
+				context.Background(), tradeID,
+			)
+			if err != nil {
+				log.WithError(err).Warn("an error occured while retrieving trade")
+				break
+			}
+
+			if txIsConfirmed {
+				if err := b.settleTrade(tradeID, e.BlockTime, e.TxHex); err != nil {
+					log.WithError(err).Warnf(
+						"an error occured while settling trade with id %s", tradeID,
+					)
+					break
+				}
+			}
+
+			if err := b.updateUtxoSet(
+				e.TxHex, e.TxID, trade.MarketQuoteAsset, txIsConfirmed,
+			); err != nil {
+				log.WithError(err).Warnf(
+					"an error occured while confirming or addding unspents",
+				)
+				break
+			}
+
+			if txIsConfirmed {
+				// Publish message for topic TradeSettled to pubsub service.
+				go b.publishTradeSettledEvent(trade)
+				// Stop watching outpoints.
+				b.StopObserveOutpoints(e.Outpoints)
+			}
 		}
 	}
 }
@@ -267,17 +268,19 @@ func (b *blockchainListener) startPendingObservables() {
 	b.pendingObservables = nil
 }
 
-func (b *blockchainListener) settleTrade(tradeID *uuid.UUID, event crawler.TransactionEvent) error {
+func (b *blockchainListener) settleTrade(
+	tradeID *uuid.UUID, blockTime int, txHex string,
+) error {
 	if err := b.repoManager.TradeRepository().UpdateTrade(
 		context.Background(),
 		tradeID,
 		func(t *domain.Trade) (*domain.Trade, error) {
 			mustAddTxHex := t.IsAccepted()
-			if _, err := t.Settle(uint64(event.BlockTime)); err != nil {
+			if _, err := t.Settle(uint64(blockTime)); err != nil {
 				return nil, err
 			}
 			if mustAddTxHex {
-				t.TxHex = event.TxHex
+				t.TxHex = txHex
 			}
 
 			return t, nil
@@ -290,10 +293,8 @@ func (b *blockchainListener) settleTrade(tradeID *uuid.UUID, event crawler.Trans
 	return nil
 }
 
-func (b *blockchainListener) confirmOrAddUnspents(
-	txHex string,
-	txID string,
-	mktAsset string,
+func (b *blockchainListener) updateUtxoSet(
+	txHex, txID, mktAsset string, isTxConfirmed bool,
 ) error {
 	ctx := context.Background()
 	_, accountIndex, err := b.repoManager.MarketRepository().GetMarketByAsset(ctx, mktAsset)
@@ -301,7 +302,7 @@ func (b *blockchainListener) confirmOrAddUnspents(
 		return err
 	}
 
-	unspentsToAdd, unspentsToSpend, err := extractUnspentsFromTx(
+	unspentsToAddOrConfirm, unspentsToSpend, err := extractUnspentsFromTx(
 		b.repoManager.VaultRepository(),
 		b.network,
 		txHex,
@@ -311,37 +312,146 @@ func (b *blockchainListener) confirmOrAddUnspents(
 		return err
 	}
 
-	uLen := len(unspentsToAdd)
-	unspentAddresses := make([]string, uLen, uLen)
-	for i, u := range unspentsToAdd {
-		unspentAddresses[i] = u.Address
-	}
-
-	u, err := b.repoManager.UnspentRepository().GetAllUnspentsForAddresses(ctx, unspentAddresses)
-	if err != nil {
-		return err
-	}
-	if len(u) > 0 {
-		unspentKeys := make([]domain.UnspentKey, uLen, uLen)
-		for i, u := range unspentsToAdd {
-			unspentKeys[i] = u.Key()
+	// If the spending tx is in mempool, its inputs can be marked as spent and
+	// the outs added to the utxo set. Otherwise, only its outputs need to be
+	// marked as confirmed.
+	if isTxConfirmed {
+		unspentKeys := make([]domain.UnspentKey, 0, len(unspentsToAddOrConfirm))
+		for _, u := range unspentsToAddOrConfirm {
+			unspentKeys = append(unspentKeys, u.Key())
 		}
-		count, err := b.repoManager.UnspentRepository().ConfirmUnspents(ctx, unspentKeys)
+
+		count, err := b.repoManager.UnspentRepository().ConfirmUnspents(
+			ctx, unspentKeys,
+		)
 		if err != nil {
 			return err
 		}
-		log.Debugf("confirmed %d unspents", count)
+		if count > 0 {
+			log.Debugf("confirmed %d unspents", count)
+		}
 		return nil
 	}
 
-	go func() {
-		// these unspents must be inserted already confirmed.
-		for i := range unspentsToAdd {
-			unspentsToAdd[i].Confirmed = true
-		}
-		addUnspentsAsync(b.repoManager.UnspentRepository(), unspentsToAdd)
-		spendUnspentsAsync(b.repoManager.UnspentRepository(), unspentsToSpend)
-	}()
+	count, err := b.repoManager.UnspentRepository().AddUnspents(
+		ctx, unspentsToAddOrConfirm,
+	)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		log.Debugf("added %d unspents", count)
+	}
+
+	count, err = b.repoManager.UnspentRepository().SpendUnspents(
+		ctx, unspentsToSpend,
+	)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		log.Debugf("spent %d unspents", count)
+	}
 
 	return nil
+}
+
+func (b *blockchainListener) addOrQueueObservable(obs crawler.Observable) {
+	if !b.started {
+		b.pendingObservables = append(b.pendingObservables, obs)
+		return
+	}
+	b.crawlerSvc.AddObservable(obs)
+}
+
+func (b *blockchainListener) publishTradeSettledEvent(trade *domain.Trade) {
+	if b.pubsubSvc == nil {
+		return
+	}
+
+	ctx := context.Background()
+	mkt, mktAccount, err := b.repoManager.MarketRepository().GetMarketByAsset(
+		ctx, trade.MarketQuoteAsset,
+	)
+	if err != nil {
+		log.WithError(err).Warn("an error occured while retrieving market")
+		return
+	}
+
+	info, err := b.repoManager.VaultRepository().GetAllDerivedAddressesInfoForAccount(
+		ctx, mktAccount,
+	)
+	if err != nil {
+		log.WithError(err).Warn("an error occured while retrieving market addresses")
+		return
+	}
+	addresses := info.Addresses()
+	baseBalance, err := b.repoManager.UnspentRepository().GetBalance(
+		ctx, addresses, mkt.BaseAsset,
+	)
+	if err != nil {
+		log.WithError(err).Warn("an error occured while retrieving base balance")
+		return
+	}
+	quoteBalance, err := b.repoManager.UnspentRepository().GetBalance(
+		ctx, addresses, mkt.QuoteAsset,
+	)
+	if err != nil {
+		log.WithError(err).Warn("an error occured while retrieving quote balance")
+		return
+	}
+
+	payload := map[string]interface{}{
+		"txid":                 trade.TxID,
+		"settlement_timestamp": trade.SettlementTime,
+		"settlement_date":      time.Unix(int64(trade.SettlementTime), 0).Format(time.UnixDate),
+		"swap": map[string]interface{}{
+			"amount_p": trade.SwapRequestMessage().GetAmountP(),
+			"asset_p":  trade.SwapRequestMessage().GetAssetP(),
+			"amount_r": trade.SwapRequestMessage().GetAmountR(),
+			"asset_r":  trade.SwapRequestMessage().GetAssetR(),
+		},
+		"price": map[string]string{
+			"base_price":  trade.MarketPrice.BasePrice.String(),
+			"quote_price": trade.MarketPrice.QuotePrice.String(),
+		},
+		"market": map[string]string{
+			"base_asset":  mkt.BaseAsset,
+			"quote_asset": trade.MarketQuoteAsset,
+		},
+		"balance": map[string]uint64{
+			"base_balance":  baseBalance,
+			"quote_balance": quoteBalance,
+		},
+	}
+	message, _ := json.Marshal(payload)
+	topics := b.pubsubSvc.TopicsByCode()
+	topic := topics[TradeSettled]
+
+	if err := b.pubsubSvc.Publish(topic.Label(), string(message)); err != nil {
+		log.WithError(err).Warnf(
+			"an error occured while publishing message for topic %s",
+			topic.Label(),
+		)
+	}
+}
+
+func extractTradeID(data interface{}) (*uuid.UUID, error) {
+	m, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("extra data unknown type")
+	}
+	iTradeID, ok := m["tradeid"]
+	if !ok {
+		return nil, fmt.Errorf("extra data misses trade ID")
+	}
+	tradeID, ok := iTradeID.(string)
+	if !ok {
+		return nil, fmt.Errorf("extra data unknown trade ID type")
+	}
+	id, err := uuid.Parse(tradeID)
+	if err != nil {
+		return nil, err
+	}
+	return &id, nil
 }

--- a/internal/core/application/blockchain_listener.go
+++ b/internal/core/application/blockchain_listener.go
@@ -116,7 +116,7 @@ func (b *blockchainListener) StartObserveAddress(
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	observable := crawler.NewAddressObservable(accountIndex, addr, blindKey)
+	observable := crawler.NewAddressObservable(addr, blindKey, accountIndex)
 
 	b.addOrQueueObservable(observable)
 }

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -138,12 +138,12 @@ func (m *mockExplorer) GetUnspentsForAddresses(
 
 func (m *mockExplorer) GetUnspentStatus(
 	hash string, index uint32,
-) (*explorer.UtxoStatus, error) {
+) (explorer.UtxoStatus, error) {
 	args := m.Called(hash, index)
 
-	var res *explorer.UtxoStatus
+	var res explorer.UtxoStatus
 	if a := args.Get(0); a != nil {
-		res = a.(*explorer.UtxoStatus)
+		res = a.(explorer.UtxoStatus)
 	}
 	return res, args.Error(1)
 }
@@ -178,14 +178,13 @@ func (m *mockExplorer) IsTransactionConfirmed(txid string) (bool, error) {
 	return res, args.Error(1)
 }
 
-func (m *mockExplorer) GetTransactionStatus(txid string) (map[string]interface{}, error) {
+func (m *mockExplorer) GetTransactionStatus(txid string) (explorer.TransactionStatus, error) {
 	args := m.Called(txid)
 
-	var res map[string]interface{}
 	if a := args.Get(0); a != nil {
-		res = a.(map[string]interface{})
+		return a.(explorer.TransactionStatus), nil
 	}
-	return res, args.Error(1)
+	return nil, args.Error(1)
 }
 
 func (m *mockExplorer) GetTransactionsForAddress(
@@ -495,6 +494,23 @@ func (m *mockSwapParser) DeserializeFail(msg []byte) (domain.SwapFail, error) {
 		res = a.(domain.SwapFail)
 	}
 	return res, args.Error(1)
+}
+
+// trandaction status
+
+type mockTxStatus map[string]interface{}
+
+func (m mockTxStatus) Confirmed() bool {
+	return m["confirmed"].(bool)
+}
+func (m mockTxStatus) BlockHash() string {
+	return m["block_hash"].(string)
+}
+func (m mockTxStatus) BlockTime() int {
+	return int(m["block_time"].(float64))
+}
+func (m mockTxStatus) BlockHeight() int {
+	return int(m["block_height"].(float64))
 }
 
 // **** SwapRequest ****

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -136,6 +136,18 @@ func (m *mockExplorer) GetUnspentsForAddresses(
 	return res, args.Error(1)
 }
 
+func (m *mockExplorer) GetUnspentStatus(
+	hash string, index uint32,
+) (*explorer.UtxoStatus, error) {
+	args := m.Called(hash, index)
+
+	var res *explorer.UtxoStatus
+	if a := args.Get(0); a != nil {
+		res = a.(*explorer.UtxoStatus)
+	}
+	return res, args.Error(1)
+}
+
 func (m *mockExplorer) GetTransaction(txid string) (explorer.Transaction, error) {
 	args := m.Called(txid)
 

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -957,22 +957,20 @@ func (o *operatorService) ListUtxos(
 func (o *operatorService) ReloadUtxos(ctx context.Context) error {
 	//get all addresses
 	vault, err := o.repoManager.VaultRepository().GetOrCreateVault(
-		ctx,
-		nil,
-		"",
-		nil,
+		ctx, nil, "", nil,
 	)
 	if err != nil {
 		return err
 	}
 
 	addressesInfo := vault.AllDerivedAddressesInfo()
-	return fetchAndAddUnspents(
+	_, err = fetchAndAddUnspents(
 		o.explorerSvc,
 		o.repoManager.UnspentRepository(),
 		o.blockchainListener,
 		addressesInfo,
 	)
+	return err
 }
 
 // ClaimMarketDeposit method add unspents to the market

--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -452,7 +452,9 @@ end:
 		}
 
 		if swapAccept != nil {
-			t.blockchainListener.StartObserveTx(trade.TxID)
+			t.blockchainListener.StartObserveOutpoints(
+				fillProposalResult.SelectedUnspents, trade.ID.String(),
+			)
 		}
 	}()
 

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -236,7 +236,7 @@ func newTradeService(withFixedFee bool) (application.TradeService, error) {
 	}); err != nil {
 		return nil, err
 	}
-	if err := repoManager.UnspentRepository().AddUnspents(ctx, unspents); err != nil {
+	if _, err := repoManager.UnspentRepository().AddUnspents(ctx, unspents); err != nil {
 		return nil, err
 	}
 
@@ -254,10 +254,11 @@ func newTradeService(withFixedFee bool) (application.TradeService, error) {
 
 	explorerSvc.(*mockExplorer).
 		On("GetTransactionStatus", mock.AnythingOfType("string")).
-		Return(map[string]interface{}{
-			"confirmed":  true,
-			"block_time": randomIntInRange(100000, 1000000),
-			"block_hash": randomHex(32),
+		Return(mockTxStatus{
+			"confirmed":    true,
+			"block_time":   randomIntInRange(100000, 1000000),
+			"block_height": randomIntInRange(100000, 1000000),
+			"block_hash":   randomHex(32),
 		}, nil)
 	explorerSvc.(*mockExplorer).
 		On("GetTransactionHex", mock.AnythingOfType("string")).

--- a/internal/core/application/walletunlocker_service.go
+++ b/internal/core/application/walletunlocker_service.go
@@ -114,7 +114,7 @@ func newWalletUnlockerService(
 			log.Info("Restoring internal wallet's utxo set. This could take a while...")
 
 			info := vault.AllDerivedAddressesInfo()
-			if err := fetchAndAddUnspents(
+			if _, err := fetchAndAddUnspents(
 				w.explorerService,
 				w.repoManager.UnspentRepository(),
 				w.blockchainListener,
@@ -624,7 +624,7 @@ func (w *walletUnlockerService) persistRestoredState(
 			}
 
 			// update utxo set
-			if err := w.repoManager.UnspentRepository().AddUnspents(ctx, unspents); err != nil {
+			if _, err := w.repoManager.UnspentRepository().AddUnspents(ctx, unspents); err != nil {
 				return nil, fmt.Errorf("unable to persist changes to the unspent repo: %s", err)
 			}
 
@@ -830,7 +830,7 @@ func fetchUnspents(
 
 func addUnspents(
 	unspentRepo domain.UnspentRepository, unspents []domain.Unspent,
-) error {
+) (int, error) {
 	return unspentRepo.AddUnspents(context.Background(), unspents)
 }
 
@@ -839,7 +839,7 @@ func fetchAndAddUnspents(
 	unspentRepo domain.UnspentRepository,
 	bcListener BlockchainListener,
 	info domain.AddressesInfo,
-) error {
+) (int, error) {
 	var unspents []domain.Unspent
 	var err error
 
@@ -852,10 +852,10 @@ func fetchAndAddUnspents(
 
 	unspents, err = fetchUnspents(explorerSvc, info)
 	if err != nil {
-		return err
+		return -1, err
 	}
 	if unspents == nil {
-		return nil
+		return 0, nil
 	}
 	go startObserveUnconfirmedUnspents(bcListener, unspents)
 	return addUnspents(unspentRepo, unspents)
@@ -868,14 +868,17 @@ func spendUnspents(
 }
 
 func addUnspentsAsync(unspentRepo domain.UnspentRepository, unspents []domain.Unspent) {
-	if err := addUnspents(unspentRepo, unspents); err != nil {
+	count, err := addUnspents(unspentRepo, unspents)
+	if err != nil {
 		log.Warnf(
 			"unexpected error occured while adding unspents to the utxo set. "+
 				"You must manually run ReloadUtxo RPC as soon as possible to restore "+
 				"the utxo set of the internal wallet. Error: %v", err,
 		)
 	}
-	log.Debugf("added %d unspents", len(unspents))
+	if count > 0 {
+		log.Debugf("added %d unspents", count)
+	}
 }
 
 func spendUnspentsAsync(
@@ -890,7 +893,9 @@ func spendUnspentsAsync(
 				"Error: %v", err,
 		)
 	}
-	log.Debugf("spent %d unspents", count)
+	if count > 0 {
+		log.Debugf("spent %d unspents", count)
+	}
 }
 
 func startObserveUnconfirmedUnspents(

--- a/internal/core/application/walletunlocker_service.go
+++ b/internal/core/application/walletunlocker_service.go
@@ -251,8 +251,6 @@ func (w *walletUnlockerService) InitWallet(
 			chErr <- fmt.Errorf("unable to persist restored state: %v", err)
 			return
 		}
-
-		go startObserveUnconfirmedUnspents(w.blockchainListener, unspents)
 	}
 
 	if w.blockchainListener.PubSubService() != nil {
@@ -857,7 +855,6 @@ func fetchAndAddUnspents(
 	if unspents == nil {
 		return 0, nil
 	}
-	go startObserveUnconfirmedUnspents(bcListener, unspents)
 	return addUnspents(unspentRepo, unspents)
 }
 
@@ -895,21 +892,6 @@ func spendUnspentsAsync(
 	}
 	if count > 0 {
 		log.Debugf("spent %d unspents", count)
-	}
-}
-
-func startObserveUnconfirmedUnspents(
-	bcListener BlockchainListener, unspents []domain.Unspent,
-) {
-	count := 0
-	for _, u := range unspents {
-		if !u.IsConfirmed() {
-			bcListener.StartObserveTx(u.TxID)
-			count++
-		}
-	}
-	if count > 0 {
-		log.Debugf("num of unconfirmed unspents to watch: %d", count)
 	}
 }
 

--- a/internal/core/domain/trade_service.go
+++ b/internal/core/domain/trade_service.go
@@ -86,7 +86,6 @@ func (t *Trade) Accept(
 	t.SwapAccept.Message = swapAcceptMsg
 	t.SwapAccept.Timestamp = now
 	t.PsetBase64 = psetBase64
-	t.TxID, _ = PsetParserManager.GetTxID(psetBase64)
 
 	return true, nil
 }
@@ -99,7 +98,7 @@ type CompleteResult struct {
 }
 
 // Complete brings a trade from the Accepted to the Completed status by
-// checiking that the given PSET completes the one of the SwapAccept message
+// checking that the given PSET completes the one of the SwapAccept message
 // and by finalizing it and extracting the raw tx in hex format. Complete must
 // be called before the trade expires, otherwise it won't be possible to
 // actually complete an accepted trade.
@@ -236,7 +235,7 @@ func (t *Trade) IsRejected() bool {
 	return t.Status.Failed
 }
 
-// IsExpired returns whether the trade has is in Expired status, or if its
+// IsExpired returns whether the trade is in Expired status, or if its
 // expiration date has passed.
 func (t *Trade) IsExpired() bool {
 	now := uint64(time.Now().Unix())

--- a/internal/core/domain/unspent_repository.go
+++ b/internal/core/domain/unspent_repository.go
@@ -11,7 +11,7 @@ import (
 type UnspentRepository interface {
 	// AddUnspents adds the provided unspents to the repository. Those already
 	// existing won't be re-added
-	AddUnspents(ctx context.Context, unspents []Unspent) error
+	AddUnspents(ctx context.Context, unspents []Unspent) (int, error)
 	// GetAllUnspents returns the entire UTXO set, included those locked or
 	// already spent.
 	GetAllUnspents(ctx context.Context) []Unspent

--- a/internal/infrastructure/pubsub/webhook/service.go
+++ b/internal/infrastructure/pubsub/webhook/service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/sony/gobreaker"
 	"github.com/tdex-network/tdex-daemon/internal/core/ports"
 	"github.com/tdex-network/tdex-daemon/pkg/circuitbreaker"

--- a/internal/infrastructure/storage/db/test/unspent_repository_impl_test.go
+++ b/internal/infrastructure/storage/db/test/unspent_repository_impl_test.go
@@ -90,7 +90,7 @@ func testAddUnspents(t *testing.T, repo unspentRepository) {
 	mockedUnspents := mockedData.unspents
 
 	iNewUnspents, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -108,7 +108,7 @@ func testGetAvailableUnspents(t *testing.T, repo unspentRepository) {
 	mockedUnspents := mockedData.unspents
 
 	iAvailableUnspents, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -127,7 +127,7 @@ func testGetAllUnspentsForAddresses(t *testing.T, repo unspentRepository) {
 	mockedUnspents := mockedData.unspents
 
 	iAllUnspents, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -147,7 +147,7 @@ func testGetUnspentsForAddresses(t *testing.T, repo unspentRepository) {
 	expectedUnspents := mockedData.expectedUnspents
 
 	iUnspents, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -166,7 +166,7 @@ func testGetAvailableUnspentsForAddresses(t *testing.T, repo unspentRepository) 
 	mockedUnspents := mockedData.unspents
 
 	iAvailableUnspents, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -191,7 +191,7 @@ func testGetUnspentWithKey(t *testing.T, repo unspentRepository) {
 	require.Nil(t, unspent)
 
 	unspent, err = repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -208,7 +208,7 @@ func testGetBalance(t *testing.T, repo unspentRepository) {
 	asset := mockedData.asset
 
 	iBalance, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -228,7 +228,7 @@ func testGetUnlockedBalance(t *testing.T, repo unspentRepository) {
 	asset := mockedData.asset
 
 	iBalance, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -247,7 +247,7 @@ func testSpendUnspents(t *testing.T, repo unspentRepository) {
 	unspentKeys := mockedData.unspentKeys
 
 	iUnspents, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -295,7 +295,7 @@ func testConfirmUnspents(t *testing.T, repo unspentRepository) {
 	unspentKeys := mockedData.unspentKeys
 
 	iUnspents, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 
@@ -344,7 +344,7 @@ func testLockUnlockUnspents(t *testing.T, repo unspentRepository) {
 	mockedTradeID := uuid.New()
 
 	iLockedUnspents, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
+		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
 			return nil, err
 		}
 

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -28,6 +28,5 @@ type Service interface {
 	Stop()
 	AddObservable(observable Observable)
 	RemoveObservable(observable Observable)
-	IsObservingAddresses(addresses []string) bool
 	GetEventChannel() chan Event
 }

--- a/pkg/crawler/event.go
+++ b/pkg/crawler/event.go
@@ -8,6 +8,9 @@ const (
 	MarketAccountDeposit
 	TransactionConfirmed
 	TransactionUnConfirmed
+	OutpointsUnspent
+	OutpointsSpentAndUnconfirmed
+	OutpointsSpentAndConfirmed
 )
 
 type EventType int
@@ -24,6 +27,12 @@ func (et EventType) String() string {
 		return "TransactionConfirmed"
 	case TransactionUnConfirmed:
 		return "TransactionUnConfirmed"
+	case OutpointsUnspent:
+		return "OutpointsUnspent"
+	case OutpointsSpentAndUnconfirmed:
+		return "OutpointsSpentAndUnconfirmed"
+	case OutpointsSpentAndConfirmed:
+		return "OutpointsSpentAndConfirmed"
 	default:
 		return "Unknown"
 	}
@@ -51,9 +60,23 @@ type TransactionEvent struct {
 	TxHex     string
 	EventType EventType
 	BlockHash string
-	BlockTime float64
+	BlockTime int
 }
 
 func (t TransactionEvent) Type() EventType {
 	return t.EventType
+}
+
+type OutpointsEvent struct {
+	EventType EventType
+	Outpoints []Outpoint
+	ExtraData interface{}
+	TxID      string
+	TxHex     string
+	BlockHash string
+	BlockTime int
+}
+
+func (o OutpointsEvent) Type() EventType {
+	return o.EventType
 }

--- a/pkg/crawler/event.go
+++ b/pkg/crawler/event.go
@@ -4,10 +4,9 @@ import "github.com/tdex-network/tdex-daemon/pkg/explorer"
 
 const (
 	CloseSignal EventType = iota
-	FeeAccountDeposit
-	MarketAccountDeposit
+	AddressUnspents
 	TransactionConfirmed
-	TransactionUnConfirmed
+	TransactionUnconfirmed
 	OutpointsUnspent
 	OutpointsSpentAndUnconfirmed
 	OutpointsSpentAndConfirmed
@@ -19,14 +18,12 @@ func (et EventType) String() string {
 	switch et {
 	case CloseSignal:
 		return "CloseSignal"
-	case FeeAccountDeposit:
-		return "FeeAccountDeposit"
-	case MarketAccountDeposit:
-		return "MarketAccountDeposit"
+	case AddressUnspents:
+		return "AddressUnspents"
 	case TransactionConfirmed:
 		return "TransactionConfirmed"
-	case TransactionUnConfirmed:
-		return "TransactionUnConfirmed"
+	case TransactionUnconfirmed:
+		return "TransactionUnconfirmed"
 	case OutpointsUnspent:
 		return "OutpointsUnspent"
 	case OutpointsSpentAndUnconfirmed:
@@ -45,10 +42,10 @@ func (q CloseEvent) Type() EventType {
 }
 
 type AddressEvent struct {
-	EventType    EventType
-	AccountIndex int
-	Address      string
-	Utxos        []explorer.Utxo
+	EventType EventType
+	Address   string
+	ExtraData interface{}
+	Utxos     []explorer.Utxo
 }
 
 func (a AddressEvent) Type() EventType {

--- a/pkg/crawler/mock_test.go
+++ b/pkg/crawler/mock_test.go
@@ -1,0 +1,203 @@
+package crawler_test
+
+import (
+	"github.com/stretchr/testify/mock"
+	"github.com/tdex-network/tdex-daemon/pkg/explorer"
+)
+
+// Explorer
+type mockExplorer struct {
+	mock.Mock
+}
+
+func (m *mockExplorer) GetUnspents(
+	addr string, blindKeys [][]byte,
+) ([]explorer.Utxo, error) {
+	args := m.Called(addr, blindKeys)
+
+	var res []explorer.Utxo
+	if a := args.Get(0); a != nil {
+		res = a.([]explorer.Utxo)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) GetUnspentsForAddresses(
+	addresses []string, blindKeys [][]byte,
+) ([]explorer.Utxo, error) {
+	args := m.Called(addresses, blindKeys)
+
+	var res []explorer.Utxo
+	if a := args.Get(0); a != nil {
+		res = a.([]explorer.Utxo)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) GetUnspentStatus(
+	hash string, index uint32,
+) (explorer.UtxoStatus, error) {
+	args := m.Called(hash, index)
+
+	var res explorer.UtxoStatus
+	if a := args.Get(0); a != nil {
+		res = a.(explorer.UtxoStatus)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) GetTransaction(txid string) (explorer.Transaction, error) {
+	args := m.Called(txid)
+
+	var res explorer.Transaction
+	if a := args.Get(0); a != nil {
+		res = a.(explorer.Transaction)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) GetTransactionHex(txid string) (string, error) {
+	args := m.Called(txid)
+
+	var res string
+	if a := args.Get(0); a != nil {
+		res = a.(string)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) IsTransactionConfirmed(txid string) (bool, error) {
+	args := m.Called(txid)
+
+	var res bool
+	if a := args.Get(0); a != nil {
+		res = a.(bool)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) GetTransactionStatus(txid string) (explorer.TransactionStatus, error) {
+	args := m.Called(txid)
+
+	if a := args.Get(0); a != nil {
+		return a.(explorer.TransactionStatus), nil
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockExplorer) GetTransactionsForAddress(
+	addr string, blindKey []byte,
+) ([]explorer.Transaction, error) {
+	args := m.Called(addr, blindKey)
+
+	var res []explorer.Transaction
+	if a := args.Get(0); a != nil {
+		res = a.([]explorer.Transaction)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) BroadcastTransaction(txhex string) (string, error) {
+	args := m.Called(txhex)
+
+	var res string
+	if a := args.Get(0); a != nil {
+		res = a.(string)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) Faucet(addr string, amount float64, asset string) (string, error) {
+	args := m.Called(addr, amount, asset)
+
+	var res string
+	if a := args.Get(0); a != nil {
+		res = a.(string)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) Mint(addr string, amount float64) (string, string, error) {
+	args := m.Called(addr, amount)
+
+	var res string
+	if a := args.Get(0); a != nil {
+		res = a.(string)
+	}
+	var res1 string
+	if a := args.Get(1); a != nil {
+		res1 = a.(string)
+	}
+	return res, res1, args.Error(2)
+}
+
+func (m *mockExplorer) GetBlockHeight() (int, error) {
+	args := m.Called()
+
+	var res int
+	if a := args.Get(0); a != nil {
+		res = a.(int)
+	}
+	return res, args.Error(1)
+}
+
+// UtxoStatus
+
+type mockUtxoStatus struct {
+	mock.Mock
+}
+
+func (m *mockUtxoStatus) Spent() bool {
+	args := m.Called()
+	return args.Get(0).(bool)
+}
+
+func (m *mockUtxoStatus) Hash() string {
+	args := m.Called()
+	return args.Get(0).(string)
+}
+
+func (m *mockUtxoStatus) Index() int {
+	args := m.Called()
+	return args.Get(0).(int)
+}
+
+// TransactionStatus
+type mockTxStatus struct {
+	mock.Mock
+}
+
+func (m *mockTxStatus) Confirmed() bool {
+	args := m.Called()
+	return args.Get(0).(bool)
+}
+
+func (m *mockTxStatus) BlockHash() string {
+	args := m.Called()
+	return args.Get(0).(string)
+}
+
+func (m *mockTxStatus) BlockHeight() int {
+	args := m.Called()
+	return args.Get(0).(int)
+}
+
+func (m *mockTxStatus) BlockTime() int {
+	args := m.Called()
+	return args.Get(0).(int)
+}
+
+// Outpoint
+type mockOutpoint struct {
+	mock.Mock
+}
+
+func (m *mockOutpoint) Hash() string {
+	args := m.Called()
+	return args.Get(0).(string)
+}
+
+func (m *mockOutpoint) Index() uint32 {
+	args := m.Called()
+	return uint32(args.Get(0).(int))
+}

--- a/pkg/crawler/observable_test.go
+++ b/pkg/crawler/observable_test.go
@@ -1,0 +1,224 @@
+package crawler_test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tdex-network/tdex-daemon/pkg/crawler"
+	"github.com/tdex-network/tdex-daemon/pkg/explorer"
+	"golang.org/x/time/rate"
+)
+
+var (
+	observationInterval = 2 * time.Second
+	rateLimiter         = newTestRateLimiter()
+	wantUtxoSpent       = true
+	wantTxConfirmed     = true
+)
+
+func TestObservables(t *testing.T) {
+	tests := []struct {
+		name                  string
+		observable            crawler.Observable
+		mockedExplorer        explorer.Service
+		expectedObservableKey string
+		expectedEventType     crawler.EventType
+	}{
+		{
+			name:                  "AddressObservable emits AddressUnspents",
+			observable:            crawler.NewAddressObservable("el1qqdhke3shlafa8xrmxrp9lwpw063w0w9eqg4m4w86t6u986xt890wcztxj80rm395mvdq7zja6yzt4z539knpw3g588su6mnkn", h2b("86967925d6603ac1bf839ca7f3c7bf7879918bf48104b5ba3493acba8b292817"), nil),
+			mockedExplorer:        mockedExplorerForAddressObs(),
+			expectedObservableKey: "el1qqdhke3shlafa8xrmxrp9lwpw063w0w9eqg4m4w86t6u986xt890wcztxj80rm395mvdq7zja6yzt4z539knpw3g588su6mnkn",
+			expectedEventType:     crawler.AddressUnspents,
+		},
+		{
+			name:                  fmt.Sprintf("TransactionObservable emits %s", crawler.TransactionUnconfirmed),
+			observable:            crawler.NewTransactionObservable("560d912df33521da808dc1f7d43a894ba7221af352328cda3f3b2ec894510477"),
+			mockedExplorer:        mockedExplorerForTransactionObs(!wantTxConfirmed),
+			expectedObservableKey: "560d912df33521da808dc1f7d43a894ba7221af352328cda3f3b2ec894510477",
+			expectedEventType:     crawler.TransactionConfirmed,
+		},
+		{
+			name:                  fmt.Sprintf("TransactionObservable emits %s", crawler.TransactionConfirmed),
+			observable:            crawler.NewTransactionObservable("69fe1192a74e9c9a874ac1a1f80c244ce801b359e86f3c8d08084f93844e3845"),
+			mockedExplorer:        mockedExplorerForTransactionObs(wantTxConfirmed),
+			expectedObservableKey: "69fe1192a74e9c9a874ac1a1f80c244ce801b359e86f3c8d08084f93844e3845",
+			expectedEventType:     crawler.TransactionConfirmed,
+		},
+		{
+			name:                  fmt.Sprintf("OutpointsObservable emits %s", crawler.OutpointsUnspent),
+			observable:            crawler.NewOutpointsObservable(mockedOutpoints(2), nil),
+			mockedExplorer:        mockedExplorerForOutpointsObs(!wantUtxoSpent, !wantTxConfirmed),
+			expectedObservableKey: "",
+			expectedEventType:     crawler.OutpointsUnspent,
+		},
+		{
+			name:                  fmt.Sprintf("OutpointsObservable emits %s", crawler.OutpointsSpentAndUnconfirmed),
+			observable:            crawler.NewOutpointsObservable(mockedOutpoints(2), nil),
+			mockedExplorer:        mockedExplorerForOutpointsObs(wantUtxoSpent, !wantTxConfirmed),
+			expectedObservableKey: "",
+			expectedEventType:     crawler.OutpointsSpentAndUnconfirmed,
+		},
+		{
+			name:                  fmt.Sprintf("OutpointsObservable emits %s", crawler.OutpointsSpentAndConfirmed),
+			observable:            crawler.NewOutpointsObservable(mockedOutpoints(2), nil),
+			mockedExplorer:        mockedExplorerForOutpointsObs(wantUtxoSpent, wantTxConfirmed),
+			expectedObservableKey: "",
+			expectedEventType:     crawler.OutpointsSpentAndConfirmed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checkObservableKey := len(tt.expectedObservableKey) > 0
+			if checkObservableKey {
+				require.Equal(t, tt.expectedObservableKey, tt.observable.Key())
+			}
+
+			wg := &sync.WaitGroup{}
+			eventChan := make(chan crawler.Event)
+			errChan := make(chan error)
+			handler := crawler.NewObservableHandler(
+				tt.observable, tt.mockedExplorer,
+				wg, observationInterval, eventChan, errChan, rateLimiter,
+			)
+
+			go handler.Start()
+			defer handler.Stop()
+
+			event, err := listenToChannels(eventChan, errChan)
+			require.NoError(t, err)
+			require.NotNil(t, event)
+			require.Equal(t, tt.expectedEventType, event.Type())
+		})
+	}
+}
+
+func listenToChannels(
+	eventChan chan crawler.Event, errChan chan error,
+) (crawler.Event, error) {
+	select {
+	case err := <-errChan:
+		return nil, err
+	case event := <-eventChan:
+		return event, nil
+	}
+}
+
+func mockedExplorerForAddressObs() explorer.Service {
+	svc := &mockExplorer{}
+	svc.On("GetUnspents", mock.Anything, mock.Anything).Return([]explorer.Utxo{}, nil)
+	return svc
+}
+
+func mockedExplorerForTransactionObs(wantTxConfirmed bool) explorer.Service {
+	status := newMockedTxStatus(wantTxConfirmed)
+
+	svc := &mockExplorer{}
+	svc.On("GetTransactionStatus", mock.Anything).Return(status, nil)
+	return svc
+}
+
+func mockedExplorerForOutpointsObs(wantUtxoSpent, wantTxConfirmed bool) explorer.Service {
+	utxoStatus := newMockedUtxoStatus(wantUtxoSpent)
+	txStatus := newMockedTxStatus(wantTxConfirmed)
+
+	svc := &mockExplorer{}
+	svc.On("GetUnspentStatus", mock.Anything, mock.Anything).Return(utxoStatus, nil)
+	svc.On("GetTransactionStatus", mock.Anything).Return(txStatus, nil)
+	svc.On("GetTransactionHex", mock.Anything).Return(randomHex(100), nil)
+	return svc
+}
+
+func newTestRateLimiter() *rate.Limiter {
+	rt := rate.Every(100 * time.Millisecond)
+	return rate.NewLimiter(rt, 1)
+}
+
+func newMockedTxStatus(wantTxConfirmed bool) explorer.TransactionStatus {
+	confirmed := false
+	blockHash := ""
+	blockTime, blockHeight := -1, -1
+	if wantTxConfirmed {
+		confirmed = true
+		blockHash = randomHex(32)
+		blockTime = 1627421914
+		blockHeight = randomIntInRange(100, 1000)
+	}
+	status := &mockTxStatus{}
+	status.On("Confirmed").Return(confirmed)
+	status.On("BlockHash").Return(blockHash)
+	status.On("BlockTime").Return(blockTime)
+	status.On("BlockHeight").Return(blockHeight)
+	return status
+}
+
+func newMockedUtxoStatus(wantUtxoSpent bool) explorer.UtxoStatus {
+	spent := false
+	hash := ""
+	index := -1
+	if wantUtxoSpent {
+		spent = true
+		hash = randomHex(32)
+		index = randomIntInRange(0, 15)
+	}
+	status := &mockUtxoStatus{}
+	status.On("Spent").Return(spent)
+	status.On("Hash").Return(hash)
+	status.On("Index").Return(index)
+	return status
+}
+
+func unspentUtxoStatus() explorer.UtxoStatus {
+	status := &mockUtxoStatus{}
+	status.On("Spent").Return(false)
+	return status
+}
+
+func spentUtxoStatus() explorer.UtxoStatus {
+	status := &mockUtxoStatus{}
+	status.On("Spent").Return(true)
+	status.On("Hash").Return(randomHex(32))
+	status.On("Index").Return(randomIntInRange(0, 15))
+	return status
+}
+
+func mockedOutpoints(num int) []crawler.Outpoint {
+	outs := make([]crawler.Outpoint, 0, num)
+	for i := 0; i < num; i++ {
+		out := &mockOutpoint{}
+		out.On("Hash").Return(randomHex(32))
+		out.On("Index").Return(randomIntInRange(0, 15))
+		outs = append(outs, out)
+	}
+	return outs
+}
+
+func randomHex(len int) string {
+	return hex.EncodeToString(randomBytes(len))
+}
+
+func randomBytes(len int) []byte {
+	b := make([]byte, len)
+	rand.Read(b)
+	return b
+}
+
+func randomIntInRange(min, max int) int {
+	n, _ := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	return int(int(n.Int64())) + min
+}
+
+func h2b(str string) []byte {
+	buf, _ := hex.DecodeString(str)
+	return buf
+}

--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -89,11 +89,37 @@ func (m mockExplorer) IsTransactionConfirmed(txID string) (bool, error) {
 	return false, nil
 }
 
+type txStatus map[string]interface{}
+
+func (s txStatus) Confirmed() bool {
+	return s["confirmed"].(bool)
+}
+
+func (s txStatus) BlockHash() string {
+	str := s["block_hash"]
+	if str == nil {
+		return ""
+	}
+	return str.(string)
+}
+
+func (s txStatus) BlockTime() int {
+	i := s["block_time"]
+	if i == nil {
+		return -1
+	}
+	return i.(int)
+}
+
+func (s txStatus) BlockHeight() int {
+	return -1
+}
+
 func (m mockExplorer) GetTransactionStatus(txID string) (
-	map[string]interface{},
+	explorer.TransactionStatus,
 	error,
 ) {
-	status := make(map[string]interface{}, 0)
+	status := make(txStatus, 0)
 	status["confirmed"] = false
 
 	if txID == "4" || txID == "5" || txID == "6" || txID == "102" {
@@ -121,7 +147,9 @@ func (m mockExplorer) GetUnspents(addr string, blindKeys [][]byte) (
 	return nil, nil
 }
 
-func (m mockExplorer) GetUnspentStatus(txID string, vout uint32) (*explorer.UtxoStatus, error) {
+func (m mockExplorer) GetUnspentStatus(
+	hash string, index uint32,
+) (explorer.UtxoStatus, error) {
 	return nil, errors.New("implement me")
 }
 

--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -1,20 +1,23 @@
-package crawler
+package crawler_test
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/tdex-network/tdex-daemon/pkg/crawler"
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
-	"github.com/vulpemventures/go-elements/transaction"
 )
 
 func TestCrawler(t *testing.T) {
-	mockExplorerSvc := mockExplorer{}
+	explorerSvc := &mockExplorer{}
+	explorerSvc.On("GetUnspents", mock.Anything, mock.Anything).Return([]explorer.Utxo{}, nil)
+	explorerSvc.On("GetTransactionStatus", mock.Anything).Return(newMockedTxStatus(wantTxConfirmed), nil)
+	explorerSvc.On("GetTransactionHex", mock.Anything).Return(randomHex(100), nil)
 
-	crawlSvc := NewService(Opts{
-		ExplorerSvc: mockExplorerSvc,
+	crawlSvc := crawler.NewService(crawler.Opts{
+		ExplorerSvc: explorerSvc,
 		ErrorHandler: func(err error) {
 			if err != nil {
 				fmt.Println(err)
@@ -34,208 +37,30 @@ func TestCrawler(t *testing.T) {
 	crawlSvc.Stop()
 }
 
-func listen(t *testing.T, crawlSvc Service) {
+func listen(t *testing.T, crawlSvc crawler.Service) {
 	eventChan := crawlSvc.GetEventChannel()
 	for {
 		event := <-eventChan
-		switch e := event.(type) {
-		case CloseEvent:
+		switch tt := event.Type(); tt {
+		case crawler.CloseSignal:
 			return
-		case AddressEvent:
-			for _, u := range e.Utxos {
-				t.Log(fmt.Sprintf("%v %v %v", "ADR", e.EventType, u.Value()))
-			}
-		case TransactionEvent:
-			if e.EventType == TransactionConfirmed {
-				t.Log(fmt.Sprintf("%v %v %v", "TX", e.EventType, e.TxID))
-			}
+		default:
+			t.Logf("received event %s\n", tt)
 		}
 	}
 }
 
-func stopCrawlerAfterTimeout(crawler Service) {
-	crawler.Stop()
-}
-
-func removeObservableAfterTimeout(crawler Service) {
-	crawler.RemoveObservable(&AddressObservable{
-		AccountIndex: 0,
-		Address:      "101",
+func removeObservableAfterTimeout(crawlerSvc crawler.Service) {
+	crawlerSvc.RemoveObservable(&crawler.AddressObservable{
+		Address: "101",
 	})
 	time.Sleep(400 * time.Millisecond)
-	crawler.RemoveObservable(NewTransactionObservable("102"))
+	crawlerSvc.RemoveObservable(crawler.NewTransactionObservable("102"))
 }
 
-func addObservableAfterTimeout(crawler Service) {
+func addObservableAfterTimeout(crawlerSvc crawler.Service) {
 	time.Sleep(2 * time.Second)
-	crawler.AddObservable(NewAddressObservable(0, "101", nil))
+	crawlerSvc.AddObservable(crawler.NewAddressObservable("101", nil, 0))
 	time.Sleep(300 * time.Millisecond)
-	crawler.AddObservable(NewTransactionObservable("102"))
-}
-
-// MOCK //
-
-type mockExplorer struct{}
-
-func (m mockExplorer) GetBlockHeight() (int, error) {
-	panic("implement me")
-}
-
-func (m mockExplorer) GetUnspentsForAddresses(addresses []string, blindingKeys [][]byte) ([]explorer.Utxo, error) {
-	panic("implement me")
-}
-
-func (m mockExplorer) IsTransactionConfirmed(txID string) (bool, error) {
-	return false, nil
-}
-
-type txStatus map[string]interface{}
-
-func (s txStatus) Confirmed() bool {
-	return s["confirmed"].(bool)
-}
-
-func (s txStatus) BlockHash() string {
-	str := s["block_hash"]
-	if str == nil {
-		return ""
-	}
-	return str.(string)
-}
-
-func (s txStatus) BlockTime() int {
-	i := s["block_time"]
-	if i == nil {
-		return -1
-	}
-	return i.(int)
-}
-
-func (s txStatus) BlockHeight() int {
-	return -1
-}
-
-func (m mockExplorer) GetTransactionStatus(txID string) (
-	explorer.TransactionStatus,
-	error,
-) {
-	status := make(txStatus, 0)
-	status["confirmed"] = false
-
-	if txID == "4" || txID == "5" || txID == "6" || txID == "102" {
-		status["confirmed"] = true
-		status["block_hash"] = "afbd0d4e3db10be68371b3fee107397297e9c057e3c52ee9e9a76fd62fc069a6"
-		status["block_time"] = 1600178119
-	}
-
-	return status, nil
-}
-
-func (m mockExplorer) GetUnspents(addr string, blindKeys [][]byte) (
-	[]explorer.Utxo,
-	error,
-) {
-	if addr == "1" {
-		return []explorer.Utxo{mockUtxo{value: 1}}, nil
-	} else if addr == "2" {
-		return []explorer.Utxo{mockUtxo{value: 2}}, nil
-	} else if addr == "3" {
-		return []explorer.Utxo{mockUtxo{value: 3}}, nil
-	} else if addr == "101" {
-		return []explorer.Utxo{mockUtxo{value: 101}}, nil
-	}
-	return nil, nil
-}
-
-func (m mockExplorer) GetUnspentStatus(
-	hash string, index uint32,
-) (explorer.UtxoStatus, error) {
-	return nil, errors.New("implement me")
-}
-
-func (m mockExplorer) GetTransaction(txID string) (explorer.Transaction, error) {
-	return nil, errors.New("implement me")
-}
-func (m mockExplorer) GetTransactionHex(txID string) (string, error) {
-	return "", errors.New("implement me")
-}
-func (m mockExplorer) GetTransactionsForAddress(addr string, blindingKey []byte) ([]explorer.Transaction, error) {
-	return nil, errors.New("implement me")
-}
-func (m mockExplorer) BroadcastTransaction(txHex string) (string, error) {
-	return "", errors.New("implement me")
-}
-func (m mockExplorer) Faucet(addr string, amount float64, asset string) (string, error) {
-	return "", errors.New("implement me")
-}
-func (m mockExplorer) Mint(addr string, amount float64) (string, string, error) {
-	return "", "", errors.New("implement me")
-}
-
-type mockUtxo struct {
-	value uint64
-}
-
-func (m mockUtxo) Hash() string {
-	panic("implement me")
-}
-
-func (m mockUtxo) Index() uint32 {
-	panic("implement me")
-}
-
-func (m mockUtxo) Value() uint64 {
-	return m.value
-}
-
-func (m mockUtxo) Asset() string {
-	panic("implement me")
-}
-
-func (m mockUtxo) ValueCommitment() string {
-	panic("implement me")
-}
-
-func (m mockUtxo) AssetCommitment() string {
-	panic("implement me")
-}
-
-func (m mockUtxo) ValueBlinder() []byte {
-	panic("implement me")
-}
-
-func (m mockUtxo) AssetBlinder() []byte {
-	panic("implement me")
-}
-
-func (m mockUtxo) Nonce() []byte {
-	panic("implement me")
-}
-
-func (m mockUtxo) Script() []byte {
-	panic("implement me")
-}
-
-func (m mockUtxo) RangeProof() []byte {
-	panic("implement me")
-}
-
-func (m mockUtxo) SurjectionProof() []byte {
-	panic("implement me")
-}
-
-func (m mockUtxo) IsConfidential() bool {
-	panic("implement me")
-}
-
-func (m mockUtxo) IsRevealed() bool {
-	panic("implement me")
-}
-
-func (m mockUtxo) Parse() (*transaction.TxInput, *transaction.TxOutput, error) {
-	panic("implement me")
-}
-
-func (m mockUtxo) IsConfirmed() bool {
-	panic("implement me")
+	crawlerSvc.AddObservable(crawler.NewTransactionObservable("102"))
 }

--- a/pkg/crawler/service_test.go
+++ b/pkg/crawler/service_test.go
@@ -121,6 +121,10 @@ func (m mockExplorer) GetUnspents(addr string, blindKeys [][]byte) (
 	return nil, nil
 }
 
+func (m mockExplorer) GetUnspentStatus(txID string, vout uint32) (*explorer.UtxoStatus, error) {
+	return nil, errors.New("implement me")
+}
+
 func (m mockExplorer) GetTransaction(txID string) (explorer.Transaction, error) {
 	return nil, errors.New("implement me")
 }

--- a/pkg/explorer/elements/transaction.go
+++ b/pkg/explorer/elements/transaction.go
@@ -53,7 +53,9 @@ func (e *elements) IsTransactionConfirmed(txid string) (bool, error) {
 // Otherwise some other info about the block that includes the tx are returned
 // along with its confirmation status. This method makes use of gettransaction
 // and getblock RPCs.
-func (e *elements) GetTransactionStatus(txid string) (map[string]interface{}, error) {
+func (e *elements) GetTransactionStatus(
+	txid string,
+) (explorer.TransactionStatus, error) {
 	data, err := e.getTransaction(txid)
 	if err != nil {
 		return nil, err
@@ -71,16 +73,13 @@ func (e *elements) GetTransactionStatus(txid string) (map[string]interface{}, er
 			return nil, fmt.Errorf("unmarshal: %w", err)
 		}
 
-		return map[string]interface{}{
-			"confirmed":    true,
-			"block_hash":   data["hash"],
-			"block_height": data["height"],
-			"block_time":   data["time"],
-		}, nil
+		return newConfirmedTxStatus(
+			data["hash"].(string),
+			int(data["height"].(float64)),
+			int(data["time"].(float64)),
+		), nil
 	}
-	return map[string]interface{}{
-		"confirmed": false,
-	}, nil
+	return newUnconfirmedTxStatus(), nil
 }
 
 type txResult struct {

--- a/pkg/explorer/elements/transaction_test.go
+++ b/pkg/explorer/elements/transaction_test.go
@@ -102,10 +102,10 @@ func TestGetTransactionStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, true, status["confirmed"].(bool))
-	assert.Equal(t, true, len(status["block_hash"].(string)) > 0)
-	assert.Equal(t, true, status["block_height"].(float64) > 0)
-	assert.Equal(t, true, status["block_time"].(float64) > 0)
+	assert.Equal(t, true, status.Confirmed())
+	assert.Equal(t, true, len(status.BlockHash()) > 0)
+	assert.Equal(t, true, status.BlockHeight() > 0)
+	assert.Equal(t, true, status.BlockTime() > 0)
 }
 
 func TestGetTransactionsForAddress(t *testing.T) {

--- a/pkg/explorer/elements/types.go
+++ b/pkg/explorer/elements/types.go
@@ -90,6 +90,48 @@ func (t *tx) Confirmed() bool {
 	return t.TxConfirmed
 }
 
+type txStatus struct {
+	confirmed   bool
+	blockHash   string
+	blockHeight int
+	blockTime   int
+}
+
+func newUnconfirmedTxStatus() explorer.TransactionStatus {
+	return &txStatus{
+		confirmed:   false,
+		blockHeight: -1,
+		blockTime:   -1,
+	}
+}
+
+func newConfirmedTxStatus(
+	blockHash string, blockHeight, blockTime int,
+) explorer.TransactionStatus {
+	return &txStatus{
+		confirmed:   true,
+		blockHash:   blockHash,
+		blockHeight: blockHeight,
+		blockTime:   blockTime,
+	}
+}
+
+func (s txStatus) Confirmed() bool {
+	return s.confirmed
+}
+
+func (s txStatus) BlockHash() string {
+	return s.blockHash
+}
+
+func (s txStatus) BlockHeight() int {
+	return s.blockHeight
+}
+
+func (s txStatus) BlockTime() int {
+	return s.blockTime
+}
+
 type elementsUnspent struct {
 	UAddress          string  `json:"address,omitempty"`
 	ULabel            string  `json:"label,omitempty"`

--- a/pkg/explorer/elements/unspents.go
+++ b/pkg/explorer/elements/unspents.go
@@ -92,10 +92,8 @@ func (e *elements) GetUnspentsForAddresses(
 	return e.toUtxos(unspents)
 }
 
-func (e *elements) GetUnspentStatus(
-	hash string, index uint32,
-) (*explorer.UtxoStatus, error) {
-	return nil, fmt.Errorf("not implemeneted")
+func (e *elements) GetUnspentStatus(txid string, index uint32) (explorer.UtxoStatus, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 type utxoResult struct {

--- a/pkg/explorer/elements/unspents.go
+++ b/pkg/explorer/elements/unspents.go
@@ -92,6 +92,12 @@ func (e *elements) GetUnspentsForAddresses(
 	return e.toUtxos(unspents)
 }
 
+func (e *elements) GetUnspentStatus(
+	hash string, index uint32,
+) (*explorer.UtxoStatus, error) {
+	return nil, fmt.Errorf("not implemeneted")
+}
+
 type utxoResult struct {
 	utxo explorer.Utxo
 	err  error

--- a/pkg/explorer/esplora/transaction.go
+++ b/pkg/explorer/esplora/transaction.go
@@ -30,7 +30,9 @@ func (e *esplora) IsTransactionConfirmed(hash string) (bool, error) {
 	return e.isTransactionConfirmed(hash)
 }
 
-func (e *esplora) GetTransactionStatus(hash string) (map[string]interface{}, error) {
+func (e *esplora) GetTransactionStatus(
+	hash string,
+) (explorer.TransactionStatus, error) {
 	return e.getTransactionStatus(hash)
 }
 
@@ -136,21 +138,16 @@ func (e *esplora) getTransactionHex(hash string) (string, error) {
 }
 
 func (e *esplora) isTransactionConfirmed(hash string) (bool, error) {
-	trxStatus, err := e.getTransactionStatus(hash)
+	status, err := e.getTransactionStatus(hash)
 	if err != nil {
 		return false, err
 	}
-
-	var isConfirmed bool
-	switch confirmed := trxStatus["confirmed"].(type) {
-	case bool:
-		isConfirmed = confirmed
-	}
-
-	return isConfirmed, nil
+	return status.Confirmed(), nil
 }
 
-func (e *esplora) getTransactionStatus(hash string) (map[string]interface{}, error) {
+func (e *esplora) getTransactionStatus(
+	hash string,
+) (explorer.TransactionStatus, error) {
 	url := fmt.Sprintf(
 		"%s/tx/%s/status",
 		e.apiURL,
@@ -164,13 +161,12 @@ func (e *esplora) getTransactionStatus(hash string) (map[string]interface{}, err
 		return nil, fmt.Errorf(resp)
 	}
 
-	var trxStatus map[string]interface{}
-	err = json.Unmarshal([]byte(resp), &trxStatus)
-	if err != nil {
+	var txStatus txStatus
+	if err := json.Unmarshal([]byte(resp), &txStatus); err != nil {
 		return nil, err
 	}
 
-	return trxStatus, nil
+	return txStatus, nil
 }
 
 type txResult struct {

--- a/pkg/explorer/esplora/transaction_test.go
+++ b/pkg/explorer/esplora/transaction_test.go
@@ -58,7 +58,10 @@ func TestGetTransactionStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, trxStatus["confirmed"], true)
+	assert.Equal(t, trxStatus.Confirmed(), true)
+	assert.Equal(t, len(trxStatus.BlockHash()) > 0, true)
+	assert.Equal(t, trxStatus.BlockHeight(), true)
+	assert.Equal(t, trxStatus.BlockTime(), true)
 
 	isConfirmed, err := explorerSvc.IsTransactionConfirmed(txID)
 	if err != nil {

--- a/pkg/explorer/esplora/types.go
+++ b/pkg/explorer/esplora/types.go
@@ -84,6 +84,57 @@ func (t *tx) Confirmed() bool {
 	return t.TxConfirmed
 }
 
+// txStatus implements explorer.TransactionStatus interface
+type txStatus map[string]interface{}
+
+func (s txStatus) Confirmed() bool {
+	iConfirmed := s["confirmed"]
+	if iConfirmed == nil {
+		return false
+	}
+	confirmed, ok := iConfirmed.(bool)
+	if !ok {
+		return false
+	}
+	return confirmed
+}
+
+func (s txStatus) BlockHash() string {
+	iBlockHash := s["block_hash"]
+	if iBlockHash == nil {
+		return ""
+	}
+	blockHash, ok := iBlockHash.(string)
+	if !ok {
+		return ""
+	}
+	return blockHash
+}
+
+func (s txStatus) BlockHeight() int {
+	iBlockHeight := s["block_height"]
+	if iBlockHeight == nil {
+		return -1
+	}
+	blockHeight, ok := iBlockHeight.(float64)
+	if !ok {
+		return -1
+	}
+	return int(blockHeight)
+}
+
+func (s txStatus) BlockTime() int {
+	iBlockTime := s["block_time"]
+	if iBlockTime == nil {
+		return -1
+	}
+	blockTime, ok := iBlockTime.(float64)
+	if !ok {
+		return -1
+	}
+	return int(blockTime)
+}
+
 func parseInput(i interface{}) *transaction.TxInput {
 	m := i.(map[string]interface{})
 
@@ -327,4 +378,43 @@ func (wu witnessUtxo) Parse() (*transaction.TxInput, *transaction.TxOutput, erro
 	}
 
 	return input, witnessUtxo, nil
+}
+
+// utxoStatus implements explorer.UtxoStatus interface
+type utxoStatus map[string]interface{}
+
+func (s utxoStatus) Spent() bool {
+	iSpent := s["spent"]
+	if iSpent == nil {
+		return false
+	}
+	spent, ok := iSpent.(bool)
+	if !ok {
+		return false
+	}
+	return spent
+}
+
+func (s utxoStatus) Hash() string {
+	iHash := s["txid"]
+	if iHash == nil {
+		return ""
+	}
+	hash, ok := iHash.(string)
+	if !ok {
+		return ""
+	}
+	return hash
+}
+
+func (s utxoStatus) Index() int {
+	iIndex := s["vin"]
+	if iIndex == nil {
+		return -1
+	}
+	index, ok := iIndex.(float64)
+	if !ok {
+		return -1
+	}
+	return int(index)
 }

--- a/pkg/explorer/esplora/unspents.go
+++ b/pkg/explorer/esplora/unspents.go
@@ -54,37 +54,22 @@ func (e *esplora) GetUnspentsForAddresses(
 }
 
 func (e *esplora) GetUnspentStatus(
-	hash string, index uint32,
-) (*explorer.UtxoStatus, error) {
-	url := fmt.Sprintf("%s/tx/%s/outspend/%d", e.apiURL, hash, index)
+	txid string, index uint32,
+) (explorer.UtxoStatus, error) {
+	url := fmt.Sprintf("%s/tx/%s/outspend/%d", e.apiURL, txid, index)
 	status, resp, err := e.client.NewHTTPRequest("GET", url, "", nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error on retrieving unspent status: %s", err)
 	}
 	if status != http.StatusOK {
 		return nil, fmt.Errorf(resp)
 	}
 
-	var utxoStatus map[string]interface{}
-	if err := json.Unmarshal([]byte(resp), &utxoStatus); err != nil {
-		return nil, fmt.Errorf("error on retrieving utxo status: %s", err)
+	unspentStatus := utxoStatus{}
+	if err := json.Unmarshal([]byte(resp), &unspentStatus); err != nil {
+		return nil, fmt.Errorf("error on parsing unspent status: %s", err)
 	}
-
-	spent := utxoStatus["spent"].(bool)
-	txHash := ""
-	if hash, ok := utxoStatus["txid"]; ok {
-		txHash = hash.(string)
-	}
-	txInIndex := -1
-	if index, ok := utxoStatus["vin"]; ok {
-		txInIndex = int(index.(float64))
-	}
-
-	return &explorer.UtxoStatus{
-		Spent:        spent,
-		TxHash:       txHash,
-		TxInputIndex: txInIndex,
-	}, nil
+	return unspentStatus, nil
 }
 
 type utxoResult struct {
@@ -104,7 +89,7 @@ func (e *esplora) getUtxos(addr string, blindingKeys [][]byte) ([]explorer.Utxo,
 
 	var witnessOuts []witnessUtxo
 	if err := json.Unmarshal([]byte(resp), &witnessOuts); err != nil {
-		return nil, fmt.Errorf("error on retrieving utxos: %s", err)
+		return nil, fmt.Errorf("error on parsing utxos: %s", err)
 	}
 
 	utxos := make([]explorer.Utxo, 0, len(witnessOuts))

--- a/pkg/explorer/esplora/unspents_test.go
+++ b/pkg/explorer/esplora/unspents_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
 	"github.com/vulpemventures/go-elements/network"
 	"github.com/vulpemventures/go-elements/payment"
@@ -36,13 +37,18 @@ func TestGetUnspents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 1, len(utxos))
+	require.Equal(t, 1, len(utxos))
 
-	if len(utxos) > 0 {
-		assert.Equal(t, true, len(utxos[0].Nonce()) > 1)
-		assert.Equal(t, true, len(utxos[0].RangeProof()) > 0)
-		assert.Equal(t, true, len(utxos[0].SurjectionProof()) > 0)
-	}
+	utxo := utxos[0]
+	require.Equal(t, true, len(utxo.Nonce()) > 1)
+	require.Equal(t, true, len(utxo.RangeProof()) > 0)
+	require.Equal(t, true, len(utxo.SurjectionProof()) > 0)
+
+	status, err := explorerSvc.GetUnspentStatus(utxo.Hash(), utxo.Index())
+	require.NoError(t, err)
+	require.False(t, status.Spent)
+	require.Empty(t, status.TxHash)
+	require.Equal(t, -1, status.TxInputIndex)
 }
 
 func TestSelectUnspents(t *testing.T) {

--- a/pkg/explorer/explorer.go
+++ b/pkg/explorer/explorer.go
@@ -24,6 +24,14 @@ type Utxo interface {
 	Parse() (*transaction.TxInput, *transaction.TxOutput, error)
 }
 
+// UtxoStatus represents the status of an Utxo whether it is spent, and if true
+// the hash of the spending transaction and the input index.
+type UtxoStatus struct {
+	Spent        bool
+	TxHash       string
+	TxInputIndex int
+}
+
 // Transaction represents a transaction in the elements chain.
 type Transaction interface {
 	Hash() string
@@ -48,6 +56,9 @@ type Service interface {
 		addresses []string,
 		blindingKeys [][]byte,
 	) (unspents []Utxo, err error)
+	// GetUnspentStatus returns the status of the given utxo identified by its
+	// hash and index.
+	GetUnspentStatus(hash string, index uint32) (*UtxoStatus, error)
 	// GetTransaction fetches the transaction given its hash.
 	GetTransaction(txid string) (tx Transaction, err error)
 	// GetTransactionHex fetches the transaction in hex format given its hash.

--- a/pkg/explorer/explorer.go
+++ b/pkg/explorer/explorer.go
@@ -24,12 +24,12 @@ type Utxo interface {
 	Parse() (*transaction.TxInput, *transaction.TxOutput, error)
 }
 
-// UtxoStatus represents the status of an Utxo whether it is spent, and if true
-// the hash of the spending transaction and the input index.
-type UtxoStatus struct {
-	Spent        bool
-	TxHash       string
-	TxInputIndex int
+// UtxoStatus represents whether a UTXO is spent. If it's actually spent,
+// it provides methods to know the hash and input index of the tx that spent it.
+type UtxoStatus interface {
+	Spent() bool
+	Hash() string
+	Index() int
 }
 
 // Transaction represents a transaction in the elements chain.
@@ -44,6 +44,13 @@ type Transaction interface {
 	Confirmed() bool
 }
 
+type TransactionStatus interface {
+	Confirmed() bool
+	BlockHash() string
+	BlockHeight() int
+	BlockTime() int
+}
+
 // Service is representation of an explorer that allows to fetch data from the
 // blockchain, to broadcast transactions, and for regtest ONLY, to fund and
 // and address with LBTC or some other asset.
@@ -56,9 +63,8 @@ type Service interface {
 		addresses []string,
 		blindingKeys [][]byte,
 	) (unspents []Utxo, err error)
-	// GetUnspentStatus returns the status of the given utxo identified by its
-	// hash and index.
-	GetUnspentStatus(hash string, index uint32) (*UtxoStatus, error)
+	// GetUnspentStatus returns the status of the provided unspent txid:index.
+	GetUnspentStatus(txid string, index uint32) (status UtxoStatus, err error)
 	// GetTransaction fetches the transaction given its hash.
 	GetTransaction(txid string) (tx Transaction, err error)
 	// GetTransactionHex fetches the transaction in hex format given its hash.
@@ -67,7 +73,7 @@ type Service interface {
 	// been included in the blockchain.
 	IsTransactionConfirmed(txid string) (confirmed bool, err error)
 	// GetTransactionStatus returns the status of the tx identified by its hash.
-	GetTransactionStatus(txid string) (status map[string]interface{}, err error)
+	GetTransactionStatus(txid string) (status TransactionStatus, err error)
 	// GetTransactionsForAddress returns the list of all txs relative to the
 	// given address.
 	GetTransactionsForAddress(address string, blindingKey []byte) (txs []Transaction, err error)


### PR DESCRIPTION
## Overwiew

Before this, after a proposal was accepted, the daemon would have started watching for the id extracted from the related partial trasaction. This is fine only for "full" native-segwit transactions where the hash of the tx doesn't change before and after it being singed. Unfortunately, as well known, this doesn't hold in case the tx included wrapped-segwit or legacy inputs.

For this reason, this adds the required changes to make the daemon watching for single outpoints, or the inputs of the spending tx, and now acquires the txid from the blockchain instead of applying the logic described above.

## Explorer

It was necessary to add a new [method](https://github.com/altafan/tdex-daemon/blob/observe-utxo/pkg/explorer/explorer.go#L67) to the explorer interface (and related implementations) to get the status of some utxo.
This status is represented by an [interface](https://github.com/altafan/tdex-daemon/blob/observe-utxo/pkg/explorer/explorer.go#L29) and the same has been done for the returned value of the already existing  [GetTransactionStatus](https://github.com/altafan/tdex-daemon/blob/observe-utxo/pkg/explorer/explorer.go#L47) for consistency and clean programming.

## Crawler

This package has been refactored a bit:
* the observable handler type and its functions have been exported to make it possible to unit-test all kind of observable and checking the event/error they eventually emit.
* AddressObservable has been decoupled from the core's internal Vault domain. The original AccountIndex field has been replace by a general `ExtraData` interface returned in the event emitted.
* A new type `OutpointsObservable` has been added useful to observe the status of a group of outpoints, all used as inputs of the same transacton. This observable emits events in case the outpoints have not yet been spent, or if they've been spent and the tx is in mempool, or if they've been spent and the tx is in blockchain.

## Trade Service

This service now instructs the bc listener to watch for outpoints instead of transactions.

## Blockchain Listener

Added support for adding/removing OutpointsObservables and to handle events they possibly emit: in case the outpoints have been spent but the tx is not yet confirmed, its outs are added as new unconfirmed utxos to the repo, while its ins are marked as SPENT; when the tx is confirmed the new utxos get confirmed as well in the repo. Only in case the spending tx is confirmed the trade gets settled and the topic pushed in the pubsub service.

## Bonus
* Settlement timestamp and date added to the TRADE_SETTLED event payload
* Updated jwt lib to the new path


This closes #389.
This closes #369.

Please @tiero review this.


