### PR TITLE
GoReleaser: pre-compile linux & darwin arm64 binaries & docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get cross-compiling targets
         run: |
-          docker run --name cross ghcr.io/gythialy/golang-cross:latest /bin/bash
+          docker run --name cross ghcr.io/gythialy/golang-cross-builder /bin/bash
           docker cp cross:/osxcross/target/bin /
 
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,61 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get cross-compiling targets
+      - name: Get OSX cross-compiling targets
         run: |
           mkdir -p ../../osxcross/target
           docker run --name cross ghcr.io/gythialy/golang-cross-builder /bin/bash
           docker cp -a cross:/osxcross/target/bin /home/runner/work/osxcross/target
-          cd /home/runner/work/osxcross/target/bin
-          ls -la
+
+      - name: Install ubuntu cross-compiling targets
+        run: |
+          dpkg --add-architecture arm64                      \
+          && dpkg --add-architecture armel                      \
+          && dpkg --add-architecture armhf                      \
+          && dpkg --add-architecture i386                       \
+          && dpkg --add-architecture mips                       \
+          && dpkg --add-architecture mipsel                     \
+          && dpkg --add-architecture powerpc                    \
+          && dpkg --add-architecture ppc64el                    \
+          && apt-get update                                     \
+          && apt-get install -y -q                              \
+                  autoconf                                       \
+                  automake                                       \
+                  autotools-dev                                  \
+                  bc                                             \
+                  binfmt-support                                 \
+                  binutils-multiarch                             \
+                  binutils-multiarch-dev                         \
+                  build-essential                                \
+                  clang                                          \
+                  crossbuild-essential-arm64                     \
+                  crossbuild-essential-armel                     \
+                  crossbuild-essential-armhf                     \
+                  crossbuild-essential-mipsel                    \
+                  crossbuild-essential-ppc64el                   \
+                  curl                                           \
+                  devscripts                                     \
+                  gdb                                            \
+                  git-core                                       \
+                  libtool                                        \
+                  llvm                                           \
+                  mercurial                                      \
+                  multistrap                                     \
+                  patch                                          \
+                  software-properties-common                     \
+                  subversion                                     \
+                  wget                                           \
+                  xz-utils                                       \
+                  cmake                                          \
+                  qemu-user-static                               \
+                  libxml2-dev                                    \
+                  lzma-dev                                       \
+                  openssl                                        \
+                  mingw-w64                                      \
+                  musl-tools                                     \
+                  libssl-dev                                  && \
+                  apt -y autoremove && \
+                  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - run: ls -la
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -60,10 +62,10 @@ jobs:
       - name: Run GoReleaser with docker image for cross-compiling
         run: |
           docker run --rm --privileged \
-            -e "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" \
-            -e "PRIVATE_KEY=${{ secrets.GPG_PRIVATE_KEY }}" \
-            -v "$(CURDIR):/app" \
-            -v "/var/run/docker.sock:/var/run/docker.sock" \
-            -v "$(GOPATH)/src:/go/src" \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e PRIVATE_KEY=${{ secrets.GPG_PRIVATE_KEY }} \
+            -v $(pwd):/app \
+            -v var/run/docker.sock:/var/run/docker.sock \
+            -v ~/go/src:/go/src \
             -w /app \
             ghcr.io/gythialy/golang-cross:latest --rm-dist --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-20.04
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
 
     permissions: write-all
 
@@ -18,7 +20,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -46,7 +51,6 @@ jobs:
 
       - name: Install Linux aarch64 cross-compiling targets
         run: sudo apt install gcc make gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser with docker image for cross-compiling
-        run: docker run --rm --privileged -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e PRIVATE_KEY=${{ secrets.GPG_PRIVATE_KEY }} -v $(CURDIR):/app -v /var/run/docker.sock:/var/run/docker.sock -v $(GOPATH)/src:/go/src -w /app ghcr.io/gythialy/golang-cross:latest --rm-dist --debug
+        run: |
+          docker run --rm --privileged \
+            -e "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" \
+            -e "PRIVATE_KEY=${{ secrets.GPG_PRIVATE_KEY }}" \
+            -v "$(CURDIR):/app" \
+            -v "/var/run/docker.sock:/var/run/docker.sock" \
+            -v "$(GOPATH)/src:/go/src" \
+            -w /app \
+            ghcr.io/gythialy/golang-cross:latest --rm-dist --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,6 @@ jobs:
           mkdir ../../osxcross
           git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
 
