### PR TITLE
Fragmenters: Wait for tx to be returned by the explorer before claiming & Use fee account to cover fees of market fragmentation

### DIFF
--- a/internal/core/application/explorer_utils.go
+++ b/internal/core/application/explorer_utils.go
@@ -2,6 +2,8 @@ package application
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/tdex-network/tdex-daemon/internal/core/ports"
 	"github.com/tdex-network/tdex-daemon/pkg/circuitbreaker"
@@ -62,4 +64,19 @@ func getBalancesByAsset(unspents []explorer.Utxo) map[string]BalanceInfo {
 		balances[unspent.Asset()] = balance
 	}
 	return balances
+}
+
+func waitForTx(explorerSvc explorer.Service, txid string) error {
+	waitingTime := 1 * time.Second
+	for {
+		_, err := explorerSvc.GetTransaction(txid)
+		if err != nil {
+			if strings.Contains(err.Error(), "Transaction not found") {
+				time.Sleep(waitingTime)
+				continue
+			}
+			return err
+		}
+		return nil
+	}
 }

--- a/internal/core/application/explorer_utils.go
+++ b/internal/core/application/explorer_utils.go
@@ -2,8 +2,6 @@ package application
 
 import (
 	"context"
-	"strings"
-	"time"
 
 	"github.com/tdex-network/tdex-daemon/internal/core/ports"
 	"github.com/tdex-network/tdex-daemon/pkg/circuitbreaker"
@@ -64,19 +62,4 @@ func getBalancesByAsset(unspents []explorer.Utxo) map[string]BalanceInfo {
 		balances[unspent.Asset()] = balance
 	}
 	return balances
-}
-
-func waitForTx(explorerSvc explorer.Service, txid string) error {
-	waitingTime := 1 * time.Second
-	for {
-		_, err := explorerSvc.GetTransaction(txid)
-		if err != nil {
-			if strings.Contains(err.Error(), "Transaction not found") {
-				time.Sleep(waitingTime)
-				continue
-			}
-			return err
-		}
-		return nil
-	}
 }

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -3,6 +3,7 @@ package application_test
 import (
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/tdex-network/tdex-daemon/internal/core/application"
@@ -206,6 +207,18 @@ func (m *mockExplorer) BroadcastTransaction(txhex string) (string, error) {
 	var res string
 	if a := args.Get(0); a != nil {
 		res = a.(string)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) PollGetKnownTransaction(
+	txid string, interval time.Duration,
+) (explorer.Transaction, error) {
+	args := m.Called(txid, interval)
+
+	var res explorer.Transaction
+	if a := args.Get(0); a != nil {
+		res = a.(explorer.Transaction)
 	}
 	return res, args.Error(1)
 }

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -35,7 +35,8 @@ var (
 		3: 10,
 		5: 2,
 	}
-	PollInterval = 1 * time.Second
+	PollInterval           = 1 * time.Second
+	MinFeeFragmenterAmount = 5000
 )
 
 // OperatorService defines the methods of the application layer for the operator service.
@@ -1839,6 +1840,15 @@ func (o *operatorService) splitFeeFragmenterFunds(
 			Err: fmt.Errorf(
 				"found funds with asset different from LBTC. Use a recover address " +
 					"to get them back",
+			),
+		}
+		return
+	}
+	if int(amountPerAsset[lbtc]) < MinFeeFragmenterAmount {
+		chRes <- FragmenterSplitFundsReply{
+			Err: fmt.Errorf(
+				"amount to fragment is too small, should be at least %d sats of LBTC",
+				MinFeeFragmenterAmount,
 			),
 		}
 		return

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -35,6 +35,7 @@ var (
 		3: 10,
 		5: 2,
 	}
+	PollInterval = 1 * time.Second
 )
 
 // OperatorService defines the methods of the application layer for the operator service.
