### PR TITLE
Check fee/market low balances & publish topic on pubsub

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -120,6 +120,7 @@ func main() {
 		tradesExpiryDurationInSeconds,
 		pricesSlippagePercentage,
 		network,
+		feeThreshold,
 	)
 	operatorSvc := application.NewOperatorService(
 		repoManager,

--- a/internal/core/application/errors.go
+++ b/internal/core/application/errors.go
@@ -29,12 +29,9 @@ var (
 	// ErrInvalidActionType is returned if the attempting to register a webhook
 	// for an invalid action type.
 	ErrInvalidActionType = errors.New("action type is unknown")
-	// ErrMarketBaseBalanceTooLow is returned when the balance of the base asset
-	// of a market is below 0.
-	ErrMarketBaseBalanceTooLow = errors.New("market base balance is too low")
-	// ErrMarketQuoteBalanceTooLow is returned when the balance of the quote asset
-	// of a market is below 0.
-	ErrMarketQuoteBalanceTooLow = errors.New("market quote balance is too low")
+	// ErrMarketBalanceTooLow is returned when the balance of the base or quote
+	// asset of a market is below its fixed fee.
+	ErrMarketBalanceTooLow = errors.New("market base or quote balance too low")
 	// ErrWithdrawBaseAmountTooBig is returned when attempting to withdraw more
 	// than the total amount of base asset of a market.
 	ErrWithdrawBaseAmountTooBig = errors.New(

--- a/internal/core/application/pubsub_utils.go
+++ b/internal/core/application/pubsub_utils.go
@@ -1,0 +1,118 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tdex-network/tdex-daemon/internal/core/domain"
+	"github.com/tdex-network/tdex-daemon/internal/core/ports"
+)
+
+// checkFeeAndMarketBalances helper to check for low balances for fee and
+// market accounts and to publish AccountLowBalance topic on pubsub just in case.
+func checkFeeAndMarketBalances(
+	repoManager ports.RepoManager, pubsub ports.SecurePubSub,
+	ctx context.Context, mkt *domain.Market, lbtcAsset string, feeThreshold uint64,
+) {
+	// Get balance including locked unspents.
+	feeBalance, err := getBalanceForFee(repoManager, ctx, lbtcAsset, false)
+	if err == nil && feeBalance <= feeThreshold {
+		account := map[string]interface{}{
+			"type":  "fee",
+			"index": domain.FeeAccount,
+		}
+		if err := publishAccountLowBalanceTopic(
+			pubsub, account, feeBalance,
+		); err != nil {
+			log.Warn(err)
+		}
+	}
+
+	// Get balance including locked unspents.
+	mktBalance, err := getBalanceForMarket(repoManager, ctx, mkt, false)
+	if err == nil {
+		lowBalance := mktBalance.BaseAmount <= uint64(mkt.FixedFee.BaseFee) ||
+			mktBalance.QuoteAmount <= uint64(mkt.FixedFee.QuoteFee)
+		if lowBalance {
+			account := map[string]interface{}{
+				"type":        "market",
+				"base_asset":  mkt.BaseAsset,
+				"quote_asset": mkt.QuoteAsset,
+				"index":       mkt.AccountIndex,
+			}
+			if err := publishAccountLowBalanceTopic(
+				pubsub, account, mktBalance,
+			); err != nil {
+				log.Warn(err)
+			}
+		}
+	}
+}
+
+// publishAccountLowBalanceTopic helper to publish an AccountLowBalance topic
+// on the given pubsub service.
+func publishAccountLowBalanceTopic(
+	pubsub ports.SecurePubSub, account, balance interface{},
+) error {
+	if pubsub == nil {
+		return nil
+	}
+
+	topics := pubsub.TopicsByCode()
+	topic := topics[AccountLowBalance]
+	payload := map[string]interface{}{
+		"account": account,
+		"balance": balance,
+	}
+	message, _ := json.Marshal(payload)
+
+	if err := pubsub.Publish(topic.Label(), string(message)); err != nil {
+		return fmt.Errorf(
+			"an error occured while publishing message for topic %s: %s",
+			topic.Label(), err,
+		)
+	}
+	return nil
+}
+
+func publishAccountWithdrawTopic(
+	pubsub ports.SecurePubSub,
+	mkt Market, mktBalance, withdrewBalance Balance,
+	destAddress, txid string,
+) error {
+	if pubsub == nil {
+		return nil
+	}
+
+	baseBalance := mktBalance.BaseAmount - withdrewBalance.BaseAmount
+	quoteBalance := mktBalance.QuoteAmount - withdrewBalance.QuoteAmount
+
+	payload := map[string]interface{}{
+		"market": map[string]string{
+			"base_asset":  mkt.BaseAsset,
+			"quote_asset": mkt.QuoteAsset,
+		},
+		"amount_withdraw": map[string]interface{}{
+			"base_amount":  withdrewBalance.BaseAmount,
+			"quote_amount": withdrewBalance.QuoteAmount,
+		},
+		"receiving_address": destAddress,
+		"txid":              txid,
+		"balance": map[string]uint64{
+			"base_balance":  baseBalance,
+			"quote_balance": quoteBalance,
+		},
+	}
+	message, _ := json.Marshal(payload)
+	topics := pubsub.TopicsByCode()
+	topic := topics[AccountWithdraw]
+	if err := pubsub.Publish(topic.Label(), string(message)); err != nil {
+		log.WithError(err).Warnf(
+			"an error occured while publishing message for topic %s",
+			topic.Label(),
+		)
+	}
+	return nil
+}

--- a/internal/core/application/repo_utils.go
+++ b/internal/core/application/repo_utils.go
@@ -1,0 +1,79 @@
+package application
+
+import (
+	"context"
+
+	"github.com/tdex-network/tdex-daemon/internal/core/domain"
+	"github.com/tdex-network/tdex-daemon/internal/core/ports"
+)
+
+// getUnlockedBalanceForMarket helper to get the available balance of a market
+// from the repositories of a repoManager.
+func getUnlockedBalanceForMarket(
+	repoManager ports.RepoManager, ctx context.Context, mkt *domain.Market,
+) (*Balance, error) {
+	return getBalanceForMarket(repoManager, ctx, mkt, true)
+}
+
+// getUnlockedBalanceForFee helper to get the available balance of the fee
+// account from the repositories of a repoManager.
+func getUnlockedBalanceForFee(
+	repoManager ports.RepoManager, ctx context.Context, lbtcAsset string,
+) (uint64, error) {
+	return getBalanceForFee(repoManager, ctx, lbtcAsset, true)
+}
+
+// getBalanceForMarket helper to get the balance or "unlocked" balance of a
+// market account.
+func getBalanceForMarket(
+	repoManager ports.RepoManager,
+	ctx context.Context, mkt *domain.Market, wantUnlocked bool,
+) (*Balance, error) {
+	info, err := repoManager.VaultRepository().
+		GetAllDerivedAddressesInfoForAccount(ctx, mkt.AccountIndex)
+	if err != nil {
+		return nil, err
+	}
+	addresses := info.Addresses()
+
+	getBalance := repoManager.UnspentRepository().GetBalance
+	if wantUnlocked {
+		getBalance = repoManager.UnspentRepository().GetUnlockedBalance
+	}
+
+	baseBalance, err := getBalance(ctx, addresses, mkt.BaseAsset)
+	if err != nil {
+		return nil, err
+	}
+
+	quoteBalance, err := getBalance(ctx, addresses, mkt.QuoteAsset)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Balance{
+		BaseAmount:  baseBalance,
+		QuoteAmount: quoteBalance,
+	}, nil
+}
+
+// getBalanceForFee helper to get the balance or "unlocked" balance of the fee
+// account.
+func getBalanceForFee(
+	repoManager ports.RepoManager,
+	ctx context.Context, lbtcAsset string, wantUnlocked bool,
+) (uint64, error) {
+	info, err := repoManager.VaultRepository().
+		GetAllDerivedAddressesInfoForAccount(ctx, domain.FeeAccount)
+	if err != nil {
+		return 0, err
+	}
+	addresses := info.Addresses()
+
+	getBalance := repoManager.UnspentRepository().GetBalance
+	if wantUnlocked {
+		getBalance = repoManager.UnspentRepository().GetUnlockedBalance
+	}
+
+	return getBalance(ctx, addresses, lbtcAsset)
+}

--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -47,13 +47,14 @@ type TradeService interface {
 }
 
 type tradeService struct {
-	repoManager        ports.RepoManager
-	explorerSvc        explorer.Service
-	blockchainListener BlockchainListener
-	marketBaseAsset    string
-	expiryDuration     time.Duration
-	priceSlippage      decimal.Decimal
-	network            *network.Network
+	repoManager                ports.RepoManager
+	explorerSvc                explorer.Service
+	blockchainListener         BlockchainListener
+	marketBaseAsset            string
+	expiryDuration             time.Duration
+	priceSlippage              decimal.Decimal
+	network                    *network.Network
+	feeAccountBalanceThreshold uint64
 }
 
 func NewTradeService(
@@ -64,6 +65,7 @@ func NewTradeService(
 	expiryDuration time.Duration,
 	priceSlippage decimal.Decimal,
 	net *network.Network,
+	feeAccountBalanceThreshold uint64,
 ) TradeService {
 	return newTradeService(
 		repoManager,
@@ -73,6 +75,7 @@ func NewTradeService(
 		expiryDuration,
 		priceSlippage,
 		net,
+		feeAccountBalanceThreshold,
 	)
 }
 
@@ -84,15 +87,17 @@ func newTradeService(
 	expiryDuration time.Duration,
 	priceSlippage decimal.Decimal,
 	net *network.Network,
+	feeAccountBalanceThreshold uint64,
 ) *tradeService {
 	return &tradeService{
-		repoManager:        repoManager,
-		explorerSvc:        explorerSvc,
-		blockchainListener: bcListener,
-		marketBaseAsset:    marketBaseAsset,
-		expiryDuration:     expiryDuration,
-		priceSlippage:      priceSlippage,
-		network:            net,
+		repoManager:                repoManager,
+		explorerSvc:                explorerSvc,
+		blockchainListener:         bcListener,
+		marketBaseAsset:            marketBaseAsset,
+		expiryDuration:             expiryDuration,
+		priceSlippage:              priceSlippage,
+		network:                    net,
+		feeAccountBalanceThreshold: feeAccountBalanceThreshold,
 	}
 }
 
@@ -190,24 +195,12 @@ func (t *tradeService) GetMarketBalance(
 	market Market,
 ) (*BalanceWithFee, error) {
 	// check the asset strings
-	err := validateAssetString(market.BaseAsset)
-	if err != nil {
+	if err := validateAssetString(market.BaseAsset); err != nil {
 		return nil, domain.ErrMarketInvalidBaseAsset
 	}
 
-	err = validateAssetString(market.QuoteAsset)
-	if err != nil {
+	if err := validateAssetString(market.QuoteAsset); err != nil {
 		return nil, domain.ErrMarketInvalidQuoteAsset
-	}
-
-	vault, err := t.repoManager.VaultRepository().GetOrCreateVault(ctx, nil, "", nil)
-	if err != nil {
-		log.Debugf("error while retrieving vault: %s", err)
-		return nil, ErrServiceUnavailable
-	}
-	if vault.IsLocked() {
-		log.Debug("vault is locked")
-		return nil, ErrServiceUnavailable
 	}
 
 	m, accountIndex, err := t.repoManager.MarketRepository().GetMarketByAsset(
@@ -215,45 +208,21 @@ func (t *tradeService) GetMarketBalance(
 		market.QuoteAsset,
 	)
 	if err != nil {
-		log.Debugf("error while retrieving market: %s", err)
+		log.WithError(err).Debug("error while retrieving market")
 		return nil, ErrServiceUnavailable
 	}
 	if accountIndex < 0 {
 		return nil, ErrMarketNotExist
 	}
 
-	info, err := vault.AllDerivedAddressesInfoForAccount(m.AccountIndex)
+	balance, err := getUnlockedBalanceForMarket(t.repoManager, ctx, m)
 	if err != nil {
-		log.Debugf("error while retrieving addresses: %s", err)
-		return nil, ErrServiceUnavailable
-	}
-	marketAddresses := info.Addresses()
-
-	baseAssetBalance, err := t.repoManager.UnspentRepository().GetBalance(
-		ctx,
-		marketAddresses,
-		m.BaseAsset,
-	)
-	if err != nil {
-		log.Debugf("error while retrieving base asset balance: %s", err)
-		return nil, ErrServiceUnavailable
-	}
-
-	quoteAssetBalance, err := t.repoManager.UnspentRepository().GetBalance(
-		ctx,
-		marketAddresses,
-		m.QuoteAsset,
-	)
-	if err != nil {
-		log.Debugf("error while retrieving quote asset balance: %s", err)
+		log.WithError(err).Debug("error while retrieving balance")
 		return nil, ErrServiceUnavailable
 	}
 
 	return &BalanceWithFee{
-		Balance: Balance{
-			BaseAmount:  baseAssetBalance,
-			QuoteAmount: quoteAssetBalance,
-		},
+		Balance: *balance,
 		Fee: Fee{
 			BasisPoint:    m.Fee,
 			FixedBaseFee:  m.FixedFee.BaseFee,
@@ -297,6 +266,14 @@ func (t *tradeService) TradePropose(
 	if marketAccountIndex < 0 {
 		return nil, nil, 0, ErrMarketNotExist
 	}
+
+	// Eventually, check fee and market accounts to notify for low balances.
+	defer func() {
+		go checkFeeAndMarketBalances(
+			t.repoManager, t.blockchainListener.PubSubService(),
+			ctx, mkt, t.network.AssetID, t.feeAccountBalanceThreshold,
+		)
+	}()
 
 	// get all unspents for market account (both as []domain.Unspents and as
 	// []explorer.Utxo)along with private blinding keys and signing derivation
@@ -381,8 +358,9 @@ func (t *tradeService) TradePropose(
 		trade.Fail(
 			swapRequest.GetId(),
 			int(pkgswap.ErrCodeRejectedSwapRequest),
-			err.Error(),
+			"internal error",
 		)
+		log.WithError(err).Infof("trade with id %s rejected", trade.ID)
 		swapFail = trade.SwapFailMessage()
 		goto end
 	}
@@ -394,6 +372,7 @@ func (t *tradeService) TradePropose(
 		uint64(t.expiryDuration.Seconds()),
 	); !ok {
 		swapFail = trade.SwapFailMessage()
+		log.Infof("trade with id %s rejected", trade.ID)
 		goto end
 	}
 
@@ -420,8 +399,8 @@ end:
 			time.Sleep(t.expiryDuration + time.Minute)
 			t.checkTradeExpiration(trade.TxID, selectedUnspentKeys)
 		}()
-	} else {
-		log.WithField("reason", swapFail.GetFailureMessage()).Infof("trade with id %s rejected", trade.ID)
+
+		t.blockchainListener.StartObserveTx(trade.TxID)
 	}
 
 	go func() {
@@ -449,10 +428,6 @@ end:
 			},
 		); err != nil {
 			log.WithError(err).Warn("unable to persist changes after trade is accepted")
-		}
-
-		if swapAccept != nil {
-			t.blockchainListener.StartObserveTx(trade.TxID)
 		}
 	}()
 

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -274,6 +274,7 @@ func newTradeService(withFixedFee bool) (application.TradeService, error) {
 		tradeExpiryDuration,
 		tradePriceSlippage,
 		regtest,
+		feeBalanceThreshold,
 	), nil
 }
 

--- a/internal/core/application/walletunlocker_service.go
+++ b/internal/core/application/walletunlocker_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sony/gobreaker"
 	"github.com/tdex-network/tdex-daemon/internal/core/domain"
 	"github.com/tdex-network/tdex-daemon/internal/core/ports"
+	"github.com/tdex-network/tdex-daemon/pkg/circuitbreaker"
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
 	"github.com/tdex-network/tdex-daemon/pkg/wallet"
 	"github.com/vulpemventures/go-elements/network"
@@ -647,7 +648,7 @@ func (w *walletUnlockerService) restoreUnspents(
 ) ([]domain.Unspent, error) {
 	chUnspentsInfo := make(chan unspentInfo)
 	unspents := make([]domain.Unspent, 0)
-	cb := newCircuitBreaker()
+	cb := circuitbreaker.NewCircuitBreaker()
 	wg := &sync.WaitGroup{}
 	wg.Add(len(info))
 
@@ -791,7 +792,7 @@ func fetchUnspents(
 	if len(info) <= 0 {
 		return nil, nil
 	}
-	cb := newCircuitBreaker()
+	cb := circuitbreaker.NewCircuitBreaker()
 
 	iUtxos, err := cb.Execute(func() (interface{}, error) {
 		return explorerSvc.GetUnspentsForAddresses(info.AddressesAndKeys())
@@ -958,25 +959,4 @@ func extractUnspentsFromTxAndUpdateUtxoSet(
 	}
 	addUnspentsAsync(unspentRepo, unspentsToAdd)
 	spendUnspentsAsync(unspentRepo, unspentsToSpend)
-}
-
-func newCircuitBreaker() *gobreaker.CircuitBreaker {
-	return gobreaker.NewCircuitBreaker(gobreaker.Settings{
-		Name: "explorer",
-		ReadyToTrip: func(counts gobreaker.Counts) bool {
-			failureRatio := float64(counts.TotalFailures) / float64(counts.Requests)
-			return counts.Requests > 20 && failureRatio >= 0.7
-		},
-		OnStateChange: func(name string, from, to gobreaker.State) {
-			if to == gobreaker.StateOpen {
-				log.Warn("explorer seems down, stop allowing requests")
-			}
-			if from == gobreaker.StateOpen && to == gobreaker.StateHalfOpen {
-				log.Info("checking explorer status")
-			}
-			if from == gobreaker.StateHalfOpen && to == gobreaker.StateClosed {
-				log.Info("explorer seems ok, restart allowing requests")
-			}
-		},
-	})
 }


### PR DESCRIPTION
Before this, the daemon wasn't "watching" for fee/market balances anymore (it used to do that with the help of the blockchain listener for versions prior to v0.3.0).

This makes the daemon checking balances whenever a trade proposal is handled or a market withdrawal is performed and the check is made over the balances including also locked unspents.

The fee account is in "low balance state" when the sum of its unspents' amount is equal or below the configurable FeeBalanceThreshold, while for a market it means that its base or quote balances are equal or below the respective fixed fee. In case the market fixed fee is not set, then the balance is low if one or both of them are equal to 0.

It's important to note that these checks are deferred: this means that for the fee account, even if its balance is below the threshold, a trade/withdrawal might succeed if fees are covered, while for a market account, it purely depends on the amounts of the trade/withdrawal and an error would be returned in case of invalid operation.

The idea is that whenever balances are low, an external entity gets notified and theorically does something to prevent other trades/withdrawals to be performed until the account is refunded.

The payloads sent through the pubsub service are:
* fee account:
```json
{
   "account": {
      "type": "fee",
      "index": 0
   },
   "balance": <lbtc_asset_balance>
}
```
* market account:
```json
{
   "account": {
      "type": "market",
      "base_asset": "<base_asset_hash>",
      "quote_asset": "<quote_asset_hash>",
      "index": <account_index>
   },
   "balance": {
      "base_amount": <base_asset_balance>,
      "quote_amount": <quote_asset_balance>
   }
}
```

BONUS: In case the daemon fails to fill a valid trade proposal, a generic `internal error` message is returned to the counter-party and the real error is logged on stdout instead of being returned. 

This closes #365.

Please @tiero review this.