-
-      - name: Linux armhf for CGO Support
-        run: |
-          mkdir ../../sysroot
-          git clone https://github.com/troian/golang-cross-example-sysroot.git ../../sysroot
-
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v3
@@ -63,11 +57,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist --debug
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      - name: Run GoReleaser with docker image for cross-compiling
+        run: |
+          docker run --rm --privileged \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e PRIVATE_KEY=${{ secrets.GPG_PRIVATE_KEY }} \
+            -v $(CURDIR):/app \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v $(GOPATH)/src:/go/src \
+            -w /app \
+            ghcr.io/gythialy/golang-cross:latest --rm-dist --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,9 @@ jobs:
 
       - name: Get cross-compiling targets
         run: |
-          mkdir -p ../../osxcross/target/bin
+          mkdir -p ../../osxcross/target
           docker run --name cross ghcr.io/gythialy/golang-cross-builder /bin/bash
-          docker cp -a cross:/osxcross/target/bin /home/runner/work/osxcross/target/bin
+          docker cp -a cross:/osxcross/target/bin /home/runner/work/osxcross/target
           cd /home/runner/work/osxcross/target/bin
           ls -la
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,54 +52,7 @@ jobs:
           docker cp -a cross:/osxcross/target/bin /home/runner/work/osxcross/target
 
       - name: Install ubuntu cross-compiling targets
-        run: |
-          sudo dpkg --add-architecture arm64                      \
-          && sudo dpkg --add-architecture armel                      \
-          && sudo dpkg --add-architecture armhf                      \
-          && sudo dpkg --add-architecture i386                       \
-          && sudo dpkg --add-architecture mips                       \
-          && sudo dpkg --add-architecture mipsel                     \
-          && sudo dpkg --add-architecture powerpc                    \
-          && sudo dpkg --add-architecture ppc64el                    \
-          && sudo apt-get update                                     \
-          && sudo apt-get install -y -q                              \
-                  autoconf                                       \
-                  automake                                       \
-                  autotools-dev                                  \
-                  bc                                             \
-                  binfmt-support                                 \
-                  binutils-multiarch                             \
-                  binutils-multiarch-dev                         \
-                  build-essential                                \
-                  clang                                          \
-                  crossbuild-essential-arm64                     \
-                  crossbuild-essential-armel                     \
-                  crossbuild-essential-armhf                     \
-                  crossbuild-essential-mipsel                    \
-                  crossbuild-essential-ppc64el                   \
-                  curl                                           \
-                  devscripts                                     \
-                  gdb                                            \
-                  git-core                                       \
-                  libtool                                        \
-                  llvm                                           \
-                  mercurial                                      \
-                  multistrap                                     \
-                  patch                                          \
-                  software-properties-common                     \
-                  subversion                                     \
-                  wget                                           \
-                  xz-utils                                       \
-                  cmake                                          \
-                  qemu-user-static                               \
-                  libxml2-dev                                    \
-                  lzma-dev                                       \
-                  openssl                                        \
-                  mingw-w64                                      \
-                  musl-tools                                     \
-                  libssl-dev                                     \
-            && sudo apt -y autoremove                           \
-            && sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+        run: sudo apt install gcc make gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
 
       - run: which aarch64-linux-gnu-gcc
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
                   apt -y autoremove && \
                   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+      - run: which aarch64-linux-gnu-gcc
+      
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           docker run --rm --privileged \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }} \
             -v $(pwd):/app \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v ~/go/src:/go/src \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           docker run --rm --privileged \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -e GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }} \
+            -e GPG_FINGERPRINT=${{ steps.import_gpg.outputs.fingerprint }} \
             -v $(pwd):/app \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v ~/go/src:/go/src \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
         run: |
           docker run --rm --privileged \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -e GPG_FINGERPRINT=${{ steps.import_gpg.outputs.fingerprint }} \
             -v $(pwd):/app \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v ~/go/src:/go/src \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
         run: |
           docker run --rm --privileged \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -e PRIVATE_KEY=${{ secrets.GPG_PRIVATE_KEY }} \
             -v $(pwd):/app \
             -v var/run/docker.sock:/var/run/docker.sock \
             -v ~/go/src:/go/src \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,9 @@ jobs:
 
       - name: Get cross-compiling targets
         run: |
