### PR TITLE
[pkg(macaroons] Allow disabling TLS

### DIFF
--- a/cmd/tdex/main.go
+++ b/cmd/tdex/main.go
@@ -263,7 +263,7 @@ func getClientConn(skipMacaroon bool) (*grpc.ClientConn, error) {
 			if err := mac.UnmarshalBinary(macBytes); err != nil {
 				return nil, fmt.Errorf("could not parse macaroon %s: %s", macPath, err)
 			}
-			macCreds := macaroons.NewMacaroonCredential(mac)
+			macCreds := macaroons.NewMacaroonCredential(mac, true)
 			opts = append(opts, grpc.WithPerRPCCredentials(macCreds))
 		}
 	}

--- a/pkg/macaroons/auth.go
+++ b/pkg/macaroons/auth.go
@@ -11,11 +11,12 @@ import (
 // credentials.PerRPCCredentials interface.
 type MacaroonCredential struct {
 	*macaroon.Macaroon
+	withTLS bool
 }
 
 // RequireTransportSecurity implements the PerRPCCredentials interface.
 func (m MacaroonCredential) RequireTransportSecurity() bool {
-	return true
+	return m.withTLS
 }
 
 // GetRequestMetadata implements the PerRPCCredentials interface. This method
@@ -38,8 +39,9 @@ func (m MacaroonCredential) GetRequestMetadata(
 
 // NewMacaroonCredential returns a copy of the passed macaroon wrapped in a
 // MacaroonCredential struct which implements PerRPCCredentials.
-func NewMacaroonCredential(m *macaroon.Macaroon) MacaroonCredential {
+func NewMacaroonCredential(m *macaroon.Macaroon, withTLS bool) MacaroonCredential {
 	ms := MacaroonCredential{}
 	ms.Macaroon = m.Clone()
+	ms.withTLS = withTLS
 	return ms
 }


### PR DESCRIPTION
Before this, the requirements for transport security of macaroons' credential was hardcoded (`true` value).
This, instead, makes it possible to disable TLS at will.

This closes #405 

Please @tiero review this.