### PR TITLE
Persist unspents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -475,6 +475,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426080607-c94f62235c83 h1:kHSDPqCtsHZOg0nVylfTo20DDhE9gG4Y0jn7hKQ0QAM=
 golang.org/x/sys v0.0.0-20210426080607-c94f62235c83/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365 h1:6wSTsvPddg9gc/mVEEyk9oOAoxn+bT4Z9q1zx+4RwA4=
+golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -1150,9 +1150,9 @@ func (o *operatorService) claimDeposit(
 	// loop there MUST be only one counter matching the length of the give
 	// outpoints.
 	counter := make(map[int]int)
-	unspents := make([]domain.Unspent, len(outpoints), len(outpoints))
+	unspents := make([]domain.Unspent, 0, len(outpoints))
 	deposits := make([]domain.Deposit, 0, len(outpoints))
-	for i, v := range outpoints {
+	for _, v := range outpoints {
 		confirmed, err := o.explorerSvc.IsTransactionConfirmed(v.Hash)
 		if err != nil {
 			return err
@@ -1183,7 +1183,7 @@ func (o *operatorService) claimDeposit(
 				return errors.New("unable to unblind output")
 			}
 
-			unspents[i] = domain.Unspent{
+			unspents = append(unspents, domain.Unspent{
 				TxID:            v.Hash,
 				VOut:            uint32(v.Index),
 				Value:           unconfidential.Value,
@@ -1198,7 +1198,7 @@ func (o *operatorService) claimDeposit(
 				SurjectionProof: make([]byte, 1),
 				Address:         info.Address,
 				Confirmed:       true,
-			}
+			})
 
 			deposits = append(deposits, domain.Deposit{
 				AccountIndex: info.AccountIndex,

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -180,9 +180,9 @@ type WebhookInfo struct {
 type Unspents []domain.Unspent
 
 func (u Unspents) ToUtxos() []explorer.Utxo {
-	l := make([]explorer.Utxo, len(u), len(u))
+	l := make([]explorer.Utxo, 0, len(u))
 	for i := range u {
-		l[i] = u[i].ToUtxo()
+		l = append(l, u[i].ToUtxo())
 	}
 	return l
 }

--- a/internal/core/application/walletunlocker_service.go
+++ b/internal/core/application/walletunlocker_service.go
@@ -725,9 +725,9 @@ func (w *walletUnlockerService) restoreUnspentsForAddress(
 	}
 	utxos := iUtxos.([]explorer.Utxo)
 
-	unspents := make([]domain.Unspent, len(utxos), len(utxos))
-	for i, u := range utxos {
-		unspents[i] = domain.Unspent{
+	unspents := make([]domain.Unspent, 0, len(utxos))
+	for _, u := range utxos {
+		unspents = append(unspents, domain.Unspent{
 			TxID:            u.Hash(),
 			VOut:            u.Index(),
 			Value:           u.Value(),
@@ -742,7 +742,7 @@ func (w *walletUnlockerService) restoreUnspentsForAddress(
 			SurjectionProof: make([]byte, 1),
 			Confirmed:       u.IsConfirmed(),
 			Address:         addr,
-		}
+		})
 	}
 	chUnspent <- unspentInfo{info: info, unspents: unspents}
 }

--- a/internal/core/application/walletunlocker_service.go
+++ b/internal/core/application/walletunlocker_service.go
@@ -103,30 +103,37 @@ func newWalletUnlockerService(
 		pwChan:             make(chan PassphraseMsg, 1),
 		readyChan:          make(chan bool, 1),
 	}
+
 	// to understand if the service has an already initialized wallet we check
 	// if the inner vaultRepo is able to return a Vault without passing mnemonic
 	// and passphrase. If it does, it means it's been retrieved from storage,
 	// therefore we let the crawler to start watch all derived addresses and mark
 	// the wallet as initialized
+	ctx := context.Background()
 	if vault, err := w.repoManager.VaultRepository().GetOrCreateVault(
-		context.Background(), nil, "", nil,
+		ctx, nil, "", nil,
 	); err == nil {
 		go func() {
-			log.Info("Restoring internal wallet's utxo set. This could take a while...")
+			// check whether the whole internal UTXO set needs to be restored
+			unspents := w.repoManager.UnspentRepository().GetAllUnspents(ctx)
+			if len(unspents) > 0 {
+				w.setRestored(true)
+			} else {
+				log.Info("Restoring internal wallet's utxo set. This could take a while...")
 
-			info := vault.AllDerivedAddressesInfo()
-			if _, err := fetchAndAddUnspents(
-				w.explorerService,
-				w.repoManager.UnspentRepository(),
-				w.blockchainListener,
-				info,
-			); err != nil {
-				log.Infof("Failed for reason: %s", err)
-				w.setRestored(false)
-				return
+				if _, err := fetchAndAddUnspents(
+					w.explorerService,
+					w.repoManager.UnspentRepository(),
+					w.blockchainListener,
+					vault.AllDerivedAddressesInfo(),
+				); err != nil {
+					log.Infof("Failed for reason: %s", err)
+					w.setRestored(false)
+					return
+				}
+				log.Info("Done")
+				w.setRestored(true)
 			}
-			log.Info("Done")
-			w.setRestored(true)
 		}()
 		w.setInitialized(true)
 
@@ -179,13 +186,7 @@ func (w *walletUnlockerService) InitWallet(
 	}
 
 	if restore {
-		w.setSyncing(true)
 		log.Debug("restoring wallet")
-		start := time.Now()
-		defer func() {
-			elapsed := time.Since(start)
-			log.Debugf("Restoration took: %.2fs", elapsed.Seconds())
-		}()
 	} else {
 		log.Debug("creating wallet")
 	}
@@ -198,6 +199,15 @@ func (w *walletUnlockerService) InitWallet(
 	defer vault.Lock()
 
 	if restore {
+		w.setSyncing(true)
+		start := time.Now()
+		defer func() {
+			if w.isRestored() {
+				elapsed := time.Since(start)
+				log.Debugf("Restoration took: %.2fs", elapsed.Seconds())
+			}
+		}()
+
 		data := "addresses discovery"
 
 		chRes <- &InitWalletReply{

--- a/internal/core/application/walletunlocker_service.go
+++ b/internal/core/application/walletunlocker_service.go
@@ -119,7 +119,7 @@ func newWalletUnlockerService(
 			if len(unspents) > 0 {
 				w.setRestored(true)
 			} else {
-				log.Info("Restoring internal wallet's utxo set. This could take a while...")
+				log.Info("rescan internal wallet's utxo set. This could take a while...")
 
 				if _, err := fetchAndAddUnspents(
 					w.explorerService,
@@ -127,11 +127,11 @@ func newWalletUnlockerService(
 					w.blockchainListener,
 					vault.AllDerivedAddressesInfo(),
 				); err != nil {
-					log.Infof("Failed for reason: %s", err)
+					log.Infof("failed for reason: %s", err)
 					w.setRestored(false)
 					return
 				}
-				log.Info("Done")
+				log.Info("done")
 				w.setRestored(true)
 			}
 		}()

--- a/internal/core/domain/vault_model.go
+++ b/internal/core/domain/vault_model.go
@@ -42,19 +42,19 @@ type AddressInfo struct {
 type AddressesInfo []AddressInfo
 
 func (info AddressesInfo) Addresses() []string {
-	addresses := make([]string, len(info), len(info))
-	for i, in := range info {
-		addresses[i] = in.Address
+	addresses := make([]string, 0, len(info))
+	for _, in := range info {
+		addresses = append(addresses, in.Address)
 	}
 	return addresses
 }
 
 func (info AddressesInfo) AddressesAndKeys() ([]string, [][]byte) {
-	addresses := make([]string, len(info), len(info))
-	keys := make([][]byte, len(info), len(info))
-	for i, in := range info {
-		addresses[i] = in.Address
-		keys[i] = in.BlindingKey
+	addresses := make([]string, 0, len(info))
+	keys := make([][]byte, 0, len(info))
+	for _, in := range info {
+		addresses = append(addresses, in.Address)
+		keys = append(keys, in.BlindingKey)
 	}
 	return addresses, keys
 }

--- a/internal/infrastructure/storage/db/badger/db_manager.go
+++ b/internal/infrastructure/storage/db/badger/db_manager.go
@@ -35,10 +35,11 @@ type repoManager struct {
 // It creates a dedicated directory for main and prices stores, while the
 // unspent repository lives in memory.
 func NewRepoManager(baseDbDir string, logger badger.Logger) (ports.RepoManager, error) {
-	var maindbDir, pricedbDir string
+	var maindbDir, pricedbDir, unspentDir string
 	if len(baseDbDir) > 0 {
 		maindbDir = filepath.Join(baseDbDir, "main")
 		pricedbDir = filepath.Join(baseDbDir, "prices")
+		unspentDir = filepath.Join(baseDbDir, "unspents")
 	}
 
 	mainDb, err := createDb(maindbDir, logger)
@@ -51,7 +52,7 @@ func NewRepoManager(baseDbDir string, logger badger.Logger) (ports.RepoManager, 
 		return nil, fmt.Errorf("opening prices db: %w", err)
 	}
 
-	unspentDb, err := createDb("", logger)
+	unspentDb, err := createDb(unspentDir, logger)
 	if err != nil {
 		return nil, fmt.Errorf("opening unspents db: %w", err)
 	}

--- a/internal/infrastructure/storage/db/badger/trade_repository_impl.go
+++ b/internal/infrastructure/storage/db/badger/trade_repository_impl.go
@@ -161,10 +161,9 @@ func (t tradeRepositoryImpl) findTrades(
 		return nil, err
 	}
 
-	trades := make([]*domain.Trade, len(tr), len(tr))
-	for i := range tr {
-		trade := tr[i]
-		trades[i] = &trade
+	trades := make([]*domain.Trade, 0, len(tr))
+	for _, trade := range tr {
+		trades = append(trades, &trade)
 	}
 
 	return trades, nil

--- a/pkg/explorer/elements/unspents.go
+++ b/pkg/explorer/elements/unspents.go
@@ -52,13 +52,13 @@ func (e *elements) GetUnspentsForAddresses(
 	addresses []string,
 	blindingKeys [][]byte,
 ) ([]explorer.Utxo, error) {
-	sortedBlindingKeys := make([][]byte, len(addresses), len(addresses))
-	for i, addr := range addresses {
+	sortedBlindingKeys := make([][]byte, 0, len(addresses))
+	for _, addr := range addresses {
 		blindKey, err := findBlindKeyForAddress(addr, blindingKeys)
 		if err != nil {
 			return nil, fmt.Errorf("find key: %w", err)
 		}
-		sortedBlindingKeys[i] = blindKey
+		sortedBlindingKeys = append(sortedBlindingKeys, blindKey)
 	}
 
 	for i, addr := range addresses {

--- a/pkg/wallet/util.go
+++ b/pkg/wallet/util.go
@@ -162,7 +162,7 @@ func addInsAndOutsToPset(
 }
 
 func extractScriptTypesFromPset(ptx *pset.Pset) ([]int, []int, []int, []int, []int) {
-	inScriptTypes := make([]int, len(ptx.Inputs), len(ptx.Inputs))
+	inScriptTypes := make([]int, 0, len(ptx.Inputs))
 	inAuxiliaryRedeemScriptSize := make([]int, 0)
 	inAuxiliaryWitnessSize := make([]int, 0)
 	for i, in := range ptx.Inputs {
@@ -178,7 +178,7 @@ func extractScriptTypesFromPset(ptx *pset.Pset) ([]int, []int, []int, []int, []i
 		switch sType {
 		case address.P2ShScript:
 			if in.WitnessScript != nil {
-				inScriptTypes[i] = P2SH_P2WSH
+				inScriptTypes = append(inScriptTypes, P2SH_P2WSH)
 				// redeem script is treated as a multisig one. In case it's something
 				// different, it is treated as a singlesig instead.
 				m, _, _ := txscript.CalcMultiSigStats(in.RedeemScript)
@@ -191,42 +191,37 @@ func extractScriptTypesFromPset(ptx *pset.Pset) ([]int, []int, []int, []int, []i
 			} else if in.RedeemScript != nil {
 				inScriptTypes[i] = P2SH_P2WPKH
 			}
-			break
 		case address.P2WpkhScript:
-			inScriptTypes[i] = P2WPKH
-			break
+			inScriptTypes = append(inScriptTypes, P2WPKH)
 		case address.P2WshScript:
-			inScriptTypes[i] = P2WSH
+			inScriptTypes = append(inScriptTypes, P2WSH)
 			scriptSize := calcWitnessSizeFromRedeemScript(in.RedeemScript)
 			inAuxiliaryWitnessSize = append(inAuxiliaryWitnessSize, scriptSize)
-			break
 		case address.P2PkhScript:
-			inScriptTypes[i] = P2PKH
-			break
+			inScriptTypes = append(inScriptTypes, P2PKH)
 		case address.P2MultiSigScript:
-			inScriptTypes[i] = P2MS
+			inScriptTypes = append(inScriptTypes, P2MS)
 			scriptSize := calcWitnessSizeFromRedeemScript(in.RedeemScript)
 			inAuxiliaryRedeemScriptSize = append(inAuxiliaryRedeemScriptSize, scriptSize)
-			break
 		}
 	}
 
-	outScriptTypes := make([]int, len(ptx.Outputs), len(ptx.Outputs))
+	outScriptTypes := make([]int, 0, len(ptx.Outputs))
 	outAuxiliaryRedeemScriptSize := make([]int, 0)
-	for i, out := range ptx.UnsignedTx.Outputs {
+	for _, out := range ptx.UnsignedTx.Outputs {
 		sType := address.GetScriptType(out.Script)
 		switch sType {
 		case address.P2PkhScript:
-			outScriptTypes[i] = P2PKH
+			outScriptTypes = append(outScriptTypes, P2PKH)
 		case address.P2MultiSigScript:
-			outScriptTypes[i] = P2MS
+			outScriptTypes = append(outScriptTypes, P2MS)
 			scriptLen := len(out.Script)
 			scriptSize := varIntSerializeSize(uint64(scriptLen)) + scriptLen
 			outAuxiliaryRedeemScriptSize = append(outAuxiliaryRedeemScriptSize, scriptSize)
 		case address.P2WpkhScript:
-			outScriptTypes[i] = P2WPKH
+			outScriptTypes = append(outScriptTypes, P2WPKH)
 		case address.P2WshScript:
-			outScriptTypes[i] = P2WSH
+			outScriptTypes = append(outScriptTypes, P2WSH)
 		}
 	}
 


### PR DESCRIPTION
With this, the daemon will persist in a physical file into the datadir the entries of the unspent repository. For backward compatibility, at start time, if a wallet is found in the db, then if there are no unspents the daemon attempts to restore them like it was doing before this PR. Alternatively, it just signals that it is already restored and skip the process above.

This also fixes ALL slice initializations that were using assignment instead of concatenation.

This closes #411.
This closes #414.

Please @tiero, review this.