### PR TITLE
Fix fragmenter

### DIFF
--- a/cmd/tdex/fragmentmarket.go
+++ b/cmd/tdex/fragmentmarket.go
@@ -51,6 +51,10 @@ var fragmentmarket = cli.Command{
 			Name:  "recover_funds_to_address",
 			Usage: "specify an address where to send funds stuck into the fragmenter to",
 		},
+		&cli.BoolFlag{
+			Name:  "debug",
+			Usage: "print tx hex in case the transaction fails to be broadcasted",
+		},
 	},
 	Action: fragmentMarketAction,
 }
@@ -89,9 +93,10 @@ func fragmentMarketAction(ctx *cli.Context) error {
 	if baseAssetOpt == "" {
 		baseAssetOpt = net.AssetID
 	}
+	debug := ctx.Bool("debug")
 
 	if recoverAddress != "" {
-		return recoverFundsToAddress(net, walletType, recoverAddress)
+		return recoverFundsToAddress(net, walletType, recoverAddress, debug)
 	}
 
 	explorerSvc, err := getExplorerFromState()
@@ -197,6 +202,9 @@ func fragmentMarketAction(ctx *cli.Context) error {
 	log.Info("sending transaction...")
 	txID, err := explorerSvc.BroadcastTransaction(txHex)
 	if err != nil {
+		if debug {
+			log.Info("tx hex", txHex)
+		}
 		return fmt.Errorf("failed to braodcast tx: %v", err)
 	}
 


### PR DESCRIPTION
This adds new features to the fragmenter tool: both `fragmentfee` and `fragmentmarket` cmds now have 2 new flags defined:
* `--recover_funds_to_address` which lets the user passing an address where to eventually send all the funds stuck into the fragmented single-key wallet.
* `--debug` for debugging purposes, let the command print the hex of the transaction if it fails to be broadcasted.

Only for the `fragmentfee` command, this adds one more flag `--max_fragments` to override the max number of fragments that will eventually become deposits for the fee account.
Note that the previous `MaxNumOfOutputs` contact has been decreased from `150` to `50`.

Last but not least, this replaces the creation of slices via assignment with the use of `append` in the CLI commands.

Closes #437.

Please @tiero review this.