+          mkdir ../../osxcross/target/bin
           docker run --name cross ghcr.io/gythialy/golang-cross-builder /bin/bash
-          docker cp cross:/osxcross/target/bin /
+          docker cp cross:/osxcross/target/bin /home/runner/work/osxcross/target/bin
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: goreleaser
 
 on:
   workflow_dispatch:
+  push:
     tags:
       - "*"
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,12 @@ jobs:
           mkdir ../../osxcross
           git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
 
+
+      - name: Linux armhf for CGO Support
+        run: |
+          mkdir ../../sysroot
+          git clone https://github.com/troian/golang-cross-example-sysroot.git ../../sysroot
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,16 @@ jobs:
 
       - name: Install ubuntu cross-compiling targets
         run: |
-          dpkg --add-architecture arm64                      \
-          && dpkg --add-architecture armel                      \
-          && dpkg --add-architecture armhf                      \
-          && dpkg --add-architecture i386                       \
-          && dpkg --add-architecture mips                       \
-          && dpkg --add-architecture mipsel                     \
-          && dpkg --add-architecture powerpc                    \
-          && dpkg --add-architecture ppc64el                    \
-          && apt-get update                                     \
-          && apt-get install -y -q                              \
+          sudo dpkg --add-architecture arm64                      \
+          && sudo dpkg --add-architecture armel                      \
+          && sudo dpkg --add-architecture armhf                      \
+          && sudo dpkg --add-architecture i386                       \
+          && sudo dpkg --add-architecture mips                       \
+          && sudo dpkg --add-architecture mipsel                     \
+          && sudo dpkg --add-architecture powerpc                    \
+          && sudo dpkg --add-architecture ppc64el                    \
+          && sudo apt-get update                                     \
+          && sudo apt-get install -y -q                              \
                   autoconf                                       \
                   automake                                       \
                   autotools-dev                                  \
@@ -97,12 +97,12 @@ jobs:
                   openssl                                        \
                   mingw-w64                                      \
                   musl-tools                                     \
-                  libssl-dev                                  && \
-                  apt -y autoremove && \
-                  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+                  libssl-dev                                     \
+            && sudo apt -y autoremove                           \
+            && sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
       - run: which aarch64-linux-gnu-gcc
-      
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser with docker image for cross-compiling
-        run: |
-          docker run --rm --privileged \
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -e PRIVATE_KEY=${{ secrets.GPG_PRIVATE_KEY }} \
-            -v $(CURDIR):/app \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $(GOPATH)/src:/go/src \
-            -w /app \
-            ghcr.io/gythialy/golang-cross:latest --rm-dist --debug
+        run: docker run --rm --privileged -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e PRIVATE_KEY=${{ secrets.GPG_PRIVATE_KEY }} -v $(CURDIR):/app -v /var/run/docker.sock:/var/run/docker.sock -v $(GOPATH)/src:/go/src -w /app ghcr.io/gythialy/golang-cross:latest --rm-dist --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: goreleaser
 
 on:
   workflow_dispatch:
-  push:
-    # todo: remove
-    branches:
-      - "arm"
     tags:
       - "*"
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get cross-compiling targets
         run: |
-          mkdir ../../osxcross/target/bin
+          mkdir -p ../../osxcross/target/bin
           docker run --name cross ghcr.io/gythialy/golang-cross-builder /bin/bash
           docker cp cross:/osxcross/target/bin /home/runner/work/osxcross/target/bin
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           docker run --rm --privileged \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -v $(pwd):/app \
-            -v var/run/docker.sock:/var/run/docker.sock \
+            -v /var/run/docker.sock:/var/run/docker.sock \
             -v ~/go/src:/go/src \
             -w /app \
             ghcr.io/gythialy/golang-cross:latest --rm-dist --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,9 @@ jobs:
         run: |
           mkdir -p ../../osxcross/target/bin
           docker run --name cross ghcr.io/gythialy/golang-cross-builder /bin/bash
