### PR TITLE
Add configurable sats/byte for trade interface

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -46,6 +46,7 @@ var (
 	marketsFee                    = int64(config.GetFloat(config.DefaultFeeKey) * 100)
 	marketsBaseAsset              = config.GetString(config.BaseAssetKey)
 	tradesExpiryDurationInSeconds = config.GetDuration(config.TradeExpiryTimeKey) * time.Second
+	tradesSatsPerByte             = config.GetFloat(config.TradeSatsPerByte)
 	pricesSlippagePercentage      = decimal.NewFromFloat(config.GetFloat(config.PriceSlippageKey))
 	feeThreshold                  = uint64(config.GetInt(config.FeeAccountBalanceThresholdKey))
 	tradeSvcPort                  = config.GetInt(config.TradeListeningPortKey)
@@ -124,6 +125,7 @@ func main() {
 		blockchainListener,
 		marketsBaseAsset,
 		tradesExpiryDurationInSeconds,
+		tradesSatsPerByte,
 		pricesSlippagePercentage,
 		network,
 		feeThreshold,

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,8 @@ const (
 	FeeAccountBalanceThresholdKey = "FEE_ACCOUNT_BALANCE_THRESHOLD"
 	// TradeExpiryTimeKey is the duration in seconds of lock on unspents we reserve for accpeted trades, before eventually double spending it
 	TradeExpiryTimeKey = "TRADE_EXPIRY_TIME"
+	// TradeSatsPerByte is the sats per byte ratio to use for paying for trades' network fees
+	TradeSatsPerByte = "TRADE_SATS_PER_BYTE"
 	// PriceSlippageKey is the percentage of the slipage for accepting trades compared to current spot price
 	PriceSlippageKey = "PRICE_SLIPPAGE"
 	// TradeTLSKeyKey is the path of the the TLS key for the Trade interface
@@ -117,6 +119,7 @@ func init() {
 	vip.SetDefault(NetworkKey, network.Liquid.Name)
 	vip.SetDefault(BaseAssetKey, network.Liquid.AssetID)
 	vip.SetDefault(TradeExpiryTimeKey, 120)
+	vip.SetDefault(TradeSatsPerByte, 0.1)
 	vip.SetDefault(DatadirKey, defaultDatadir)
 	vip.SetDefault(PriceSlippageKey, 0.05)
 	vip.SetDefault(EnableProfilerKey, false)
@@ -282,6 +285,11 @@ func validate() error {
 	}
 	if start >= end {
 		return fmt.Errorf("%s must be greater than %s", RescanRangeStartKey, RescanGapLimitKey)
+	}
+
+	satsPerByte := GetFloat(TradeSatsPerByte)
+	if satsPerByte < 0.1 {
+		return fmt.Errorf("%s must be equal or greater than 0.1", TradeSatsPerByte)
 	}
 
 	return nil

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -23,6 +23,7 @@ import (
 var (
 	tradeExpiryDuration = 120 * time.Second
 	tradePriceSlippage  = decimal.NewFromFloat(0.1)
+	tradeSatsPerByte    = 0.1
 
 	tradeFeeOutpoints = []application.TxOutpoint{
 		{Hash: randomHex(32), Index: 0},
@@ -282,6 +283,7 @@ func newTradeService(
 		bcListener,
 		marketBaseAsset,
 		tradeExpiryDuration,
+		tradeSatsPerByte,
 		tradePriceSlippage,
 		regtest,
 		feeBalanceThreshold,

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -321,16 +321,17 @@ type Blinder interface {
 }
 
 type FillProposalOpts struct {
-	Mnemonic      []string
-	SwapRequest   domain.SwapRequest
-	MarketUtxos   []explorer.Utxo
-	FeeUtxos      []explorer.Utxo
-	MarketInfo    domain.AddressesInfo
-	FeeInfo       domain.AddressesInfo
-	OutputInfo    domain.AddressInfo
-	ChangeInfo    domain.AddressInfo
-	FeeChangeInfo domain.AddressInfo
-	Network       *network.Network
+	Mnemonic         []string
+	SwapRequest      domain.SwapRequest
+	MarketUtxos      []explorer.Utxo
+	FeeUtxos         []explorer.Utxo
+	MarketInfo       domain.AddressesInfo
+	FeeInfo          domain.AddressesInfo
+	OutputInfo       domain.AddressInfo
+	ChangeInfo       domain.AddressInfo
+	FeeChangeInfo    domain.AddressInfo
+	Network          *network.Network
+	MilliSatsPerByte int
 }
 
 type FillProposalResult struct {


### PR DESCRIPTION
This adds a new env var `TDEXD_TRADE_SATS_PER_BYTE` that allows to configure the ratio sat/byte to use when paying for network fees of accepted trades.

Closes #463.

Please @tiero review this.