### PR TITLE
Allow fragmenting only one asset of the pair for already funded markets

### DIFF
--- a/cmd/tdex/market.go
+++ b/cmd/tdex/market.go
@@ -133,10 +133,12 @@ var (
 			&cli.Int64Flag{
 				Name:  "base_fee",
 				Usage: "set the fixed fee for base asset",
+				Value: -1,
 			},
 			&cli.Int64Flag{
 				Name:  "quote_fee",
 				Usage: "set the fixed fee for quote asset",
+				Value: -1,
 			},
 		},
 		Action: marketUpdateFixedFeeAction,

--- a/internal/core/application/constants.go
+++ b/internal/core/application/constants.go
@@ -30,6 +30,6 @@ var (
 	esploraUrlByNetwork = map[string]string{
 		"liquid":  "https://blockstream.info/liquid",
 		"testnet": "https://blockstream.info/liquidtestnet",
-		"regtest": "http://localhost:3001",
+		"regtest": "http://localhost:5001",
 	}
 )

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -1792,10 +1792,6 @@ func (o *operatorService) claimDeposit(
 func verifyMarketFunds(
 	market *domain.Market, unspents []domain.Unspent,
 ) error {
-	if !market.IsStrategyBalanced() {
-		return nil
-	}
-
 	outpoints := make([]domain.OutpointWithAsset, 0, len(unspents))
 	for _, u := range unspents {
 		outpoints = append(outpoints, u.ToOutpointWithAsset())

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -2059,24 +2059,25 @@ func (o *operatorService) splitMarketFragmenterFunds(
 	// If the market has zero balance, it's mandatory to send both base and quote
 	// asset to the market fragmenter account. Otherwise, it's possible to split
 	// funds of only one of the assets of the pair.
-	marketBalance, _ := getBalanceForMarket(o.repoManager, ctx, market, false)
-	if market.IsStrategyBalanced() && marketBalance.BaseAmount == 0 &&
-		marketBalance.QuoteAmount == 0 {
-		if assetValuePair.baseValue == 0 {
-			chRes <- FragmenterSplitFundsReply{
-				Err: fmt.Errorf(
-					"missing base asset funds",
-				),
+	if market.IsStrategyBalanced() {
+		marketBalance, _ := getBalanceForMarket(o.repoManager, ctx, market, false)
+		if marketBalance.BaseAmount == 0 && marketBalance.QuoteAmount == 0 {
+			if assetValuePair.baseValue == 0 {
+				chRes <- FragmenterSplitFundsReply{
+					Err: fmt.Errorf(
+						"missing base asset funds",
+					),
+				}
+				return
 			}
-			return
-		}
-		if assetValuePair.quoteValue == 0 {
-			chRes <- FragmenterSplitFundsReply{
-				Err: fmt.Errorf(
-					"missing quote asset funds",
-				),
+			if assetValuePair.quoteValue == 0 {
+				chRes <- FragmenterSplitFundsReply{
+					Err: fmt.Errorf(
+						"missing quote asset funds",
+					),
+				}
+				return
 			}
-			return
 		}
 	}
 

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -2005,10 +2005,6 @@ func (o *operatorService) splitFeeFragmenterFunds(
 		return
 	}
 
-	chRes <- FragmenterSplitFundsReply{
-		Msg: "fragmentation succeeded",
-	}
-
 	go func() {
 		if err := o.repoManager.VaultRepository().UpdateVault(
 			ctx, func(_ *domain.Vault) (*domain.Vault, error) {
@@ -2018,6 +2014,10 @@ func (o *operatorService) splitFeeFragmenterFunds(
 			log.WithError(err).Warn("an error occured while updating vault")
 		}
 	}()
+
+	chRes <- FragmenterSplitFundsReply{
+		Msg: "fragmentation succeeded",
+	}
 }
 
 func (o *operatorService) splitMarketFragmenterFunds(

--- a/internal/core/application/operator_service.go
+++ b/internal/core/application/operator_service.go
@@ -1792,6 +1792,10 @@ func (o *operatorService) claimDeposit(
 func verifyMarketFunds(
 	market *domain.Market, unspents []domain.Unspent,
 ) error {
+	if !market.IsStrategyBalanced() {
+		return nil
+	}
+
 	outpoints := make([]domain.OutpointWithAsset, 0, len(unspents))
 	for _, u := range unspents {
 		outpoints = append(outpoints, u.ToOutpointWithAsset())
@@ -2060,7 +2064,8 @@ func (o *operatorService) splitMarketFragmenterFunds(
 	// asset to the market fragmenter account. Otherwise, it's possible to split
 	// funds of only one of the assets of the pair.
 	marketBalance, _ := getBalanceForMarket(o.repoManager, ctx, market, false)
-	if marketBalance.BaseAmount == 0 && marketBalance.QuoteAmount == 0 {
+	if market.IsStrategyBalanced() && marketBalance.BaseAmount == 0 &&
+		marketBalance.QuoteAmount == 0 {
 		if assetValuePair.baseValue == 0 {
 			chRes <- FragmenterSplitFundsReply{
 				Err: fmt.Errorf(

--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -33,11 +33,11 @@ var (
 	//ErrMarketNotFunded is thrown when a market requires being funded for a change
 	ErrMarketNotFunded = errors.New("market must be funded")
 	//ErrMarketIsClosed is thrown when a market requires being tradable for a change
-	ErrMarketIsClosed = errors.New("market is closed")
+	ErrMarketIsClosed = errors.New("the market is paused, please open it first")
 	//ErrMarketMustBeClosed is thrown when a market requires being NOT tradable for a change
-	ErrMarketMustBeClosed = errors.New("market must be closed")
+	ErrMarketMustBeClosed = errors.New("the market is active, please pause it first")
 	//ErrMarketNotPriced is thrown when the price is still 0 (ie. not initialized)
-	ErrMarketNotPriced = errors.New("price must be inserted")
+	ErrMarketNotPriced = errors.New("the selected strategy mandates price to be updated manually")
 	//ErrMarketInvalidBasePrice is thrown when the amount for Base price is an invalid satoshis value.
 	ErrMarketInvalidBasePrice = errors.New("the amount for base price is invalid")
 	//ErrMarketInvalidQuotePrice is thrown when the amount for Quote price is an invalid satoshis value.

--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -10,13 +10,15 @@ var (
 	ErrMarketFeeTooLow = errors.New("market fee too low, must be at least 1 bp (0.01%)")
 	// ErrMarketFeeTooHigh ...
 	ErrMarketFeeTooHigh = errors.New("market fee too high, must be at most 9999 bp (99,99%)")
+	// ErrMarketMissingFunds ...
+	ErrMarketMissingFunds = errors.New("missing funds of both base and quote asset")
 	// ErrMarketMissingBaseAsset ...
 	ErrMarketMissingBaseAsset = errors.New("base asset is missing")
 	// ErrMarketMissingQuoteAsset ...
 	ErrMarketMissingQuoteAsset = errors.New("quote asset is missing")
 	// ErrMarketTooManyAssets ...
 	ErrMarketTooManyAssets = errors.New(
-		"It's not possible to determine the correct asset pair of the market " +
+		"it's not possible to determine the correct asset pair of the market " +
 			"because more than 2 type of assets has been found in the outpoint list",
 	)
 	//ErrMarketNotFunded is thrown when a market requires being funded for a change

--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -13,13 +13,22 @@ var (
 	// ErrMarketMissingFunds ...
 	ErrMarketMissingFunds = errors.New("missing funds of both base and quote asset")
 	// ErrMarketMissingBaseAsset ...
-	ErrMarketMissingBaseAsset = errors.New("base asset is missing")
+	ErrMarketMissingBaseAsset = errors.New(
+		"missing funds for base asset. A market with zero balance and balanced " +
+			"strategy requires a deposit with funds of both assets. " +
+			"You should change strategy to be able to make a single asset deposit",
+	)
 	// ErrMarketMissingQuoteAsset ...
-	ErrMarketMissingQuoteAsset = errors.New("quote asset is missing")
+	ErrMarketMissingQuoteAsset = errors.New(
+		"quote asset is missing. A market with zero balance and balanced " +
+			"strategy requires a deposit with funds of both assets. " +
+			"You should change strategy to be able to make a single asset deposit",
+	)
 	// ErrMarketTooManyAssets ...
 	ErrMarketTooManyAssets = errors.New(
-		"it's not possible to determine the correct asset pair of the market " +
-			"because more than 2 type of assets has been found in the outpoint list",
+		"too many assets. This means among the deposited funds there are " +
+			"unspents with asset different from the market pair. " +
+			"They must be withdrawn to open the market",
 	)
 	//ErrMarketNotFunded is thrown when a market requires being funded for a change
 	ErrMarketNotFunded = errors.New("market must be funded")

--- a/internal/core/domain/market_service.go
+++ b/internal/core/domain/market_service.go
@@ -156,10 +156,10 @@ func (m *Market) ChangeFixedFee(baseFee, quoteFee int64) error {
 		return err
 	}
 
-	if baseFee > 0 {
+	if baseFee >= 0 {
 		m.FixedFee.BaseFee = baseFee
 	}
-	if quoteFee > 0 {
+	if quoteFee >= 0 {
 		m.FixedFee.QuoteFee = quoteFee
 	}
 	return nil
@@ -383,7 +383,7 @@ func validateFee(basisPoint int64) error {
 }
 
 func validateFixedFee(baseFee, quoteFee int64) error {
-	if baseFee < 0 || quoteFee < 0 {
+	if baseFee < -1 || quoteFee < -1 {
 		return ErrInvalidFixedFee
 	}
 

--- a/internal/core/domain/market_service.go
+++ b/internal/core/domain/market_service.go
@@ -39,6 +39,10 @@ func (m *Market) QuoteAssetPrice() decimal.Decimal {
 	return decimal.Decimal(quotePrice)
 }
 
+func (m *Market) IsStrategyBalanced() bool {
+	return m.Strategy.Type == int(StrategyTypeBalanced)
+}
+
 // IsStrategyPluggable returns true if the the startegy isn't automated.
 func (m *Market) IsStrategyPluggable() bool {
 	return !m.Strategy.IsZero() && m.Strategy.Type == int(StrategyTypePluggable)

--- a/internal/core/domain/market_service_test.go
+++ b/internal/core/domain/market_service_test.go
@@ -141,11 +141,14 @@ func TestMakeStrategyPluggable(t *testing.T) {
 	t.Parallel()
 
 	m := newTestMarket()
+	require.True(t, m.IsStrategyBalanced())
+	require.False(t, m.IsStrategyPluggable())
 
 	err := m.MakeStrategyPluggable()
 	require.NoError(t, err)
 	require.True(t, m.IsStrategyPluggable())
 	require.False(t, m.IsStrategyPluggableInitialized())
+	require.False(t, m.IsStrategyBalanced())
 }
 
 func TestFailingMakeStrategyPluggable(t *testing.T) {

--- a/internal/core/domain/market_service_test.go
+++ b/internal/core/domain/market_service_test.go
@@ -232,13 +232,13 @@ func TestChangeFixedFee(t *testing.T) {
 
 	m := newTestMarket()
 	baseFee := int64(100)
-	err := m.ChangeFixedFee(baseFee, 0)
+	err := m.ChangeFixedFee(baseFee, -1)
 	require.NoError(t, err)
 	require.Equal(t, baseFee, m.FixedFee.BaseFee)
 	require.Zero(t, m.FixedFee.QuoteFee)
 
 	quoteFee := int64(200000)
-	err = m.ChangeFixedFee(0, quoteFee)
+	err = m.ChangeFixedFee(-1, quoteFee)
 	require.NoError(t, err)
 	require.Equal(t, baseFee, m.FixedFee.BaseFee)
 	require.Equal(t, quoteFee, m.FixedFee.QuoteFee)
@@ -261,7 +261,7 @@ func TestFailingChangeFixedFee(t *testing.T) {
 		{
 			name:          "invalid_fixed_base_fee",
 			market:        newTestMarket(),
-			baseFee:       -1,
+			baseFee:       -2,
 			quoteFee:      1000,
 			expectedError: domain.ErrInvalidFixedFee,
 		},
@@ -269,7 +269,7 @@ func TestFailingChangeFixedFee(t *testing.T) {
 			name:          "invalid_fixed_quote_fee",
 			market:        newTestMarket(),
 			baseFee:       100,
-			quoteFee:      -1,
+			quoteFee:      -2,
 			expectedError: domain.ErrInvalidFixedFee,
 		},
 	}

--- a/internal/interfaces/grpc/permissions/permissions.go
+++ b/internal/interfaces/grpc/permissions/permissions.go
@@ -196,7 +196,15 @@ func Whitelist() map[string][]bakery.Op {
 			Entity: EntityTrade,
 			Action: "write",
 		}},
+		"/Trade/ProposeTrade": {{
+			Entity: EntityTrade,
+			Action: "write",
+		}},
 		"/Trade/TradeComplete": {{
+			Entity: EntityTrade,
+			Action: "write",
+		}},
+		"/Trade/CompleteTrade": {{
 			Entity: EntityTrade,
 			Action: "write",
 		}},

--- a/internal/interfaces/grpc/permissions/permissions_test.go
+++ b/internal/interfaces/grpc/permissions/permissions_test.go
@@ -1,0 +1,47 @@
+package permissions_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	pboperator "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/operator"
+	pbwallet "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/wallet"
+	pbunlocker "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/walletunlocker"
+	"github.com/tdex-network/tdex-daemon/internal/interfaces/grpc/permissions"
+	pbtrade "github.com/tdex-network/tdex-protobuf/generated/go/trade"
+)
+
+func TestRestrictedMethods(t *testing.T) {
+	allMethods := make([]string, 0)
+	for _, m := range pboperator.Operator_ServiceDesc.Methods {
+		allMethods = append(allMethods, fmt.Sprintf("/Operator/%s", m.MethodName))
+	}
+	for _, m := range pbwallet.Wallet_ServiceDesc.Methods {
+		allMethods = append(allMethods, fmt.Sprintf("/Wallet/%s", m.MethodName))
+	}
+
+	allPermissions := permissions.AllPermissionsByMethod()
+	for _, method := range allMethods {
+		_, ok := allPermissions[method]
+		require.True(t, ok, fmt.Sprintf("missing permission for %s", method))
+	}
+}
+
+func TestWhitelistedMethods(t *testing.T) {
+	allMethods := make([]string, 0)
+	for _, m := range pbunlocker.WalletUnlocker_ServiceDesc.Methods {
+		allMethods = append(allMethods, fmt.Sprintf("/WalletUnlocker/%s", m.MethodName))
+	}
+	tradeMethods := pbtrade.File_trade_proto.Services().ByName("Trade").Methods()
+	for i := 0; i < tradeMethods.Len(); i++ {
+		m := tradeMethods.Get(i)
+		allMethods = append(allMethods, fmt.Sprintf("/Trade/%s", m.Name()))
+	}
+
+	whitelist := permissions.Whitelist()
+	for _, m := range allMethods {
+		_, ok := whitelist[m]
+		require.True(t, ok, fmt.Sprintf("missing %s in whitelist", m))
+	}
+}


### PR DESCRIPTION
Before this, every market fragmentation required to send both assets to the fragmenter account. Now, this behavior is maintained only in case the market has zero balance, otherwise the operator is allowed to fragment funds of only one asset of the pair.

- Closes #522.
- closes #521 by using the special `-1` value to ignore change to base/quote fee instead of using `0`.
- closes #525 by using `localhost:5001` for regtest instead of `localhost:3001`
- closes #523 and added a test to make sure that all methods are either whitelisted or restricted by a permission
- closes #504 by updating the error messages as requested

Please @tiero review this.