-          docker cp cross:/osxcross/target/bin /home/runner/work/osxcross/target/bin
+          docker cp -a cross:/osxcross/target/bin /home/runner/work/osxcross/target/bin
+          cd /home/runner/work/osxcross/target/bin
+          ls -la
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: ls -la
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -33,18 +31,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
-      # This because https://github.com/plentico/osxcross-target/issues/2#issuecomment-815850611
-      - name: Downgrade libssl
-        run: |
-          echo 'deb http://security.ubuntu.com/ubuntu bionic-security main' | sudo tee -a /etc/apt/sources.list
-          sudo apt update && apt-cache policy libssl1.0-dev
-          sudo apt-get install libssl1.0-dev
-
-      - name: OSXCross for CGO Support
-        run: |
-          mkdir ../../osxcross
-          git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
 
       - name: Import GPG key
         id: import_gpg
@@ -59,12 +45,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run GoReleaser with docker image for cross-compiling
+      - name: Get cross-compiling targets
         run: |
-          docker run --rm --privileged \
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -v $(pwd):/app \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -v ~/go/src:/go/src \
-            -w /app \
-            ghcr.io/gythialy/golang-cross:latest --rm-dist --debug
+          docker run --name cross ghcr.io/gythialy/golang-cross:latest /bin/bash
+          docker cp cross:/osxcross/target/bin /
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,22 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      
+      # This because https://github.com/plentico/osxcross-target/issues/2#issuecomment-815850611
+      - name: Downgrade libssl
+        run: |
+          echo 'deb http://security.ubuntu.com/ubuntu bionic-security main' | sudo tee -a /etc/apt/sources.list
+          sudo apt update && apt-cache policy libssl1.0-dev
+          sudo apt-get install libssl1.0-dev
+
+      - name: Install OSX cross-compiling targets
+        run: |
+          mkdir ../../osxcross
+          git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
+
+      - name: Install Linux aarch64 cross-compiling targets
+        run: sudo apt install gcc make gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+
 
       - name: Import GPG key
         id: import_gpg
@@ -44,17 +60,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get OSX cross-compiling targets
-        run: |
-          mkdir -p ../../osxcross/target
-          docker run --name cross ghcr.io/gythialy/golang-cross-builder /bin/bash
-          docker cp -a cross:/osxcross/target/bin /home/runner/work/osxcross/target
-
-      - name: Install ubuntu cross-compiling targets
-        run: sudo apt install gcc make gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-
-      - run: which aarch64-linux-gnu-gcc
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: goreleaser
 on:
   workflow_dispatch:
   push:
+    # todo: remove
+    branches:
+      - "arm"
     tags:
       - "*"
   

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -107,19 +107,6 @@ release:
 checksum:
   name_template: "checksums.txt"
 
-signs:
-  - artifacts: checksum
-    args:
-      [
-        "--batch",
-        "-u",
-        "{{ .Env.GPG_FINGERPRINT }}",
-        "--output",
-        "${signature}",
-        "--detach-sign",
-        "${artifact}",
-      ]
-
 snapshot:
   name_template: "{{ .Tag }}-next"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     binary: tdexd-linux
 
   - id: "tdexd-darwin"
@@ -24,33 +25,20 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     binary: tdexd-darwin
 
   # CLI
-  - id: "tdex-linux"
+  - id: "tdex"
     main: ./cmd/tdex
     ldflags:
       - -s -X 'main.version={{.Version}}' -X 'main.commit={{.Commit}}' -X 'main.date={{.Date}}'
-    env:
-      - CGO_ENABLED=1
     goos:
       - linux
-    goarch:
-      - amd64
-    binary: tdex-linux
-
-  - id: "tdex-darwin"
-    main: ./cmd/tdex
-    ldflags:
-      - -s -X 'main.version={{.Version}}' -X 'main.commit={{.Commit}}' -X 'main.date={{.Date}}'
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/runner/work/osxcross/target/bin/o64-clang
-      - CXX=/home/runner/work/osxcross/target/bin/o64-clang++
-    goos:
       - darwin
     goarch:
       - amd64
+      - arm64
     binary: tdex-darwin
 
   # unlocker
@@ -65,6 +53,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     binary: unlockerd
 
   # tdexdconnect
@@ -79,6 +68,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     binary: tdexdconnect
 ## flag the semver v**.**.**-<tag>.* as pre-release on Github
 release:
@@ -121,8 +111,7 @@ archives:
   - id: tdex
     format: binary
     builds:
-      - tdex-linux
-      - tdex-darwin
+      - tdex
     name_template: "tdex-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     
   - id: unlockerd

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,26 +1,10 @@
 builds:
   # daemon
