### PR TITLE
 WithdrawMarket RPC: use BlindTransactionWithData in sendToMany

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/timshannon/badgerhold/v2 v2.0.0-20201016201833-94bc303c76d4
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/vulpemventures/go-bip39 v1.0.2
-	github.com/vulpemventures/go-elements v0.2.1-0.20210409173614-5b1acc1d1e95
+	github.com/vulpemventures/go-elements v0.3.3-0.20210906091437-98e11643c7e0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/go.sum
+++ b/go.sum
@@ -366,10 +366,11 @@ github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941/go.mod h
 github.com/vulpemventures/go-bip39 v1.0.2 h1:+BgKOVo04okKf1wA4Fhv8ccvql+qFyzVUdVJKkb48r0=
 github.com/vulpemventures/go-bip39 v1.0.2/go.mod h1:mjFmuv9D6BtANI6iscMmbHhmBOwjMCFfny3mxHnuDrk=
 github.com/vulpemventures/go-elements v0.1.1/go.mod h1:OtH2q9NiwybzT9X0AWvkNY+sbxy3okD+vC9oAu5hWhE=
-github.com/vulpemventures/go-elements v0.2.1-0.20210409173614-5b1acc1d1e95 h1:k/5gNh2T0+iGup0oWk7K3G80Xdcll7bmjcCvFa9JvZ8=
-github.com/vulpemventures/go-elements v0.2.1-0.20210409173614-5b1acc1d1e95/go.mod h1:O5QYFgeOmfSPX3shsV+lvEotvzcDFtLoYY0jjdT+sVw=
-github.com/vulpemventures/go-secp256k1-zkp v1.1.0 h1:Z3qKc/lYxEQ1cukwwjD4n7EBCrg7N6of4hylVsD+lOA=
+github.com/vulpemventures/go-elements v0.3.3-0.20210906091437-98e11643c7e0 h1:mO4BwDuxtG9KX3eBB6+ggX/WL98hwTYIcEHQw+VMf7c=
+github.com/vulpemventures/go-elements v0.3.3-0.20210906091437-98e11643c7e0/go.mod h1:dr2bb8ydLAfAdubX4zodvh/1/Pc1tseE/3U8/d+oJhw=
 github.com/vulpemventures/go-secp256k1-zkp v1.1.0/go.mod h1:zo7CpgkuPgoe7fAV+inyxsI9IhGmcoFgyD8nqZaPSOM=
+github.com/vulpemventures/go-secp256k1-zkp v1.1.3 h1:Jy/OxkPYJYIFrwJkXr5vk86h9ObpqLR+3L5KHWX7Ah0=
+github.com/vulpemventures/go-secp256k1-zkp v1.1.3/go.mod h1:zo7CpgkuPgoe7fAV+inyxsI9IhGmcoFgyD8nqZaPSOM=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -419,6 +419,7 @@ func sendToMany(opts sendToManyOpts) (string, error) {
 			AssetBlinder:  v.AssetBlinder(),
 			AmountBlinder: v.ValueBlinder(),
 		}
+		index++
 	}
 
 	// again, add changes' blinding keys to the list of those of the outputs

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -381,6 +381,18 @@ func sendToMany(opts sendToManyOpts) (string, error) {
 		return "", err
 	}
 
+	inputBlindingData := make(map[int]wallet.BlindingData)
+	index := 0
+	for _, v := range updateResult.SelectedUnspents {
+		inputBlindingData[index] = wallet.BlindingData{
+			Asset:         v.Asset(),
+			Amount:        v.Value(),
+			AssetBlinder:  v.AssetBlinder(),
+			AmountBlinder: v.ValueBlinder(),
+		}
+		index++
+	}
+
 	// update the list of output blinding keys with those of the eventual changes
 	outputsBlindingKeys := opts.outputsBlindingKeys
 	for _, v := range updateResult.ChangeOutputsBlindingKeys {
@@ -400,16 +412,28 @@ func sendToMany(opts sendToManyOpts) (string, error) {
 		return "", err
 	}
 
+	for _, v := range feeUpdateResult.SelectedUnspents {
+		inputBlindingData[index] = wallet.BlindingData{
+			Asset:         v.Asset(),
+			Amount:        v.Value(),
+			AssetBlinder:  v.AssetBlinder(),
+			AmountBlinder: v.ValueBlinder(),
+		}
+	}
+
 	// again, add changes' blinding keys to the list of those of the outputs
 	for _, v := range feeUpdateResult.ChangeOutputsBlindingKeys {
 		outputsBlindingKeys = append(outputsBlindingKeys, v)
 	}
 
 	// blind the transaction
-	blindedPset, err := w.BlindTransactionWithKeys(wallet.BlindTransactionWithKeysOpts{
-		PsetBase64:         feeUpdateResult.PsetBase64,
-		OutputBlindingKeys: outputsBlindingKeys,
-	})
+	blindedPset, err := w.BlindTransactionWithData(
+		wallet.BlindTransactionWithDataOpts{
+			PsetBase64:         feeUpdateResult.PsetBase64,
+			InputBlindingData:  inputBlindingData,
+			OutputBlindingKeys: outputsBlindingKeys,
+		},
+	)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This updates private method sendToMany so that it uses BlindTransactionWithData instead BlindTransactionWithKeys since stored unspents dont holds proofs info(tnx @altafan for the advise)
It fixes issue with Withdraw bug endpoint.

This closes #409 

@tiero @altafan please review.