### PR TITLE
Lock on propose

### DIFF
--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -40,8 +40,8 @@ type TradeService interface {
 	) (domain.SwapAccept, domain.SwapFail, uint64, error)
 	TradeComplete(
 		ctx context.Context,
-		swapComplete *domain.SwapComplete,
-		swapFail *domain.SwapFail,
+		swapComplete domain.SwapComplete,
+		swapFail domain.SwapFail,
 	) (string, domain.SwapFail, error)
 	GetMarketBalance(
 		ctx context.Context,
@@ -429,11 +429,11 @@ end:
 // TradeComplete is the domain controller for the TradeComplete RPC
 func (t *tradeService) TradeComplete(
 	ctx context.Context,
-	swapComplete *domain.SwapComplete,
-	swapFail *domain.SwapFail,
+	swapComplete domain.SwapComplete,
+	swapFail domain.SwapFail,
 ) (string, domain.SwapFail, error) {
 	if swapFail != nil {
-		swapFailMsg, err := t.tradeFail(ctx, *swapFail)
+		swapFailMsg, err := t.tradeFail(ctx, swapFail)
 		if err != nil {
 			log.Debugf("error while aborting trade: %s", err)
 			return "", nil, ErrServiceUnavailable
@@ -441,7 +441,7 @@ func (t *tradeService) TradeComplete(
 		return "", swapFailMsg, nil
 	}
 
-	return t.tradeComplete(ctx, *swapComplete)
+	return t.tradeComplete(ctx, swapComplete)
 }
 
 func (t *tradeService) tradeComplete(

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -367,17 +367,14 @@ func marketOrder(
 	require.NotNil(t, swapAccept)
 	require.True(t, time.Now().Before(time.Unix(int64(expiryTimestamp), 0)))
 
-	var swapCompletePtr *domain.SwapComplete
-	var swapComplete domain.SwapComplete
-	swapComplete = &pbswap.SwapComplete{
+	swapComplete := &pbswap.SwapComplete{
 		Id:          randomId(),
 		AcceptId:    swapAccept.GetId(),
 		Transaction: swapAccept.GetTransaction(),
 	}
-	swapCompletePtr = &swapComplete
 
 	time.Sleep(200 * time.Millisecond)
-	_, _, err = tradeSvc.TradeComplete(ctx, swapCompletePtr, nil)
+	_, _, err = tradeSvc.TradeComplete(ctx, swapComplete, nil)
 	require.NoError(t, err)
 
 	time.Sleep(200 * time.Millisecond)

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -98,15 +98,19 @@ func TestMarketTrading(t *testing.T) {
 		require.True(t, balances.Balance.QuoteAmount > 0)
 
 		t.Run("buy LBTC fixed LBTC", func(t *testing.T) {
+			t.Parallel()
 			marketOrder(t, tradeSvc, market, application.TradeBuy, 0.1, marketBaseAsset)
 		})
 		t.Run("buy LBTC fixed USDT", func(t *testing.T) {
+			t.Parallel()
 			marketOrder(t, tradeSvc, market, application.TradeBuy, 900.0, marketQuoteAsset)
 		})
 		t.Run("sell LBTC fixed LBTC", func(t *testing.T) {
+			t.Parallel()
 			marketOrder(t, tradeSvc, market, application.TradeSell, 0.1, marketBaseAsset)
 		})
 		t.Run("sell LBTC fixed USDT", func(t *testing.T) {
+			t.Parallel()
 			marketOrder(t, tradeSvc, market, application.TradeSell, 900.0, marketQuoteAsset)
 		})
 	})
@@ -184,7 +188,6 @@ func newTradeService(
 	}
 
 	oLen := len(tradeMktOutpoints)
-	mktOutpointsWithAsset := make([]domain.OutpointWithAsset, oLen, oLen)
 	for i, outpoint := range tradeMktOutpoints {
 		info, _ := v.DeriveNextExternalAddressForAccount(domain.MarketAccountStart)
 		script, _ := hex.DecodeString(info.Script)
@@ -193,11 +196,6 @@ func newTradeService(
 		if i > (oLen/2 - 1) {
 			assetHash = marketQuoteAsset
 			value = 50000000000
-		}
-		mktOutpointsWithAsset[i] = domain.OutpointWithAsset{
-			Asset: assetHash,
-			Txid:  outpoint.Hash,
-			Vout:  outpoint.Index,
 		}
 
 		unspents = append(unspents, domain.Unspent{
@@ -390,10 +388,10 @@ func randomBase64() string {
 }
 
 func randomSelection(list []domain.Unspent, counter int) []explorer.Utxo {
-	selectedUtxos := make([]explorer.Utxo, 3, 3)
+	selectedUtxos := make([]explorer.Utxo, 0, 3)
 	for i := 0; i < 3; i++ {
 		selectedIndex := counter*3 + i
-		selectedUtxos[i] = list[selectedIndex].ToUtxo()
+		selectedUtxos = append(selectedUtxos, list[selectedIndex].ToUtxo())
 	}
 	return selectedUtxos
 }

--- a/internal/core/application/walletunlocker_service_test.go
+++ b/internal/core/application/walletunlocker_service_test.go
@@ -113,7 +113,7 @@ func TestInitWallet(t *testing.T) {
 
 		replies, err := listenToReplies(chReplies)
 		require.NoError(t, err)
-		require.Len(t, replies, 0)
+		require.Len(t, replies, 2)
 	})
 
 	t.Run("wallet_from_restart", func(t *testing.T) {

--- a/internal/interfaces/grpc/handler/trade.go
+++ b/internal/interfaces/grpc/handler/trade.go
@@ -252,24 +252,17 @@ func (t traderHandler) tradeComplete(
 	req *pb.TradeCompleteRequest,
 	stream pb.Trade_TradeCompleteServer,
 ) error {
-	var swapCompletePtr *domain.SwapComplete
 	var swapComplete domain.SwapComplete
 	if s := req.SwapComplete; s != nil {
 		swapComplete = s
-		swapCompletePtr = &swapComplete
 	}
-	var swapFailPtr *domain.SwapFail
 	var swapFail domain.SwapFail
 	if s := req.SwapFail; s != nil {
 		swapFail = s
-		swapFailPtr = &swapFail
 	}
 	txID, fail, err := t.traderSvc.TradeComplete(
-		stream.Context(),
-		swapCompletePtr,
-		swapFailPtr,
+		stream.Context(), swapComplete, swapFail,
 	)
-
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
@@ -289,7 +282,7 @@ func (t traderHandler) tradeComplete(
 		SwapFail: swapFailStub,
 	}
 
-	if err = stream.Send(res); err != nil {
+	if err := stream.Send(res); err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
 


### PR DESCRIPTION
This adds a mutex on the TradePropose RPC in order to grant reclusive access to the method, preventing the daemon from attempting to double spend its UTXOs in case of "concurrent" proposals, ie. incoming requests nearly at the same time.

Because of this, the parallelization of the tests has been restored to prove that now the daemon can handle this eventuality.

Minor fixes:
* Do not use pointer to interfaces in TradeComplete
* Fixes failing test in TestInitWallet
* Do not log events in TestCralwerService but check that events are actually received

Closes #388.

Please @tiero review this.