-  - id: "tdexd-linux"
-    main: ./cmd/tdexd
-    ldflags:
-      - -s -w
-    env:
-      - CGO_ENABLED=1
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
-    binary: tdexd-linux
 
   - id: "tdexd-darwin"
     main: ./cmd/tdexd
     ldflags:
       - -s -w
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/runner/work/osxcross/target/bin/o64-clang
-      - CXX=/home/runner/work/osxcross/target/bin/o64-clang++
     goos:
       - darwin
     goarch:
@@ -104,7 +88,6 @@ archives:
   - id: tdexd
     format: binary
     builds:
-      - tdexd-linux
       - tdexd-darwin
     name_template: "tdexd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 builds:
   # daemon
 
+  ### Linux
   - id: "tdexd-linux-amd64"
     main: ./cmd/tdexd
     ldflags:
@@ -27,19 +28,35 @@ builds:
       - arm64
     binary: tdexd-linux-arm64
 
-  - id: "tdexd-darwin"
+  ### Darwin
+
+  - id: "tdexd-darwin-amd64"
     main: ./cmd/tdexd
     ldflags:
       - -s -w
     env:
       - CGO_ENABLED=1
-      - CC=/home/runner/work/osxcross/target/bin/o64-clang
-      - CXX=/home/runner/work/osxcross/target/bin/o64-clang++
+      - CC=o64-clang
+      - CXX=o64-clang++
     goos:
       - darwin
     goarch:
       - amd64
-    binary: tdexd-darwin
+    binary: tdexd-darwin-amd64
+    
+  - id: "tdexd-darwin-arm64"
+    main: ./cmd/tdexd
+    ldflags:
+      - -s -w
+    env:
+      - CGO_ENABLED=1
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    binary: tdexd-darwin-arm64
 
   # CLI
   - id: "tdex"
@@ -119,7 +136,8 @@ archives:
     builds:
       - tdexd-linux-amd64
       - tdexd-linux-arm64
-      - tdexd-darwin
+      - tdexd-darwin-amd64
+      - tdexd-darwin-arm64
     name_template: "tdexd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     
   - id: tdex

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 builds:
   # daemon
 
-  - id: "tdexd-linux"
+  - id: "tdexd-linux-amd64"
     main: ./cmd/tdexd
     ldflags:
       - -s -w
@@ -11,8 +11,28 @@ builds:
       - linux
     goarch:
       - amd64
-      - arm64
-    binary: tdexd-linux
+    binary: tdexd-linux-amd64
+
+  - id: "tdexd-linux-armhf"
+    main: ./cmd/tdexd
+    ldflags:
+      - -s -w
+    flags:
+      - -mod=readonly
+    env:
+      - CC=arm-linux-gnueabihf-gcc
+      - CXX=arm-linux-gnueabihf-g++
+      - CGO_FLAGS=--sysroot=/home/runner/work/sysroot/linux/armhf
+      - CGO_LDFLAGS=--sysroot=/home/runner/work/sysroot/linux/armhf
+      - PKG_CONFIG_SYSROOT_DIR=/home/runner/work/sysroot/linux/armhf
+      - PKG_CONFIG_PATH=/home/runner/work/sysroot/linux/armhf/opt/vc/lib/pkgconfig:/home/runner/work/sysroot/linux/armhf/usr/lib/arm-linux-gnueabihf/pkgconfig:/home/runner/work/sysroot/linux/armhf/usr/lib/pkgconfig:/home/runner/work/sysroot/linux/armhf/usr/local/lib/pkgconfig
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 7
+    binary: tdexd-linux-armhf
 
   - id: "tdexd-darwin"
     main: ./cmd/tdexd
@@ -104,7 +124,8 @@ archives:
   - id: tdexd
     format: binary
     builds:
-      - tdexd-linux
+      - tdexd-linux-amd64
+      - tdexd-linux-armhf
       - tdexd-darwin
     name_template: "tdexd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,26 +13,19 @@ builds:
       - amd64
     binary: tdexd-linux-amd64
 
-  - id: "tdexd-linux-armhf"
+  - id: "tdexd-linux-arm64"
     main: ./cmd/tdexd
     ldflags:
       - -s -w
-    flags:
-      - -mod=readonly
     env:
