### PR TITLE
[Trade interface] Update TradePropose, TradeComplete to unary RPC methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/tdex-network/tdex-daemon/pkg/explorer v0.0.0-20211001103242-a11e4485705a
 	github.com/tdex-network/tdex-daemon/pkg/macaroons v0.0.0-20210813140257-70d50a8b72a4
 	github.com/tdex-network/tdex-daemon/pkg/securestore v0.0.0-20210813140257-70d50a8b72a4
-	github.com/tdex-network/tdex-protobuf v0.0.0-20210507104156-d509331cccdb
+	github.com/tdex-network/tdex-protobuf v0.0.0-20211020101617-010c28e72122
 	github.com/thanhpk/randstr v1.0.4
 	github.com/timshannon/badgerhold/v2 v2.0.0-20201016201833-94bc303c76d4
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,8 @@ github.com/tdex-network/tdex-daemon v0.2.1-0.20210324163246-ed408aba2ec6/go.mod 
 github.com/tdex-network/tdex-protobuf v0.0.0-20210322132201-a185bdfeb24f/go.mod h1:tVWv01BSMH/neJOsixdDFU5T0ll0OZbPliLXBsYQjA8=
 github.com/tdex-network/tdex-protobuf v0.0.0-20210507104156-d509331cccdb h1:QfeDbKuqY2nbcTKd/WHAbzcb6SkbRIBFLUHBMtPM5do=
 github.com/tdex-network/tdex-protobuf v0.0.0-20210507104156-d509331cccdb/go.mod h1:tVWv01BSMH/neJOsixdDFU5T0ll0OZbPliLXBsYQjA8=
+github.com/tdex-network/tdex-protobuf v0.0.0-20211020101617-010c28e72122 h1:UPZgIQpC7RItn9Ud71MkU0odJrBrP8sNtXnlgclxszY=
+github.com/tdex-network/tdex-protobuf v0.0.0-20211020101617-010c28e72122/go.mod h1:tVWv01BSMH/neJOsixdDFU5T0ll0OZbPliLXBsYQjA8=
 github.com/thanhpk/randstr v1.0.4 h1:IN78qu/bR+My+gHCvMEXhR/i5oriVHcTB/BJJIRTsNo=
 github.com/thanhpk/randstr v1.0.4/go.mod h1:M/H2P1eNLZzlDwAzpkkkUvoyNNMbzRGhESZuEQk3r0U=
 github.com/timshannon/badgerhold/v2 v2.0.0-20201016201833-94bc303c76d4 h1:5g8lFrH34MM7MhZyluuTOJEuCjDHPgFZfNSHvOBLaNE=

--- a/pkg/trade/client/trade_complete.go
+++ b/pkg/trade/client/trade_complete.go
@@ -69,9 +69,5 @@ func (c *Client) TradeComplete(opts TradeCompleteOpts) (*pbtrade.TradeCompleteRe
 		SwapComplete: swapComplete,
 		SwapFail:     swapFail,
 	}
-	stream, err := c.client.TradeComplete(context.Background(), request)
-	if err != nil {
-		return nil, err
-	}
-	return stream.Recv()
+	return c.client.TradeComplete(context.Background(), request)
 }

--- a/pkg/trade/client/trade_propose.go
+++ b/pkg/trade/client/trade_propose.go
@@ -58,9 +58,5 @@ func (c *Client) TradePropose(opts TradeProposeOpts) (*pbtrade.TradeProposeReply
 		SwapRequest: swapRequest,
 		Type:        pbtrade.TradeType(opts.TradeType),
 	}
-	stream, err := c.client.TradePropose(context.Background(), request)
-	if err != nil {
-		return nil, err
-	}
-	return stream.Recv()
+	return c.client.TradePropose(context.Background(), request)
 }

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -113,25 +113,26 @@ func main() {
 	}
 
 	// deposit some funds to pay for future trades' network fees
-	out, err := runCommandWithEnv(cliEnv, cli, "depositfee", "--num_of_addresses", "10")
+	out, err := runCommandWithEnv(cliEnv, cli, "fee", "deposit", "--num_of_addresses", "10")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	feeAddresses := feeAddressesFromStdout(out)
+	feeAddresses := addressesFromStdout(out)
 	feeOutpoints := fundFeeAccount(feeAddresses)