@@ -1935,7 +1936,9 @@ func (o *operatorService) splitFeeFragmenterFunds(
 	chRes <- FragmenterSplitFundsReply{
 		Msg: "waiting for tx to appear at list in mempool",
 	}
-	if err := waitForTx(o.explorerSvc, txid); err != nil {
+	if _, err := o.explorerSvc.PollGetKnownTransaction(
+		txid, PollInterval,
+	); err != nil {
 		chRes <- FragmenterSplitFundsReply{
 			Err: fmt.Errorf("failed while waiting for tx: %s", err),
 		}
@@ -2130,7 +2133,9 @@ func (o *operatorService) splitMarketFragmenterFunds(
 	chRes <- FragmenterSplitFundsReply{
 		Msg: "waiting for tx to appear at list in mempool",
 	}
-	if err := waitForTx(o.explorerSvc, txid); err != nil {
+	if _, err := o.explorerSvc.PollGetKnownTransaction(
+		txid, PollInterval,
+	); err != nil {
 		chRes <- FragmenterSplitFundsReply{
 			Err: fmt.Errorf("failed while waiting for tx: %s", err),
 		}

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -1933,6 +1933,16 @@ func (o *operatorService) splitFeeFragmenterFunds(
 	}
 
 	chRes <- FragmenterSplitFundsReply{
+		Msg: "waiting for tx to appear at list in mempool",
+	}
+	if err := waitForTx(o.explorerSvc, txid); err != nil {
+		chRes <- FragmenterSplitFundsReply{
+			Err: fmt.Errorf("failed while waiting for tx: %s", err),
+		}
+		return
+	}
+
+	chRes <- FragmenterSplitFundsReply{
 		Msg: "claiming deposits for fee account",
 	}
 
@@ -2115,6 +2125,16 @@ func (o *operatorService) splitMarketFragmenterFunds(
 
 	chRes <- FragmenterSplitFundsReply{
 		Msg: fmt.Sprintf("market account funding transaction: %s", txid),
+	}
+
+	chRes <- FragmenterSplitFundsReply{
+		Msg: "waiting for tx to appear at list in mempool",
+	}
+	if err := waitForTx(o.explorerSvc, txid); err != nil {
+		chRes <- FragmenterSplitFundsReply{
+			Err: fmt.Errorf("failed while waiting for tx: %s", err),
+		}
+		return
 	}
 
 	chRes <- FragmenterSplitFundsReply{

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -2212,7 +2212,9 @@ func (o *operatorService) splitMarketFragmenterFunds(
 		if err != nil {
 			log.WithError(err).Warn("an error occured while locking fee account unspents")
 		}
-		log.Debugf("locked %d unspents for account %d", count, domain.FeeAccount)
+		if count > 0 {
+			log.Debugf("locked %d unspents for account %d", count, domain.FeeAccount)
+		}
 	}()
 
 	chRes <- FragmenterSplitFundsReply{
@@ -2450,7 +2452,7 @@ func (o *operatorService) withdrawMarketFragmenterFunds(
 			return
 		}
 		if count > 0 {
-			log.Debug("locked %d unspents for accoutn", count, domain.FeeAccount)
+			log.Debugf("locked %d unspents for account %d", count, domain.FeeAccount)
 		}
 
 		o.blockchainListener.StartObserveTx(txid, Market{})

--- a/pkg/crawler/mock_test.go
+++ b/pkg/crawler/mock_test.go
@@ -1,6 +1,8 @@
 package crawler_test
 
 import (
+	"time"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
 )
@@ -103,6 +105,18 @@ func (m *mockExplorer) BroadcastTransaction(txhex string) (string, error) {
 	var res string
 	if a := args.Get(0); a != nil {
 		res = a.(string)
+	}
+	return res, args.Error(1)
+}
+
+func (m *mockExplorer) PollGetKnownTransaction(
+	txid string, interval time.Duration,
+) (explorer.Transaction, error) {
+	args := m.Called(txid, interval)
+
+	var res explorer.Transaction
+	if a := args.Get(0); a != nil {
+		res = a.(explorer.Transaction)
 	}
 	return res, args.Error(1)
 }

--- a/pkg/explorer/elements/transaction.go
+++ b/pkg/explorer/elements/transaction.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/tdex-network/tdex-daemon/pkg/explorer"
 	"github.com/vulpemventures/go-elements/address"
@@ -161,6 +162,12 @@ func (e *elements) BroadcastTransaction(txhex string) (string, error) {
 		return "", fmt.Errorf("unmarshal: %w", err)
 	}
 	return txid, nil
+}
+
+func (e *elements) PollGetKnownTransaction(
+	_ string, _ time.Duration,
+) (explorer.Transaction, error) {
+	return nil, fmt.Errorf("unimplemented")
 }
 
 /**** Regtest only ****/

--- a/pkg/explorer/explorer.go
+++ b/pkg/explorer/explorer.go
@@ -1,6 +1,8 @@
 package explorer
 
 import (
+	"time"
+
 	"github.com/vulpemventures/go-elements/transaction"
 )
 
@@ -82,6 +84,11 @@ type Service interface {
 	BroadcastTransaction(txhex string) (txid string, err error)
 	// GetBlockHeight returns the the number of block of the blockchain.
 	GetBlockHeight() (int, error)
+	// PollGetKnownTransaction polls the GetTransaction method until the transaction
+	// is actualy returned by the explorer. It may be needed when the explorer
+	// suffers of delays to keep in sync with the mempool/blockchain.
+	PollGetKnownTransaction(txid string, interval time.Duration) (tx Transaction, err error)
+
 	/**** REGTEST ONLY ****/
 	// Faucet funds the given address with the amount (in BTC) of provided asset
 	Faucet(address string, amount float64, asset string) (txid string, err error)


### PR DESCRIPTION
This adds a waiting function that polls the explorer until the fee/market funding transaction made with the related fragmenter is returned.

Only after this, the fragmenter can proceed with claiming the funds for the account.

Closes #514.
Closes #517.

~~EDIT: This adds also a check to prevent splitting too small amounts in fee fragmentation~~

Please @tiero review this.