-      - CC=arm-linux-gnueabihf-gcc
-      - CXX=arm-linux-gnueabihf-g++
-      - CGO_FLAGS=--sysroot=/home/runner/work/sysroot/linux/armhf
-      - CGO_LDFLAGS=--sysroot=/home/runner/work/sysroot/linux/armhf
-      - PKG_CONFIG_SYSROOT_DIR=/home/runner/work/sysroot/linux/armhf
-      - PKG_CONFIG_PATH=/home/runner/work/sysroot/linux/armhf/opt/vc/lib/pkgconfig:/home/runner/work/sysroot/linux/armhf/usr/lib/arm-linux-gnueabihf/pkgconfig:/home/runner/work/sysroot/linux/armhf/usr/lib/pkgconfig:/home/runner/work/sysroot/linux/armhf/usr/local/lib/pkgconfig
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
     goos:
       - linux
     goarch:
-      - arm
-    goarm:
-      - 7
-    binary: tdexd-linux-armhf
+      - arm64
+    binary: tdexd-linux-arm64
 
   - id: "tdexd-darwin"
     main: ./cmd/tdexd
@@ -125,7 +118,7 @@ archives:
     format: binary
     builds:
       - tdexd-linux-amd64
-      - tdexd-linux-armhf
+      - tdexd-linux-arm64
       - tdexd-darwin
     name_template: "tdexd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,8 +20,8 @@ builds:
       - -s -w
     env:
       - CGO_ENABLED=1
-      - CC=/home/runner/work/osxcross/target/bin/aarch64-linux-gnu-gcc
-      - CXX=/home/runner/work/osxcross/target/bin/aarch64-linux-gnu-g++
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
     goos:
       - linux
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,15 +1,31 @@
 builds:
   # daemon
 
+  - id: "tdexd-linux"
+    main: ./cmd/tdexd
+    ldflags:
+      - -s -w
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    binary: tdexd-linux
+
   - id: "tdexd-darwin"
     main: ./cmd/tdexd
     ldflags:
       - -s -w
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/runner/work/osxcross/target/bin/o64-clang
+      - CXX=/home/runner/work/osxcross/target/bin/o64-clang++
     goos:
       - darwin
     goarch:
       - amd64
-      - arm64
     binary: tdexd-darwin
 
   # CLI
@@ -88,6 +104,7 @@ archives:
   - id: tdexd
     format: binary
     builds:
+      - tdexd-linux
       - tdexd-darwin
     name_template: "tdexd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -198,12 +198,11 @@ dockers:
      # push always either release or prerelease with a docker tag with the semver only
     skip_push: false
     use: buildx
-    goarch: arm64
     dockerfile: Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux
     # GOARCH of the built binaries/packages that should be used.
-    goarch: amd64
+    goarch: arm64
     # Template of the docker build flags.
     build_flag_templates:
       - "--platform=linux/arm64/v8"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -159,21 +159,24 @@ archives:
     name_template: "tdexdconnect-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 
 dockers:
-  # push always either release or prerelease with a docker tag with the semver only
-  - skip_push: false
+
+  #amd64
+  - image_templates:
+    - "ghcr.io/tdex-network/tdexd:{{ .Tag }}-amd64"
+     # push always either release or prerelease with a docker tag with the semver only
+    skip_push: false
+    use: buildx
     dockerfile: Dockerfile
-    # image templates
-    image_templates:
-      - "ghcr.io/tdex-network/tdexd:{{ .Tag }}"
     # GOOS of the built binaries/packages that should be used.
     goos: linux
     # GOARCH of the built binaries/packages that should be used.
     goarch: amd64
     # Template of the docker build flags.
     build_flag_templates:
+      - "--platform=linux/amd64"
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.title=tdexd"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--build-arg=VERSION={{.Version}}"
@@ -188,26 +191,31 @@ dockers:
       - pkg
       - cmd
       - api-spec
-  # push only release with both a docker tag latest and one with the semver
-  - skip_push: auto
+
+  # arm64
+  - image_templates:
+    - "ghcr.io/tdex-network/tdexd:{{ .Tag }}-arm64v8"
+     # push always either release or prerelease with a docker tag with the semver only
+    skip_push: false
+    use: buildx
+    goarch: arm64
     dockerfile: Dockerfile
