### PR TITLE
Fix typo in ErrWithdrawAmountTooBig error message

### DIFF
--- a/internal/core/application/errors.go
+++ b/internal/core/application/errors.go
@@ -51,7 +51,7 @@ var (
 	// ErrWithdrawAmountTooBig is returned when attempting to withdraw more
 	// than the total amount of LBTC asset of the fee account.
 	ErrWithdrawAmountTooBig = errors.New(
-		"amount to withdraw os too big",
+		"amount to withdraw is too big",
 	)
 	// ErrInvalidAccountIndex returned if provided account index is invalid
 	ErrInvalidAccountIndex = errors.New("invalid account index")


### PR DESCRIPTION
Please review @tiero 