### PR TITLE
Hotfix GetMarketInfo macaroon permission

### DIFF
--- a/internal/interfaces/grpc/permissions/permissions.go
+++ b/internal/interfaces/grpc/permissions/permissions.go
@@ -249,7 +249,7 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 		}},
 		"/Operator/GetMarketInfo": {{
 			Entity: EntityMarket,
-			Action: "info",
+			Action: "read",
 		}},
 		"/Operator/GetMarketAddress": {{
 			Entity: EntityMarket,


### PR DESCRIPTION
This fixes the macaroon permission for the GetMarketInfo RPC.

Please @tiero review this.