-    # image templates
-    image_templates:
-      - "ghcr.io/tdex-network/tdexd:latest"
     # GOOS of the built binaries/packages that should be used.
     goos: linux
     # GOARCH of the built binaries/packages that should be used.
     goarch: amd64
     # Template of the docker build flags.
     build_flag_templates:
+      - "--platform=linux/arm64/v8"
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.title=tdexd"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--build-arg=VERSION={{.Version}}"
       - "--build-arg=COMMIT={{.Commit}}"
       - "--build-arg=DATE={{.Date}}"
+
     extra_files:
       - go.mod
       - go.sum
@@ -216,3 +224,9 @@ dockers:
       - pkg
       - cmd
       - api-spec
+
+docker_manifests:
+  - name_template: ghcr.io/tdex-network/tdexd:{{ .Tag }}
+    image_templates:
+    - ghcr.io/tdex-network/tdexd:{{ .Tag }}-amd64
+    - ghcr.io/tdex-network/tdexd:{{ .Tag }}-arm64v8

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -107,6 +107,19 @@ release:
 checksum:
   name_template: "checksums.txt"
 
+signs:
+  - artifacts: checksum
+    args:
+      [
+        "--batch",
+        "-u",
+        "{{ .Env.GPG_FINGERPRINT }}",
+        "--output",
+        "${signature}",
+        "--detach-sign",
+        "${artifact}",
+      ]
+
 snapshot:
   name_template: "{{ .Tag }}-next"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,8 +20,8 @@ builds:
       - -s -w
     env:
       - CGO_ENABLED=1
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=aarch64-linux-gnu-g++
+      - CC=/home/runner/work/osxcross/target/bin/aarch64-linux-gnu-gcc
+      - CXX=/home/runner/work/osxcross/target/bin/aarch64-linux-gnu-g++
     goos:
       - linux
     goarch:
@@ -36,8 +36,8 @@ builds:
       - -s -w
     env:
       - CGO_ENABLED=1
-      - CC=o64-clang
-      - CXX=o64-clang++
+      - CC=/home/runner/work/osxcross/target/bin/o64-clang
+      - CXX=/home/runner/work/osxcross/target/bin/o64-clang++
     goos:
       - darwin
     goarch:
@@ -50,8 +50,8 @@ builds:
       - -s -w
     env:
       - CGO_ENABLED=1
-      - CC=oa64-clang
-      - CXX=oa64-clang++
+      - CC=/home/runner/work/osxcross/target/bin/oa64-clang
+      - CXX=/home/runner/work/osxcross/target/bin/oa64-clang++
     goos:
       - darwin
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -160,6 +160,10 @@ archives:
 
 dockers:
 
+  ########################### 
+  # tag latest & prerelease #
+  ########################### 
+
   #amd64
   - image_templates:
     - "ghcr.io/tdex-network/tdexd:{{ .Tag }}-amd64"
@@ -229,3 +233,11 @@ docker_manifests:
     image_templates:
     - ghcr.io/tdex-network/tdexd:{{ .Tag }}-amd64
     - ghcr.io/tdex-network/tdexd:{{ .Tag }}-arm64v8
+    skip_push: false
+
+  - name_template: ghcr.io/tdex-network/tdexd:latest
+    image_templates:
+    - ghcr.io/tdex-network/tdexd:{{ .Tag }}-amd64
+    - ghcr.io/tdex-network/tdexd:{{ .Tag }}-arm64v8
+    skip_push: auto
+  

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,16 @@ FROM golang:1.16-buster AS builder
 ARG VERSION
 ARG COMMIT
 ARG DATE
+ARG TARGETOS
+ARG TARGETARCH
 
-RUN apt install gcc make gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-
-ENV GO111MODULE=on \
-    CGO_ENABLED=1
 
 WORKDIR /tdex-daemon
 
 COPY . .
 RUN go mod download
 
