### PR TITLE
Add permissions for fragmenter RPCs

### DIFF
--- a/internal/interfaces/grpc/permissions/permissions.go
+++ b/internal/interfaces/grpc/permissions/permissions.go
@@ -239,6 +239,14 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Entity: EntityMarket,
 			Action: "write",
 		}},
+		"/Operator/GetFeeFragmenterAddress": {{
+			Entity: EntityMarket,
+			Action: "write",
+		}},
+		"/Operator/FragmentFeeDeposits": {{
+			Entity: EntityMarket,
+			Action: "write",
+		}},
 		"/Operator/WithdrawFee": {{
 			Entity: EntityOperator,
 			Action: "write",
@@ -278,6 +286,14 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 		"/Operator/GetMarketCollectedSwapFees": {{
 			Entity: EntityMarket,
 			Action: "read",
+		}},
+		"/Operator/GetMarketFragmenterAddress": {{
+			Entity: EntityMarket,
+			Action: "write",
+		}},
+		"/Operator/FragmentMarketDeposits": {{
+			Entity: EntityMarket,
+			Action: "write",
 		}},
 		"/Operator/WithdrawMarket": {{
 			Entity: EntityOperator,


### PR DESCRIPTION
This adds the (missing) entries for fee and market fragmenter RPCs to the list of macaroons permissions.

Closes #488.

Please @tiero review this.