### PR TITLE
Bader DB: Use Find() and UpdateMatching() 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Install Nigiri
-        run: |
-          mkdir ~/.nigiri; cd ~/.nigiri
-          curl https://travis.nigiri.network | bash; cd
-          docker-compose -f ~/.nigiri/docker-compose.yml up -d
-          sleep 5
+      - name: Run Nigiri
+        uses: vulpemventures/nigiri-github-action@v1
 
       - name: Get dependencies
         run: go get -v -t -d ./...

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,12 +18,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Install Nigiri
-        run: |
-          mkdir ~/.nigiri; cd ~/.nigiri
-          curl https://travis.nigiri.network | bash; cd
-          docker-compose -f ~/.nigiri/docker-compose.yml up -d
-          sleep 10
+      - name: Run Nigiri
+        uses: vulpemventures/nigiri-github-action@v1
 
       - name: Get dependencies
         run: go get -v -t -d ./...

--- a/internal/core/domain/trade_service.go
+++ b/internal/core/domain/trade_service.go
@@ -160,7 +160,7 @@ func (t *Trade) Settle(settlementTime uint64) (bool, error) {
 		return true, nil
 	}
 
-	if !(t.IsCompleted() || t.IsAccepted() || t.Status.Failed) {
+	if !(t.IsCompleted() || t.IsAccepted()) || t.Status.Failed {
 		return false, ErrTradeMustBeCompletedOrAccepted
 	}
 

--- a/internal/core/domain/trade_service_test.go
+++ b/internal/core/domain/trade_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"github.com/tdex-network/tdex-daemon/internal/core/domain"
+	pkgswap "github.com/tdex-network/tdex-daemon/pkg/swap"
 )
 
 var mockedErr = &domain.SwapError{
@@ -373,6 +374,10 @@ func TestFailingTradeSettle(t *testing.T) {
 				name:  "with_trade_proposal",
 				trade: newTradeProposal(),
 			},
+			{
+				name:  "with_trade_failed",
+				trade: newTradeFailed(),
+			},
 		}
 
 		for i := range tests {
@@ -516,6 +521,14 @@ func newTradeSettled() *domain.Trade {
 	trade.ExpiryTime = 0
 	trade.SettlementTime = uint64(time.Now().Unix())
 	trade.Status = domain.SettledStatus
+	return trade
+}
+
+func newTradeFailed() *domain.Trade {
+	trade := newTradeProposal()
+	trade.Fail(
+		trade.SwapRequest.ID, int(pkgswap.ErrCodeRejectedSwapRequest), "mock error",
+	)
 	return trade
 }
 

--- a/internal/core/domain/trade_service_test.go
+++ b/internal/core/domain/trade_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tdex-network/tdex-daemon/internal/core/domain"
 	pkgswap "github.com/tdex-network/tdex-daemon/pkg/swap"
@@ -360,6 +361,14 @@ func TestTradeSettle(t *testing.T) {
 
 func TestFailingTradeSettle(t *testing.T) {
 	now := uint64(time.Now().Unix())
+	mockedSwapParser := mockSwapParser{}
+	mockedSwapParser.On(
+		"SerializeFail",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(randomID(), randomBytes(100))
+	domain.SwapParserManager = mockedSwapParser
 
 	t.Run("failing_because_invalid_status", func(t *testing.T) {
 		tests := []struct {

--- a/internal/core/domain/unspent_repository.go
+++ b/internal/core/domain/unspent_repository.go
@@ -29,9 +29,6 @@ type UnspentRepository interface {
 	// GetAvailableUnspentsForAddresses returns the list of spendable UTXOs for the
 	// provided list of addresses (locked unspents excluded).
 	GetAvailableUnspentsForAddresses(ctx context.Context, addresses []string) ([]Unspent, error)
-	// GetUnspentWithKey returns all the info about an UTXO, if existing in the
-	// repository.
-	GetUnspentWithKey(ctx context.Context, unspentKey UnspentKey) (*Unspent, error)
 	// GetBalance returns the current balance of a certain asset for the provided
 	// list of addresses (locked unspents included)
 	GetBalance(ctx context.Context, addresses []string, assetHash string) (uint64, error)

--- a/internal/infrastructure/storage/db/inmemory/unspent_memory_repository_impl.go
+++ b/internal/infrastructure/storage/db/inmemory/unspent_memory_repository_impl.go
@@ -118,21 +118,6 @@ func (r UnspentRepositoryImpl) GetAvailableUnspentsForAddresses(
 	return r.getAvailableUnspents(addresses), nil
 }
 
-// GetUnspentWithKey ...
-func (r UnspentRepositoryImpl) GetUnspentWithKey(
-	_ context.Context,
-	unspentKey domain.UnspentKey,
-) (*domain.Unspent, error) {
-	r.store.locker.RLock()
-	defer r.store.locker.RUnlock()
-
-	unspent, ok := r.store.unspents[unspentKey]
-	if !ok {
-		return nil, nil
-	}
-	return &unspent, nil
-}
-
 // GetBalance ...
 func (r UnspentRepositoryImpl) GetBalance(
 	_ context.Context,

--- a/internal/infrastructure/storage/db/test/unspent_repository_impl_test.go
+++ b/internal/infrastructure/storage/db/test/unspent_repository_impl_test.go
@@ -52,11 +52,6 @@ func TestUnspentRepositoryImplementations(t *testing.T) {
 				testGetAvailableUnspentsForAddresses(t, repo)
 			})
 
-			t.Run("testGetUnspentWithKey", func(t *testing.T) {
-				t.Parallel()
-				testGetUnspentWithKey(t, repo)
-			})
-
 			t.Run("testGetBalance", func(t *testing.T) {
 				t.Parallel()
 				testGetBalance(t, repo)
@@ -177,28 +172,6 @@ func testGetAvailableUnspentsForAddresses(t *testing.T, repo unspentRepository) 
 	unspents, ok := iAvailableUnspents.([]domain.Unspent)
 	require.True(t, ok)
 	require.GreaterOrEqual(t, len(unspents), mockedData.expectedUnspents)
-}
-
-func testGetUnspentWithKey(t *testing.T, repo unspentRepository) {
-	mockedData := mockUnspentTestData(opts{numOfUnspents: 1})
-	mockedUnspents := mockedData.unspents
-	unspentKey := mockedUnspents[0].Key()
-
-	unspent, err := repo.read(func(ctx context.Context) (interface{}, error) {
-		return repo.Repository.GetUnspentWithKey(ctx, unspentKey)
-	})
-	require.NoError(t, err)
-	require.Nil(t, unspent)
-
-	unspent, err = repo.write(func(ctx context.Context) (interface{}, error) {
-		if _, err := repo.Repository.AddUnspents(ctx, mockedUnspents); err != nil {
-			return nil, err
-		}
-
-		return repo.Repository.GetUnspentWithKey(ctx, unspentKey)
-	})
-	require.NoError(t, err)
-	require.NotNil(t, unspent)
 }
 
 func testGetBalance(t *testing.T, repo unspentRepository) {


### PR DESCRIPTION
This fixes the badger implementation of the unspent repository so that it doesn't make use of badgerhold's methods like `Get()` or `Update()` to read/write data from/to the store. They are replaced by `Find()` and `UpdateMatching()` that actually query the store instead of getting/updating an elem by its key.

There is still an [open issue](https://github.com/timshannon/badgerhold/issues/76) on the badgerhold repo for this. These changes could eventually be rolled back if we figure out the reason of such weird misbehavior.

This closes #452.

BONUS:
- This fixes the trade domain to prevent being able to settle a trade if it's failed (a dedicated test case has been added to prove it)
- This fixes the bc listener to properly stop the outpoint observation if the transaction has failed for any reason.

Please @tiero review this.

