### PR TITLE
Hotfix: prevent daemon crashing when calculating trade fees

### DIFF
--- a/pkg/wallet/util.go
+++ b/pkg/wallet/util.go
@@ -189,7 +189,7 @@ func extractScriptTypesFromPset(ptx *pset.Pset) ([]int, []int, []int, []int, []i
 				scriptSize := 1 + (1+72)*m + 1 + varIntSerializeSize(uint64(scriptLen)) + scriptLen
 				inAuxiliaryWitnessSize = append(inAuxiliaryWitnessSize, scriptSize)
 			} else if in.RedeemScript != nil {
-				inScriptTypes[i] = P2SH_P2WPKH
+				inScriptTypes = append(inScriptTypes, P2SH_P2WPKH)
 			}
 		case address.P2WpkhScript:
 			inScriptTypes = append(inScriptTypes, P2WPKH)


### PR DESCRIPTION
This fixes the bug that makes the daemon crash when serving trades with a counter-part using multisig scripts.

Closes #541.

Please @tiero review this.