### PR TITLE
Add TDEX_QUOTE_ASSET env var & Enforce asset pair of NewMarket request to match the one fixed by the daemon

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -45,6 +45,7 @@ var (
 	// App services config
 	marketsFee                    = int64(config.GetFloat(config.DefaultFeeKey) * 100)
 	marketsBaseAsset              = config.GetString(config.BaseAssetKey)
+	marketsQuoteAsset             = config.GetString(config.QuoteAssetKey)
 	tradesExpiryDurationInSeconds = config.GetDuration(config.TradeExpiryTimeKey) * time.Second
 	tradesSatsPerByte             = config.GetFloat(config.TradeSatsPerByte)
 	pricesSlippagePercentage      = decimal.NewFromFloat(config.GetFloat(config.PriceSlippageKey))
@@ -123,7 +124,6 @@ func main() {
 		repoManager,
 		explorerSvc,
 		blockchainListener,
-		marketsBaseAsset,
 		tradesExpiryDurationInSeconds,
 		tradesSatsPerByte,
 		pricesSlippagePercentage,
@@ -135,6 +135,7 @@ func main() {
 		explorerSvc,
 		blockchainListener,
 		marketsBaseAsset,
+		marketsQuoteAsset,
 		marketsFee,
 		network,
 		feeThreshold,
@@ -153,6 +154,7 @@ func main() {
 		network,
 		marketsFee,
 		marketsBaseAsset,
+		marketsQuoteAsset,
 		rescanRangeStart,
 		rescanGapLimit,
 	)

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -115,6 +115,7 @@ type operatorService struct {
 	explorerSvc                explorer.Service
 	blockchainListener         BlockchainListener
 	marketBaseAsset            string
+	marketQuoteAsset           string
 	marketFee                  int64
 	network                    *network.Network
 	feeAccountBalanceThreshold uint64
@@ -128,7 +129,7 @@ func NewOperatorService(
 	repoManager ports.RepoManager,
 	explorerSvc explorer.Service,
 	bcListener BlockchainListener,
-	marketBaseAsset string,
+	marketBaseAsset, marketQuoteAsset string,
 	marketFee int64,
 	net *network.Network,
 	feeAccountBalanceThreshold uint64,
@@ -138,6 +139,7 @@ func NewOperatorService(
 		explorerSvc:                explorerSvc,
 		blockchainListener:         bcListener,
 		marketBaseAsset:            marketBaseAsset,
+		marketQuoteAsset:           marketQuoteAsset,
 		marketFee:                  marketFee,
 		network:                    net,
 		feeAccountBalanceThreshold: feeAccountBalanceThreshold,
@@ -476,7 +478,7 @@ func (o *operatorService) WithdrawFeeFunds(
 	)
 
 	// Start watching tx to confirm new unspents once the tx is in blockchain.
-	go o.blockchainListener.StartObserveTx(txid, "")
+	go o.blockchainListener.StartObserveTx(txid, Market{})
 
 	// Publish message for topic AccountWithdraw to pubsub service.
 	go func() {
@@ -517,9 +519,15 @@ func (o *operatorService) NewMarket(ctx context.Context, mkt Market) error {
 	if err := mkt.Validate(); err != nil {
 		return err
 	}
+	if len(o.marketBaseAsset) > 0 && mkt.BaseAsset != o.marketBaseAsset {
+		return ErrMarketInvalidBaseAsset
+	}
+	if len(o.marketQuoteAsset) > 0 && mkt.QuoteAsset != o.marketQuoteAsset {
+		return ErrMarketInvalidQuoteAsset
+	}
 
-	_, existingAccountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, mkt.QuoteAsset,
+	_, existingAccountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, mkt.BaseAsset, mkt.QuoteAsset,
 	)
 	if err != nil {
 		return err
@@ -579,8 +587,8 @@ func (o *operatorService) GetMarketAddress(
 		return nil, err
 	}
 
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, mkt.QuoteAsset,
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, mkt.BaseAsset, mkt.QuoteAsset,
 	)
 	if err != nil {
 		return nil, err
@@ -629,8 +637,8 @@ func (o *operatorService) ListMarketExternalAddresses(
 		return nil, err
 	}
 
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, mkt.QuoteAsset,
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, mkt.BaseAsset, mkt.QuoteAsset,
 	)
 	if err != nil {
 		return nil, err
@@ -664,8 +672,8 @@ func (o *operatorService) GetMarketBalance(
 		return nil, nil, err
 	}
 
-	market, _, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, mkt.QuoteAsset,
+	market, _, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, mkt.BaseAsset, mkt.QuoteAsset,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -689,14 +697,14 @@ func (o *operatorService) GetMarketBalance(
 
 // ClaimMarketDeposit method add unspents to the market
 func (o *operatorService) ClaimMarketDeposits(
-	ctx context.Context, marketReq Market, outpoints []TxOutpoint,
+	ctx context.Context, mkt Market, outpoints []TxOutpoint,
 ) error {
-	if err := validateMarketRequest(marketReq, o.marketBaseAsset); err != nil {
+	if err := mkt.Validate(); err != nil {
 		return err
 	}
 
-	market, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, marketReq.QuoteAsset,
+	market, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, mkt.BaseAsset, mkt.QuoteAsset,
 	)
 	if err != nil {
 		return err
@@ -731,8 +739,8 @@ func (o *operatorService) OpenMarket(ctx context.Context, mkt Market) error {
 	}
 
 	// Check if market exists
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, mkt.QuoteAsset,
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, mkt.BaseAsset, mkt.QuoteAsset,
 	)
 	if err != nil {
 		return err
@@ -757,8 +765,8 @@ func (o *operatorService) CloseMarket(ctx context.Context, mkt Market) error {
 		return err
 	}
 
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, mkt.QuoteAsset,
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, mkt.BaseAsset, mkt.QuoteAsset,
 	)
 	if err != nil {
 		return err
@@ -781,8 +789,8 @@ func (o *operatorService) DropMarket(ctx context.Context, market Market) error {
 		return err
 	}
 
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, market.QuoteAsset,
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, market.BaseAsset, market.QuoteAsset,
 	)
 	if err != nil {
 		return err
@@ -817,8 +825,8 @@ func (o *operatorService) DropMarket(ctx context.Context, market Market) error {
 func (o *operatorService) GetMarketCollectedFee(
 	ctx context.Context, mkt Market, page *Page,
 ) (*ReportMarketFee, error) {
-	m, _, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, mkt.QuoteAsset,
+	m, _, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, mkt.BaseAsset, mkt.QuoteAsset,
 	)
 	if err != nil {
 		return nil, err
@@ -889,8 +897,8 @@ func (o *operatorService) GetMarketFragmenterAddress(
 		return "", fmt.Errorf("invalid market: %s", err)
 	}
 
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, market.QuoteAsset,
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, market.BaseAsset, market.QuoteAsset,
 	)
 	if err != nil {
 		return "", err
@@ -927,8 +935,8 @@ func (o *operatorService) FragmentMarketDeposits(
 		return
 	}
 
-	mkt, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, market.QuoteAsset,
+	mkt, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, market.BaseAsset, market.QuoteAsset,
 	)
 	if err != nil {
 		chRes <- FragmentDepositsReply{
@@ -986,8 +994,8 @@ func (o *operatorService) WithdrawMarketFunds(
 		return nil, nil, err
 	}
 
-	market, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, req.QuoteAsset,
+	market, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, req.BaseAsset, req.QuoteAsset,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -1142,7 +1150,7 @@ func (o *operatorService) WithdrawMarketFunds(
 	)
 
 	// Start watching tx to confirm new unspents once the tx is in blockchain.
-	go o.blockchainListener.StartObserveTx(txid, market.QuoteAsset)
+	go o.blockchainListener.StartObserveTx(txid, req.Market)
 
 	// Publish message for topic AccountWithdraw to pubsub service.
 	go func() {
@@ -1191,12 +1199,8 @@ func (o *operatorService) UpdateMarketPercentageFee(
 		return nil, err
 	}
 
-	if req.BaseAsset != o.marketBaseAsset {
-		return nil, ErrMarketNotExist
-	}
-
-	mkt, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, req.QuoteAsset,
+	mkt, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, req.BaseAsset, req.QuoteAsset,
 	)
 	if err != nil {
 		return nil, err
@@ -1239,8 +1243,8 @@ func (o *operatorService) UpdateMarketFixedFee(
 		return nil, err
 	}
 
-	mkt, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, req.QuoteAsset,
+	mkt, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, req.BaseAsset, req.QuoteAsset,
 	)
 	if err != nil {
 		return nil, err
@@ -1287,8 +1291,8 @@ func (o *operatorService) UpdateMarketPrice(
 		return err
 	}
 
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, req.QuoteAsset,
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, req.BaseAsset, req.QuoteAsset,
 	)
 	if err != nil {
 		return err
@@ -1317,8 +1321,8 @@ func (o *operatorService) UpdateMarketStrategy(
 		return err
 	}
 
-	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAsset(
-		ctx, req.QuoteAsset,
+	_, accountIndex, err := o.repoManager.MarketRepository().GetMarketByAssets(
+		ctx, req.BaseAsset, req.QuoteAsset,
 	)
 	if err != nil {
 		return err
@@ -1703,11 +1707,14 @@ func (o *operatorService) claimDeposit(
 		// Start watching for those funds that are not yet confirmed.
 		go func() {
 			for _, txid := range unconfirmedTxs {
-				var mktQuoteAsset string
+				var mkt Market
 				if market != nil {
-					mktQuoteAsset = market.QuoteAsset
+					mkt = Market{
+						BaseAsset:  market.BaseAsset,
+						QuoteAsset: market.QuoteAsset,
+					}
 				}
-				o.blockchainListener.StartObserveTx(txid, mktQuoteAsset)
+				o.blockchainListener.StartObserveTx(txid, mkt)
 			}
 		}()
 
@@ -1731,7 +1738,7 @@ func (o *operatorService) checkFeeBalance(accountInfo domain.AddressesInfo) erro
 	feeAccountBalance, err := o.repoManager.UnspentRepository().GetBalance(
 		context.Background(),
 		accountInfo.Addresses(),
-		o.marketBaseAsset,
+		o.network.AssetID,
 	)
 	if err != nil {
 		return err
@@ -2233,13 +2240,19 @@ func tradeToTradeInfo(
 	if trade.IsEmpty() {
 		return
 	}
+	// to maintain backward compatibility, since trade.MarketBaseAsset has been
+	// introduced only in versions above v0.7.1.
+	mktBaseAsset := trade.MarketBaseAsset
+	if len(mktBaseAsset) == 0 {
+		mktBaseAsset = marketBaseAsset
+	}
 
 	info := TradeInfo{
 		ID:     trade.ID.String(),
 		Status: trade.Status,
 		MarketWithFee: MarketWithFee{
 			Market{
-				BaseAsset:  marketBaseAsset,
+				BaseAsset:  mktBaseAsset,
 				QuoteAsset: trade.MarketQuoteAsset,
 			},
 			Fee{
@@ -2298,23 +2311,6 @@ func tradeToTradeInfo(
 	}
 
 	chInfo <- info
-}
-
-func validateMarketRequest(marketReq Market, baseAsset string) error {
-	if err := validateAssetString(marketReq.BaseAsset); err != nil {
-		return err
-	}
-
-	if err := validateAssetString(marketReq.QuoteAsset); err != nil {
-		return err
-	}
-
-	// Checks if base asset is valid
-	if marketReq.BaseAsset != baseAsset {
-		return domain.ErrMarketInvalidBaseAsset
-	}
-
-	return nil
 }
 
 func groupAddressesInfoByScript(info domain.AddressesInfo) map[string]domain.AddressInfo {

--- a/internal/core/application/operator_service_test.go
+++ b/internal/core/application/operator_service_test.go
@@ -157,6 +157,7 @@ func newOperatorService() (application.OperatorService, error) {
 		explorerSvc,
 		bcListener,
 		marketBaseAsset,
+		"",
 		marketFee,
 		regtest,
 		feeBalanceThreshold,

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -281,7 +281,6 @@ func newTradeService(
 		repoManager,
 		explorerSvc,
 		bcListener,
-		marketBaseAsset,
 		tradeExpiryDuration,
 		tradeSatsPerByte,
 		tradePriceSlippage,

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -104,6 +104,9 @@ func (m Market) Validate() error {
 	if err := validateAssetString(m.QuoteAsset); err != nil {
 		return ErrMarketInvalidQuoteAsset
 	}
+	if m.BaseAsset == m.QuoteAsset {
+		return fmt.Errorf("quote asset must not be equal to base asset")
+	}
 	return nil
 }
 

--- a/internal/core/application/wallet_service.go
+++ b/internal/core/application/wallet_service.go
@@ -229,7 +229,7 @@ func (w *walletService) SendToMany(
 		domain.FeeAccount,
 	)
 
-	go w.blockchainListener.StartObserveTx(txid, "")
+	go w.blockchainListener.StartObserveTx(txid, Market{})
 
 	rawTx, _ := hex.DecodeString(txHex)
 	rawTxid, _ := hex.DecodeString(txid)

--- a/internal/core/application/walletunlocker_service.go
+++ b/internal/core/application/walletunlocker_service.go
@@ -101,6 +101,7 @@ type walletUnlockerService struct {
 	network            *network.Network
 	marketFee          int64
 	marketBaseAsset    string
+	marketQuoteAsset   string
 	rescanRangeStart   int
 	rescanRangeEnd     int
 
@@ -116,6 +117,7 @@ func NewWalletUnlockerService(
 	net *network.Network,
 	marketFee int64,
 	marketBaseAsset string,
+	marketQuoteAsset string,
 	rescanRangeStart, rescanRangeEnd int,
 ) WalletUnlockerService {
 	return newWalletUnlockerService(
@@ -125,6 +127,7 @@ func NewWalletUnlockerService(
 		net,
 		marketFee,
 		marketBaseAsset,
+		marketQuoteAsset,
 		rescanRangeStart,
 		rescanRangeEnd,
 	)
@@ -136,7 +139,7 @@ func newWalletUnlockerService(
 	blockchainListener BlockchainListener,
 	net *network.Network,
 	marketFee int64,
-	marketBaseAsset string,
+	marketBaseAsset, marketQuoteAsset string,
 	rescanRangeStart, rescanRangeEnd int,
 ) *walletUnlockerService {
 	w := &walletUnlockerService{
@@ -146,6 +149,7 @@ func newWalletUnlockerService(
 		network:            net,
 		marketFee:          marketFee,
 		marketBaseAsset:    marketBaseAsset,
+		marketQuoteAsset:   marketQuoteAsset,
 		rescanRangeStart:   rescanRangeStart,
 		rescanRangeEnd:     rescanRangeEnd,
 		lock:               &sync.RWMutex{},
@@ -632,10 +636,18 @@ func (w *walletUnlockerService) restoreMarket(
 		}
 		var baseAsset, quoteAsset string
 		for asset := range outpointsByAsset {
-			if asset == w.marketBaseAsset {
-				baseAsset = asset
+			if len(w.marketBaseAsset) > 0 {
+				if asset == w.marketBaseAsset {
+					baseAsset = asset
+				} else {
+					quoteAsset = asset
+				}
 			} else {
-				quoteAsset = asset
+				if asset == w.marketQuoteAsset {
+					quoteAsset = asset
+				} else {
+					baseAsset = asset
+				}
 			}
 		}
 

--- a/internal/core/application/walletunlocker_service_test.go
+++ b/internal/core/application/walletunlocker_service_test.go
@@ -158,6 +158,7 @@ func newWalletUnlockerService() application.WalletUnlockerService {
 		regtest,
 		marketFee,
 		marketBaseAsset,
+		"",
 		rescanRangeStart,
 		rescanRangeEnd,
 	)
@@ -189,6 +190,7 @@ func newWalletUnlockerServiceRestart() (application.WalletUnlockerService, error
 		regtest,
 		marketFee,
 		marketBaseAsset,
+		"",
 		rescanRangeStart,
 		rescanRangeEnd,
 	), nil
@@ -255,6 +257,7 @@ func newWalletUnlockerServiceRestore() application.WalletUnlockerService {
 		regtest,
 		marketFee,
 		marketBaseAsset,
+		"",
 		rescanRangeStart,
 		rescanRangeEnd,
 	)

--- a/internal/core/domain/market_repository.go
+++ b/internal/core/domain/market_repository.go
@@ -9,7 +9,9 @@ type MarketRepository interface {
 	// Retrieves a market with a given account index.
 	GetMarketByAccount(ctx context.Context, accountIndex int) (market *Market, err error)
 	// Retrieves a market with a given a quote asset hash.
-	GetMarketByAsset(ctx context.Context, quoteAsset string) (market *Market, accountIndex int, err error)
+	GetMarketByAssets(
+		ctx context.Context, baseAsset, quoteAsset string,
+	) (market *Market, accountIndex int, err error)
 	// Retrieves the latest market sorted by account index
 	GetLatestMarket(ctx context.Context) (market *Market, accountIndex int, err error)
 	// Retrieves all the markets that are open for trading
@@ -24,8 +26,8 @@ type MarketRepository interface {
 		updateFn func(m *Market) (*Market, error),
 	) error
 	// Open and close trading activities for a market with the given quote asset hash
-	OpenMarket(ctx context.Context, quoteAsset string) error
-	CloseMarket(ctx context.Context, quoteAsset string) error
+	OpenMarket(ctx context.Context, accountIndex int) error
+	CloseMarket(ctx context.Context, accountIndex int) error
 	// Update only the price without touching market details
 	UpdatePrices(ctx context.Context, accountIndex int, prices Prices) error
 	// DeleteMarket deletes market for accountIndex

--- a/internal/core/domain/trade_model.go
+++ b/internal/core/domain/trade_model.go
@@ -285,6 +285,7 @@ type Status struct {
 // Trade is the data structure representing a trade entity.
 type Trade struct {
 	ID                  uuid.UUID
+	MarketBaseAsset     string
 	MarketQuoteAsset    string
 	MarketPrice         Prices
 	MarketFee           int64

--- a/internal/core/domain/trade_service.go
+++ b/internal/core/domain/trade_service.go
@@ -11,7 +11,7 @@ import (
 // provided arguments.
 func (t *Trade) Propose(
 	swapRequest SwapRequest,
-	marketQuoteAsset string,
+	marketBaseAsset, marketQuoteAsset string,
 	marketFee, fixedBaseFee, fixedQuoteFee int64,
 	traderPubkey []byte,
 ) (bool, error) {
@@ -21,6 +21,7 @@ func (t *Trade) Propose(
 
 	now := uint64(time.Now().Unix())
 	t.TraderPubkey = traderPubkey
+	t.MarketBaseAsset = marketBaseAsset
 	t.MarketQuoteAsset = marketQuoteAsset
 	t.SwapRequest.ID = swapRequest.GetId()
 	t.SwapRequest.Timestamp = now

--- a/internal/core/domain/trade_service_test.go
+++ b/internal/core/domain/trade_service_test.go
@@ -23,8 +23,9 @@ var mockedErr = &domain.SwapError{
 
 func TestTradePropose(t *testing.T) {
 	swapRequest := newMockedSwapRequest()
-	marketAsset := swapRequest.GetAssetR()
-	marketFee := int64(25)
+	mktBaseAsset := swapRequest.GetAssetP()
+	mktQuoteAsset := swapRequest.GetAssetR()
+	mktFee := int64(25)
 	traderPubkey := []byte{}
 	mockedSwapParser := mockSwapParser{}
 	mockedSwapParser.On("SerializeRequest", swapRequest).Return(randomBytes(100), nil)
@@ -62,7 +63,8 @@ func TestTradePropose(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ok, err := tt.trade.Propose(swapRequest, marketAsset, marketFee, 0, 0, traderPubkey)
+			ok, err := tt.trade.Propose(
+				swapRequest, mktBaseAsset, mktQuoteAsset, mktFee, 0, 0, traderPubkey)
 			require.NoError(t, err)
 			require.True(t, ok)
 
@@ -76,8 +78,9 @@ func TestTradePropose(t *testing.T) {
 
 func TestFailingTradePropose(t *testing.T) {
 	swapRequest := newMockedSwapRequest()
-	marketAsset := swapRequest.GetAssetR()
-	marketFee := int64(25)
+	mktBaseAsset := swapRequest.GetAssetP()
+	mktQuoteAsset := swapRequest.GetAssetR()
+	mktFee := int64(25)
 	traderPubkey := []byte{}
 	mockedSwapParser := mockSwapParser{}
 	mockedSwapParser.On("SerializeRequest", swapRequest).Return(nil, mockedErr)
@@ -92,7 +95,9 @@ func TestFailingTradePropose(t *testing.T) {
 	t.Run("failing_because_invalid_request", func(t *testing.T) {
 		trade := newTradeEmpty()
 
-		ok, err := trade.Propose(swapRequest, marketAsset, marketFee, 0, 0, traderPubkey)
+		ok, err := trade.Propose(
+			swapRequest, mktBaseAsset, mktQuoteAsset, mktFee, 0, 0, traderPubkey,
+		)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.True(t, trade.IsProposal())

--- a/internal/infrastructure/storage/db/badger/market_repository_impl.go
+++ b/internal/infrastructure/storage/db/badger/market_repository_impl.go
@@ -35,11 +35,12 @@ func (m marketRepositoryImpl) GetMarketByAccount(
 	return m.getMarket(ctx, accountIndex)
 }
 
-func (m marketRepositoryImpl) GetMarketByAsset(
+func (m marketRepositoryImpl) GetMarketByAssets(
 	ctx context.Context,
-	quoteAsset string,
+	baseAsset, quoteAsset string,
 ) (market *domain.Market, accountIndex int, err error) {
-	query := badgerhold.Where("QuoteAsset").Eq(quoteAsset)
+	query := badgerhold.
+		Where("BaseAsset").Eq(baseAsset).And("QuoteAsset").Eq(quoteAsset)
 	markets, err := m.findMarkets(ctx, query)
 	if err != nil {
 		return nil, -1, err
@@ -117,9 +118,9 @@ func (m marketRepositoryImpl) UpdateMarket(
 
 func (m marketRepositoryImpl) OpenMarket(
 	ctx context.Context,
-	quoteAsset string,
+	accountIndex int,
 ) error {
-	query := badgerhold.Where("QuoteAsset").Eq(quoteAsset)
+	query := badgerhold.Where("AccountIndex").Eq(accountIndex)
 	markets, err := m.findMarkets(ctx, query)
 	if err != nil {
 		return err
@@ -147,9 +148,9 @@ func (m marketRepositoryImpl) OpenMarket(
 
 func (m marketRepositoryImpl) CloseMarket(
 	ctx context.Context,
-	quoteAsset string,
+	accountIndex int,
 ) error {
-	query := badgerhold.Where("QuoteAsset").Eq(quoteAsset)
+	query := badgerhold.Where("AccountIndex").Eq(accountIndex)
 	markets, err := m.findMarkets(ctx, query)
 	if err != nil {
 		return err

--- a/internal/infrastructure/storage/db/inmemory/db_manager.go
+++ b/internal/infrastructure/storage/db/inmemory/db_manager.go
@@ -11,9 +11,9 @@ import (
 )
 
 type marketInmemoryStore struct {
-	markets         map[int]domain.Market
-	accountsByAsset map[string]int
-	locker          *sync.Mutex
+	markets             map[int]domain.Market
+	accountsByAssetsKey map[string]int
+	locker              *sync.Mutex
 }
 
 type tradeInmemoryStore struct {
@@ -78,9 +78,9 @@ func (tx *InmemoryTx) Discard() {
 
 func NewRepoManager() ports.RepoManager {
 	marketStore := &marketInmemoryStore{
-		markets:         map[int]domain.Market{},
-		accountsByAsset: map[string]int{},
-		locker:          &sync.Mutex{},
+		markets:             map[int]domain.Market{},
+		accountsByAssetsKey: map[string]int{},
+		locker:              &sync.Mutex{},
 	}
 	tradeStore := &tradeInmemoryStore{
 		trades:               map[uuid.UUID]domain.Trade{},

--- a/internal/infrastructure/storage/db/test/market_repository_impl_test.go
+++ b/internal/infrastructure/storage/db/test/market_repository_impl_test.go
@@ -157,7 +157,7 @@ func testGetMarketByAsset(t *testing.T, repo marketRepository) {
 	}
 	resp, err := repo.read(
 		func(ctx context.Context) (interface{}, error) {
-			mkt, accountIndex, err := repo.Repository.GetMarketByAsset(ctx, quoteAsset)
+			mkt, accountIndex, err := repo.Repository.GetMarketByAssets(ctx, baseAsset, quoteAsset)
 			if err != nil {
 				return nil, err
 			}
@@ -180,7 +180,7 @@ func testGetMarketByAsset(t *testing.T, repo marketRepository) {
 
 	resp, err = repo.read(
 		func(ctx context.Context) (interface{}, error) {
-			mkt, accountIndex, err := repo.Repository.GetMarketByAsset(ctx, quoteAsset)
+			mkt, accountIndex, err := repo.Repository.GetMarketByAssets(ctx, baseAsset, quoteAsset)
 			if err != nil {
 				return nil, err
 			}
@@ -225,7 +225,7 @@ func testOpenCloseMarket(t *testing.T, repo marketRepository) {
 			return nil, err
 		}
 
-		if err := repo.Repository.OpenMarket(ctx, quoteAsset); err != nil {
+		if err := repo.Repository.OpenMarket(ctx, accountIndex); err != nil {
 			return nil, err
 		}
 
@@ -238,7 +238,7 @@ func testOpenCloseMarket(t *testing.T, repo marketRepository) {
 	require.True(t, len(markets) > 0)
 
 	iClosedMarkets, err := repo.write(func(ctx context.Context) (interface{}, error) {
-		if err := repo.Repository.CloseMarket(ctx, quoteAsset); err != nil {
+		if err := repo.Repository.CloseMarket(ctx, accountIndex); err != nil {
 			return nil, err
 		}
 		return repo.Repository.GetTradableMarkets(ctx)

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -88,9 +88,9 @@ func main() {
 	if _, err := runCommandWithEnv(
 		cliEnv, cli, "config", "init",
 		"--network", "regtest",
-		"--explorer_url", explorerUrl,
 		"--no_macaroons",
 	); err != nil {
+		fmt.Println(err)
 		return
 	}
 
@@ -281,7 +281,7 @@ func runCommandWithEnv(env []string, name string, arg ...string) (string, error)
 	cmd := newCommand(outb, errb, name, arg...)
 	cmd.Env = env
 	if err := cmd.Run(); err != nil {
-		return "", err
+		return "", fmt.Errorf("%s: %s", err, errb.String())
 	}
 	if errMsg := errb.String(); len(errMsg) > 0 {
 		return "", fmt.Errorf(errMsg)
@@ -391,15 +391,17 @@ func setupFeeder() error {
 	configMap := map[string]interface{}{
 		"price_feeder": "kraken",
 		"interval":     1000,
-		"markets": []map[string]interface{}{
-			{
-				"base_asset":  lbtcAsset,
-				"quote_asset": usdtAsset,
-				"ticker":      "XBT/USDT",
-				"targets": map[string]string{
-					"rpc_address":    "localhost:9000",
-					"tls_cert_path":  "",
-					"macaroons_path": "",
+		"targets": map[string]string{
+			"rpc_address":    "localhost:9000",
+			"tls_cert_path":  "",
+			"macaroons_path": "",
+		},
+		"well_known_markets": map[string]interface{}{
+			"kraken": []map[string]interface{}{
+				{
+					"base_asset":  lbtcAsset,
+					"quote_asset": usdtAsset,
+					"ticker":      "XBT/USDT",
 				},
 			},
 		},


### PR DESCRIPTION
This adds a new env var `TDEX_QUOTE_ASSET` to allow the user to fix the quote asset of the markets it will then open instead of the base one.

Internally, this means that the quote asset is not an always-changing value anymore because it could be fixed. Therefore, it cannot be used alone to identify a market but must be used together with the base asset to find a market domain in the repo.

This requires to change the market repository method `GetMarketByAsset(context, marketQuoteAsset)` to `GetMarketByAssets(context, marketBaseAsset, marketQuoteAsset)`.

Always for the same reason, it is now required that the trade domain stores not only the mkt quote asset, but also the base one.

This also enforces at application level that the base/quote assets of the market provided by the user in NewMarket match the one fixed into the daemon and they are not equal.

Closes #491.
Closes #492.
Closes #493.

BONUS: This updates the e2e test to work with recent changes to operator CLI and TDEX Feeder.

Please @tiero, review this.,