-RUN go build -ldflags="-s -w " -o tdexd-linux cmd/tdexd/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w " -o tdexd-linux cmd/tdexd/main.go
 RUN go build -ldflags="-X 'main.version=${VERSION}' -X 'main.commit=${COMMIT}' -X 'main.date=${DATE}'" -o tdex cmd/tdex/*
 RUN go build -ldflags="-s -w " -o unlockerd cmd/unlockerd/*
 RUN go build -ldflags="-s -w " -o tdexdconnect cmd/tdexdconnect/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,10 @@ ARG VERSION
 ARG COMMIT
 ARG DATE
 
+RUN apt install gcc make gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
 
 ENV GO111MODULE=on \
-    GOOS=linux \
     CGO_ENABLED=1 \
-    GOARCH=amd64
 
 WORKDIR /tdex-daemon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DATE
 RUN apt install gcc make gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
 
 ENV GO111MODULE=on \
-    CGO_ENABLED=1 \
+    CGO_ENABLED=1
 
 WORKDIR /tdex-daemon
 

--- a/cmd/tdex/config.go
+++ b/cmd/tdex/config.go
@@ -11,8 +11,6 @@ import (
 	"strconv"
 
 	"github.com/btcsuite/btcutil"
-	"github.com/tdex-network/tdex-daemon/pkg/explorer"
-	"github.com/tdex-network/tdex-daemon/pkg/explorer/esplora"
 	"github.com/tdex-network/tdex-daemon/pkg/tdexdconnect"
 	"github.com/urfave/cli/v2"
 	"github.com/vulpemventures/go-elements/network"
@@ -28,7 +26,6 @@ var (
 	daemonDatadir = btcutil.AppDataDir("tdex-daemon", false)
 
 	defaultNetwork         = network.Liquid.Name
-	defaultExplorer        = "https://blockstream.info/liquid/api"
 	defaultRPCServer       = "localhost:9000"
 	defaultNoMacaroonsAuth = false
 	defaultTLSCertPath     = filepath.Join(daemonDatadir, "tls", "cert.pem")
@@ -38,12 +35,6 @@ var (
 		Name:  "network, n",
 		Usage: "the network tdexd is running on: liquid or regtest",
 		Value: defaultNetwork,
-	}
-
-	explorerUrlFlag = cli.StringFlag{
-		Name:  "explorer_url",
-		Usage: "explorer url for the current network",
-		Value: defaultExplorer,
 	}
 
 	rpcFlag = cli.StringFlag{
@@ -87,7 +78,6 @@ var cliConfig = cli.Command{
 			Action: configInitAction,
 			Flags: []cli.Flag{
 				&networkFlag,
-				&explorerUrlFlag,
 				&rpcFlag,
 				&tlsCertFlag,
 				&noMacaroonsFlag,
@@ -118,7 +108,6 @@ func configAction(ctx *cli.Context) error {
 func configInitAction(c *cli.Context) error {
 	return setState(map[string]string{
 		"network":        c.String("network"),
-		"explorer_url":   c.String("explorer_url"),
 		"rpcserver":      c.String("rpcserver"),
 		"no_macaroons":   c.String(noMacaroonsKey),
 		"tls_cert_path":  cleanAndExpandPath(c.String(tlsCertPathKey)),
@@ -244,21 +233,6 @@ func getMarketFromState() (string, string, error) {
 	}
 
 	return baseAsset, quoteAsset, nil
-}
-
-func getExplorerFromState() (explorer.Service, error) {
-	state, err := getState()
-	if err != nil {
-		return nil, err
-	}
-
-	reqTimeout := 15000
-	url, ok := state["explorer_url"]
-	if !ok {
-		url = "https://blockstream.info/liquid/api"
-	}
-
-	return esplora.NewService(url, reqTimeout)
 }
 
 func getWalletFromState(walletType string) (map[string]string, error) {

--- a/cmd/tdex/main.go
+++ b/cmd/tdex/main.go
@@ -38,7 +38,6 @@ var (
 
 	initialState = map[string]string{
 		"network":        defaultNetwork,
-		"explorer_url":   defaultExplorer,
 		"rpcserver":      defaultRPCServer,
 		"no_macaroons":   strconv.FormatBool(defaultNoMacaroonsAuth),
 		"tls_cert_path":  defaultTLSCertPath,


### PR DESCRIPTION
- Remove `explorer` package from `tdex` cli, since is not used and this let us build the cli without CGO
- GoReleaser: Add a specific build step for `linux-arm64` and `darwin-arm64`
- Install Linux packages system wide `aarch64-linux-gnu-gcc` & `aarch64-linux-gnu-g++` needed to cross compile linux arm64
- referenced `o64-clang` & `oa64-clang++`  from OSX targets to build for new Apple Silicon chips
- GoReleaser: build two separated docker images for each architecture (arm,amd64) and merge them via `docker_manifests`

It closes #483 