### PR TITLE
Hotfix: Update name of RPCs for macaroons permissions

### DIFF
--- a/internal/interfaces/grpc/permissions/permissions.go
+++ b/internal/interfaces/grpc/permissions/permissions.go
@@ -256,7 +256,7 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Action: "write",
 		}},
 		"/Operator/DropMarket": {{
-			Entity: EntityMarket,
+			Entity: EntityOperator,
 			Action: "write",
 		}},
 		"/Operator/GetMarketCollectedSwapFees": {{
@@ -288,7 +288,15 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Action: "read",
 		}},
 		"/Operator/ListTrades": {{
-			Entity: EntityOperator,
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/ListDeposits": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/ListWithdrawals": {{
+			Entity: EntityMarket,
 			Action: "read",
 		}},
 		"/Operator/ReloadUtxos": {{
@@ -296,14 +304,6 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Action: "write",
 		}},
 		"/Operator/ListUtxos": {{
-			Entity: EntityOperator,
-			Action: "read",
-		}},
-		"/Operator/ListDeposits": {{
-			Entity: EntityOperator,
-			Action: "read",
-		}},
-		"/Operator/ListWithdrawals": {{
 			Entity: EntityOperator,
 			Action: "read",
 		}},

--- a/internal/interfaces/grpc/permissions/permissions.go
+++ b/internal/interfaces/grpc/permissions/permissions.go
@@ -203,19 +203,47 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Entity: EntityWallet,
 			Action: "read",
 		}},
-		"/Operator/DepositMarket": {{
+		"/Operator/GetInfo": {{
+			Entity: EntityOperator,
+			Action: "read",
+		}},
+		"/Operator/GetFeeAddress": {{
 			Entity: EntityMarket,
 			Action: "write",
 		}},
-		"/Operator/DepositFeeAccount": {{
+		"/Operator/ListFeeAddresses": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/GetFeeBalance": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/ClaimFeeDeposits": {{
 			Entity: EntityMarket,
 			Action: "write",
 		}},
-		"/Operator/ClaimMarketDeposit": {{
+		"/Operator/WithdrawFee": {{
+			Entity: EntityOperator,
+			Action: "write",
+		}},
+		"/Operator/NewMarket": {{
 			Entity: EntityMarket,
 			Action: "write",
 		}},
-		"/Operator/ClaimFeeDeposit": {{
+		"/Operator/GetMarketAddress": {{
+			Entity: EntityMarket,
+			Action: "write",
+		}},
+		"/Operator/ListMarketAddresses": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/GetMarketBalance": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/ClaimMarketDeposits": {{
 			Entity: EntityMarket,
 			Action: "write",
 		}},
@@ -227,6 +255,18 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Entity: EntityMarket,
 			Action: "write",
 		}},
+		"/Operator/DropMarket": {{
+			Entity: EntityMarket,
+			Action: "write",
+		}},
+		"/Operator/GetMarketCollectedSwapFees": {{
+			Entity: EntityMarket,
+			Action: "read",
+		}},
+		"/Operator/WithdrawMarket": {{
+			Entity: EntityOperator,
+			Action: "write",
+		}},
 		"/Operator/UpdateMarketPercentageFee": {{
 			Entity: EntityMarket,
 			Action: "write",
@@ -235,43 +275,35 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Entity: EntityMarket,
 			Action: "write",
 		}},
-		"/Operator/UpdateMarketStrategy": {{
-			Entity: EntityMarket,
-			Action: "write",
-		}},
-		"/Operator/ListMarket": {{
-			Entity: EntityMarket,
-			Action: "read",
-		}},
-		"/Operator/ListDepositMarket": {{
-			Entity: EntityMarket,
-			Action: "read",
-		}},
-		"/Operator/BalanceFeeAccount": {{
-			Entity: EntityMarket,
-			Action: "read",
-		}},
-		"/Operator/DropMarket": {{
-			Entity: EntityMarket,
-			Action: "write",
-		}},
 		"/Operator/UpdateMarketPrice": {{
 			Entity: EntityPrice,
 			Action: "write",
 		}},
-		"/Operator/WithdrawMarket": {{
-			Entity: EntityOperator,
+		"/Operator/UpdateMarketStrategy": {{
+			Entity: EntityMarket,
 			Action: "write",
 		}},
-		"/Operator/ReloadUtxos": {{
-			Entity: EntityOperator,
-			Action: "write",
+		"/Operator/ListMarkets": {{
+			Entity: EntityMarket,
+			Action: "read",
 		}},
 		"/Operator/ListTrades": {{
 			Entity: EntityOperator,
 			Action: "read",
 		}},
+		"/Operator/ReloadUtxos": {{
+			Entity: EntityOperator,
+			Action: "write",
+		}},
 		"/Operator/ListUtxos": {{
+			Entity: EntityOperator,
+			Action: "read",
+		}},
+		"/Operator/ListDeposits": {{
+			Entity: EntityOperator,
+			Action: "read",
+		}},
+		"/Operator/ListWithdrawals": {{
 			Entity: EntityOperator,
 			Action: "read",
 		}},


### PR DESCRIPTION
This updates the name of the RPCs and also adds those missing to the list of macaroons permissions.

This also fixes the entities associated for each permission.

Please @tiero  review this.