### PR TITLE
Fix pluggable strategy type & Allow only base/quote fixed fee when updating

### DIFF
--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -37,8 +37,6 @@ var (
 	ErrMarketInvalidQuoteAsset = errors.New("invalid quote asset")
 	// ErrInvalidFixedFee ...
 	ErrInvalidFixedFee = errors.New("fixed fee must be a positive value")
-	// ErrMissingFixedFee ...
-	ErrMissingFixedFee = errors.New("fixed fee requires both base and quote amounts to be defined")
 	// ErrMarketPreviewAmountTooLow is returned when a preview fails because
 	// the provided amount makes the previewed amount to be too low (lower than
 	// the optional fixed fee).

--- a/internal/core/domain/market_service.go
+++ b/internal/core/domain/market_service.go
@@ -20,18 +20,6 @@ func (p Prices) AreZero() bool {
 	return decimal.Decimal(p.BasePrice).Equal(decimal.NewFromInt(0)) && decimal.Decimal(p.QuotePrice).Equal(decimal.NewFromInt(0))
 }
 
-func (f FixedFee) validate() error {
-	if f.BaseFee < 0 || f.QuoteFee < 0 {
-		return ErrInvalidFixedFee
-	}
-
-	if (f.BaseFee > 0 && f.QuoteFee == 0) || (f.QuoteFee > 0 && f.BaseFee == 0) {
-		return ErrMissingFixedFee
-	}
-
-	return nil
-}
-
 // IsTradable returns true if the market is available for trading
 func (m *Market) IsTradable() bool {
 	return m.Tradable
@@ -151,8 +139,12 @@ func (m *Market) ChangeFixedFee(baseFee, quoteFee int64) error {
 		return err
 	}
 
-	m.FixedFee.BaseFee = baseFee
-	m.FixedFee.QuoteFee = quoteFee
+	if baseFee > 0 {
+		m.FixedFee.BaseFee = baseFee
+	}
+	if quoteFee > 0 {
+		m.FixedFee.QuoteFee = quoteFee
+	}
 	return nil
 }
 
@@ -376,9 +368,6 @@ func validateFee(basisPoint int64) error {
 func validateFixedFee(baseFee, quoteFee int64) error {
 	if baseFee < 0 || quoteFee < 0 {
 		return ErrInvalidFixedFee
-	}
-	if (baseFee > 0 && quoteFee == 0) || (quoteFee > 0 && baseFee == 0) {
-		return ErrMissingFixedFee
 	}
 
 	return nil

--- a/internal/core/domain/market_service.go
+++ b/internal/core/domain/market_service.go
@@ -52,10 +52,8 @@ func (m *Market) QuoteAssetPrice() decimal.Decimal {
 }
 
 // IsStrategyPluggable returns true if the the startegy isn't automated.
-// For backward compatibility it returns whether the strategy is zero-ed or,
-// on the contrary, its type is extaclty PluggableStrategyType.
 func (m *Market) IsStrategyPluggable() bool {
-	return m.Strategy.IsZero() || m.Strategy.Type == PluggableStrategyType
+	return !m.Strategy.IsZero() && m.Strategy.Type == int(StrategyTypePluggable)
 }
 
 // IsStrategyPluggableInitialized returns true if the prices have been set.

--- a/internal/core/domain/market_service_test.go
+++ b/internal/core/domain/market_service_test.go
@@ -229,9 +229,13 @@ func TestChangeFixedFee(t *testing.T) {
 
 	m := newTestMarket()
 	baseFee := int64(100)
-	quoteFee := int64(200000)
+	err := m.ChangeFixedFee(baseFee, 0)
+	require.NoError(t, err)
+	require.Equal(t, baseFee, m.FixedFee.BaseFee)
+	require.Zero(t, m.FixedFee.QuoteFee)
 
-	err := m.ChangeFixedFee(baseFee, quoteFee)
+	quoteFee := int64(200000)
+	err = m.ChangeFixedFee(0, quoteFee)
 	require.NoError(t, err)
 	require.Equal(t, baseFee, m.FixedFee.BaseFee)
 	require.Equal(t, quoteFee, m.FixedFee.QuoteFee)
@@ -264,18 +268,6 @@ func TestFailingChangeFixedFee(t *testing.T) {
 			baseFee:       100,
 			quoteFee:      -1,
 			expectedError: domain.ErrInvalidFixedFee,
-		},
-		{
-			name:          "missing_fixed_base_fee",
-			market:        newTestMarket(),
-			quoteFee:      1000,
-			expectedError: domain.ErrMissingFixedFee,
-		},
-		{
-			name:          "missing_fixed_quote_fee",
-			market:        newTestMarket(),
-			baseFee:       1000,
-			expectedError: domain.ErrMissingFixedFee,
 		},
 	}
 

--- a/internal/core/domain/pluggable_strategy.go
+++ b/internal/core/domain/pluggable_strategy.go
@@ -7,8 +7,6 @@ import (
 	"github.com/tdex-network/tdex-daemon/pkg/mathutil"
 )
 
-const PluggableStrategyType = 255
-
 type PluggableStrategyOpts struct {
 	BalanceIn  uint64
 	BalanceOut uint64
@@ -60,5 +58,5 @@ func (s PluggableStrategy) InGivenOut(_opts interface{}, amountOut uint64) (uint
 }
 
 func (s PluggableStrategy) FormulaType() int {
-	return PluggableStrategyType
+	return int(StrategyTypePluggable)
 }

--- a/internal/infrastructure/storage/db/badger/market_repository_impl.go
+++ b/internal/infrastructure/storage/db/badger/market_repository_impl.go
@@ -364,12 +364,14 @@ func (m marketRepositoryImpl) updatePriceByAccountIndex(ctx context.Context, acc
 }
 
 func restoreStrategy(market *domain.Market) {
-	if !market.IsStrategyPluggable() {
-		switch market.Strategy.Type {
-		case formula.BalancedReservesType:
-			market.Strategy = mm.NewStrategyFromFormula(formula.BalancedReserves{})
-		}
+	var strategy mm.MakingStrategy
+	switch market.Strategy.Type {
+	case formula.BalancedReservesType:
+		strategy = mm.NewStrategyFromFormula(formula.BalancedReserves{})
+	default:
+		strategy = mm.NewStrategyFromFormula(domain.PluggableStrategy{})
 	}
+	market.Strategy = strategy
 }
 
 func (m marketRepositoryImpl) DeleteMarket(

--- a/pkg/marketmaking/market_making.go
+++ b/pkg/marketmaking/market_making.go
@@ -32,7 +32,7 @@ func NewStrategyFromFormula(
 
 // IsZero checks if the given strategy is the zero value
 func (ms MakingStrategy) IsZero() bool {
-	return ms.Type == 0
+	return ms.Type == 0 && ms.formula == nil
 }
 
 // Formula returns the mathematical formula of the MM strategy


### PR DESCRIPTION
This introduces changes to fix the strategy type returned by the daemon and to not require both the base and the quote fee to be defined to update the market fixed fee.

Closes #500.
Cloeses #501.

Please @tiero review this.