-	if _, err := runCommandWithEnv(cliEnv, cli, "claimfee", "--outpoints", feeOutpoints); err != nil {
+	if _, err := runCommandWithEnv(cliEnv, cli, "fee", "claim", "--outpoints", feeOutpoints); err != nil {
 		fmt.Println(err)
 		return
 	}
 
 	// create a LBTC/USDT market on regtest and deposit funds
-	out, err = runCommandWithEnv(cliEnv, cli, "depositmarket", "--num_of_addresses", "10")
-	if err != nil {
+	if _, err = runCommandWithEnv(
+		cliEnv, cli, "market", "new",
+		"--base_asset", lbtcAsset, "--quote_asset", usdtAsset,
+	); err != nil {
 		fmt.Println(err)
 		return
 	}
-	marketAddresses := marketAddressesFromStdout(out)
 
 	if _, err := runCommandWithEnv(cliEnv, cli, "config", "set", "base_asset", lbtcAsset); err != nil {
 		fmt.Println(err)
@@ -142,15 +143,22 @@ func main() {
 		return
 	}
 
+	out, err = runCommandWithEnv(cliEnv, cli, "market", "deposit", "--num_of_addresses", "10")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	marketAddresses := addressesFromStdout(out)
+
 	outpoints := fundMarketAccount(marketAddresses)
-	if _, err := runCommandWithEnv(cliEnv, cli, "claimmarket", "--outpoints", outpoints); err != nil {
+	if _, err := runCommandWithEnv(cliEnv, cli, "market", "claim", "--outpoints", outpoints); err != nil {
 		fmt.Println(err)
 		return
 	}
 
 	// before opening the market, let's set the strategy to pluggable)
 	// and start the feeder
-	if _, err := runCommandWithEnv(cliEnv, cli, "strategy", "--pluggable"); err != nil {
+	if _, err := runCommandWithEnv(cliEnv, cli, "market", "strategy", "--pluggable"); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -172,7 +180,7 @@ func main() {
 
 	time.Sleep(5 * time.Second)
 
-	if _, err := runCommandWithEnv(cliEnv, cli, "open"); err != nil {
+	if _, err := runCommandWithEnv(cliEnv, cli, "market", "open"); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -220,8 +228,6 @@ func main() {
 		fmt.Printf("error occoured while trading against LBTC/USDT market: \n%s\n", err)
 		return
 	}
-
-	return
 }
 
 func tradeOnMarket(client *trade.Trade, w *trade.Wallet, asset string) error {
@@ -316,7 +322,7 @@ func newCommand(out, err io.Writer, name string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
-func feeAddressesFromStdout(out string) []string {
+func addressesFromStdout(out string) []string {
 	res := make(map[string]interface{})
 	json.Unmarshal([]byte(out), &res)
 
@@ -347,17 +353,6 @@ func fundFeeAccount(addresses []string) string {
 
 	buf, _ := json.Marshal(funds)
 	return string(buf)
-}
-
-func marketAddressesFromStdout(out string) []string {
-	res := make(map[string]interface{})
-	json.Unmarshal([]byte(out), &res)
-
-	addresses := make([]string, 0)
-	for _, i := range res["addresses"].([]interface{}) {
-		addresses = append(addresses, i.(string))
-	}
-	return addresses
 }
 
 func fundMarketAccount(addresses []string) string {
@@ -403,22 +398,25 @@ func setupUSDTAsset() error {
 
 func setupFeeder() error {
 	configMap := map[string]interface{}{
-		"daemon_endpoint":    "127.0.0.1:9000",
-		"kraken_ws_endpoint": "ws.kraken.com",
+		"price_feeder": "kraken",
+		"interval":     1000,
 		"markets": []map[string]interface{}{
 			{
-				"base_asset":    lbtcAsset,
-				"quote_asset":   usdtAsset,
-				"kraken_ticker": "XBT/USDT",
-				"interval":      500,
+				"base_asset":  lbtcAsset,
+				"quote_asset": usdtAsset,
+				"ticker":      "XBT/USDT",
+				"targets": map[string]string{
+					"rpc_address":    "localhost:9000",
+					"tls_cert_path":  "",
+					"macaroons_path": "",
+				},
 			},
 		},
 	}
 	configJSON, _ := json.Marshal(configMap)
 	ioutil.WriteFile(feederConfigJSON, configJSON, 0777)
 
-	// get feeder's latest relase
-
+	// get feeder's latest release
 	cmd := "curl -s https://api.github.com/repos/Tdex-network/tdex-feeder/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\\1/'"
 	latestVersion, err := runCommand("bash", "-c", cmd)
 	if err != nil {


### PR DESCRIPTION
This updates the version of the tdex-protobuf to the one that changes the Trade/TradePropose and Trade/TradeComplete to unary RPC instead of having them as server-side streams.

The trade grpc handler and the "client" pkg/trade have been updated accordingly.

TODO: Change tdex-protobuf import path once branch [develop](https://github.com/tdex-network/tdex-protobuf/tree/develop) is merged in master.

BONUS: This fixes the integration test. Some of the CLI commands used were deprecated and have been updated with latest ones.

Please @tiero review this.