### PR TITLE
Add backward compatibility with old version of tdex-protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/tdex-network/tdex-daemon/pkg/explorer v0.0.0-20211001103242-a11e4485705a
 	github.com/tdex-network/tdex-daemon/pkg/macaroons v0.0.0-20210813140257-70d50a8b72a4
 	github.com/tdex-network/tdex-daemon/pkg/securestore v0.0.0-20210813140257-70d50a8b72a4
+	github.com/tdex-network/tdex-protobuf v0.0.0-20220310134014-ac3f6ebd7d36
 	github.com/thanhpk/randstr v1.0.4
 	github.com/timshannon/badgerhold/v2 v2.0.0-20201016201833-94bc303c76d4
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tdex-network/tdex-daemon v0.2.1-0.20210324163246-ed408aba2ec6/go.mod h1:+z4oJgZunJkfsjvcULRIT43RNTcm+2zsglU8p9JtwI8=
 github.com/tdex-network/tdex-protobuf v0.0.0-20210322132201-a185bdfeb24f/go.mod h1:tVWv01BSMH/neJOsixdDFU5T0ll0OZbPliLXBsYQjA8=
+github.com/tdex-network/tdex-protobuf v0.0.0-20220310134014-ac3f6ebd7d36 h1:PgWPOAMLGK2IGrWxdTwJ5TNwiLCz4sDj5vdOTgGLSPU=
+github.com/tdex-network/tdex-protobuf v0.0.0-20220310134014-ac3f6ebd7d36/go.mod h1:tVWv01BSMH/neJOsixdDFU5T0ll0OZbPliLXBsYQjA8=
 github.com/thanhpk/randstr v1.0.4 h1:IN78qu/bR+My+gHCvMEXhR/i5oriVHcTB/BJJIRTsNo=
 github.com/thanhpk/randstr v1.0.4/go.mod h1:M/H2P1eNLZzlDwAzpkkkUvoyNNMbzRGhESZuEQk3r0U=
 github.com/timshannon/badgerhold/v2 v2.0.0-20201016201833-94bc303c76d4 h1:5g8lFrH34MM7MhZyluuTOJEuCjDHPgFZfNSHvOBLaNE=

--- a/internal/interfaces/grpc/handler/trade_old.go
+++ b/internal/interfaces/grpc/handler/trade_old.go
@@ -1,0 +1,367 @@
+package grpchandler
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tdex-network/tdex-daemon/internal/core/application"
+	"github.com/tdex-network/tdex-daemon/internal/core/domain"
+	pbswap "github.com/tdex-network/tdex-protobuf/generated/go/swap"
+	pb "github.com/tdex-network/tdex-protobuf/generated/go/trade"
+	pbtypes "github.com/tdex-network/tdex-protobuf/generated/go/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type tradeOldHandler struct {
+	pb.UnimplementedTradeServer
+	tradeSvc application.TradeService
+}
+
+func NewTradeOldHandler(
+	tradeSvc application.TradeService,
+) pb.TradeServer {
+	return newTradeOldHandler(tradeSvc)
+}
+
+func newTradeOldHandler(
+	tradeSvc application.TradeService,
+) *tradeOldHandler {
+	return &tradeOldHandler{
+		tradeSvc: tradeSvc,
+	}
+}
+
+func (t tradeOldHandler) Markets(
+	ctx context.Context,
+	req *pb.MarketsRequest,
+) (*pb.MarketsReply, error) {
+	return t.markets(ctx, req)
+}
+
+func (t tradeOldHandler) Balances(
+	ctx context.Context,
+	req *pb.BalancesRequest,
+) (*pb.BalancesReply, error) {
+	return t.balances(ctx, req)
+}
+
+func (t tradeOldHandler) MarketPrice(
+	ctx context.Context,
+	req *pb.MarketPriceRequest,
+) (*pb.MarketPriceReply, error) {
+	return t.marketPrice(ctx, req)
+}
+
+func (t tradeOldHandler) TradePropose(
+	req *pb.TradeProposeRequest,
+	stream pb.Trade_TradeProposeServer,
+) error {
+	return t.tradePropose(stream, req)
+}
+
+func (t tradeOldHandler) ProposeTrade(
+	ctx context.Context, req *pb.ProposeTradeRequest,
+) (*pb.ProposeTradeReply, error) {
+	return t.proposeTrade(ctx, req)
+}
+
+func (t tradeOldHandler) TradeComplete(
+	req *pb.TradeCompleteRequest, stream pb.Trade_TradeCompleteServer,
+) error {
+	return t.tradeComplete(stream, req)
+}
+
+func (t tradeOldHandler) CompleteTrade(
+	ctx context.Context, req *pb.CompleteTradeRequest,
+) (*pb.CompleteTradeReply, error) {
+	return t.completeTrade(ctx, req)
+}
+
+func (t tradeOldHandler) markets(
+	ctx context.Context,
+	req *pb.MarketsRequest,
+) (*pb.MarketsReply, error) {
+	markets, err := t.tradeSvc.GetTradableMarkets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	marketsWithFee := make([]*pbtypes.MarketWithFee, 0, len(markets))
+	for _, v := range markets {
+		m := &pbtypes.MarketWithFee{
+			Market: &pbtypes.Market{
+				BaseAsset:  v.BaseAsset,
+				QuoteAsset: v.QuoteAsset,
+			},
+			Fee: &pbtypes.Fee{
+				BasisPoint: v.BasisPoint,
+				Fixed: &pbtypes.Fixed{
+					BaseFee:  v.FixedBaseFee,
+					QuoteFee: v.FixedQuoteFee,
+				},
+			},
+		}
+		marketsWithFee = append(marketsWithFee, m)
+	}
+
+	return &pb.MarketsReply{Markets: marketsWithFee}, nil
+}
+
+func (t tradeOldHandler) balances(
+	ctx context.Context,
+	req *pb.BalancesRequest,
+) (*pb.BalancesReply, error) {
+	market, err := parseMarketOld(req.GetMarket())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	balance, err := t.tradeSvc.GetMarketBalance(ctx, market)
+	if err != nil {
+		return nil, err
+	}
+
+	balancesWithFee := make([]*pbtypes.BalanceWithFee, 0)
+	balancesWithFee = append(balancesWithFee, &pbtypes.BalanceWithFee{
+		Balance: &pbtypes.Balance{
+			BaseAmount:  balance.Balance.BaseAmount,
+			QuoteAmount: balance.Balance.QuoteAmount,
+		},
+		Fee: &pbtypes.Fee{
+			BasisPoint: balance.Fee.BasisPoint,
+			Fixed: &pbtypes.Fixed{
+				BaseFee:  balance.Fee.FixedBaseFee,
+				QuoteFee: balance.Fee.FixedQuoteFee,
+			},
+		},
+	})
+
+	return &pb.BalancesReply{
+		Balances: balancesWithFee,
+	}, nil
+}
+
+func (t tradeOldHandler) marketPrice(
+	ctx context.Context,
+	req *pb.MarketPriceRequest,
+) (*pb.MarketPriceReply, error) {
+	market, err := parseMarketOld(req.GetMarket())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	tradeType := req.GetType()
+	if err := validateTradeTypeOld(tradeType); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	amount := req.GetAmount()
+	if err := validateAmount(amount); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	asset := req.GetAsset()
+	if err := validateAsset(asset); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	preview, err := t.tradeSvc.GetMarketPrice(
+		ctx, market, int(tradeType), amount, asset,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	basePrice, _ := preview.Price.BasePrice.Float64()
+	quotePrice, _ := preview.Price.QuotePrice.Float64()
+
+	return &pb.MarketPriceReply{
+		Prices: []*pbtypes.PriceWithFee{
+			{
+				Price: &pbtypes.Price{
+					BasePrice:  basePrice,
+					QuotePrice: quotePrice,
+				},
+				Fee: &pbtypes.Fee{
+					BasisPoint: preview.Fee.BasisPoint,
+					Fixed: &pbtypes.Fixed{
+						BaseFee:  preview.Fee.FixedBaseFee,
+						QuoteFee: preview.Fee.FixedQuoteFee,
+					},
+				},
+				Amount: preview.Amount,
+				Asset:  preview.Asset,
+				Balance: &pbtypes.Balance{
+					BaseAmount:  preview.Balance.BaseAmount,
+					QuoteAmount: preview.Balance.QuoteAmount,
+				},
+			},
+		},
+	}, nil
+}
+
+func (t tradeOldHandler) proposeTrade(
+	ctx context.Context, req *pb.ProposeTradeRequest,
+) (*pb.ProposeTradeReply, error) {
+	market, err := parseMarketOld(req.GetMarket())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	tradeType := req.GetType()
+	if err := validateTradeTypeOld(tradeType); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	swapRequest := req.GetSwapRequest()
+	if err := validateSwapRequestOld(swapRequest); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	accept, fail, swapExpiryTime, err := t.tradeSvc.TradePropose(
+		ctx, market, int(tradeType), swapRequest,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var swapAccept *pbswap.SwapAccept
+	var swapFail *pbswap.SwapFail
+
+	if accept != nil {
+		swapAccept = &pbswap.SwapAccept{
+			Id:                accept.GetId(),
+			RequestId:         accept.GetRequestId(),
+			Transaction:       accept.GetTransaction(),
+			InputBlindingKey:  accept.GetInputBlindingKey(),
+			OutputBlindingKey: accept.GetOutputBlindingKey(),
+		}
+	}
+	if fail != nil {
+		swapFail = &pbswap.SwapFail{
+			Id:             fail.GetId(),
+			MessageId:      fail.GetMessageId(),
+			FailureCode:    fail.GetFailureCode(),
+			FailureMessage: fail.GetFailureMessage(),
+		}
+	}
+
+	return &pb.ProposeTradeReply{
+		SwapAccept:     swapAccept,
+		SwapFail:       swapFail,
+		ExpiryTimeUnix: swapExpiryTime,
+	}, nil
+}
+
+func (t tradeOldHandler) completeTrade(
+	ctx context.Context, req *pb.CompleteTradeRequest,
+) (*pb.CompleteTradeReply, error) {
+	var swapComplete domain.SwapComplete
+	if s := req.SwapComplete; s != nil {
+		swapComplete = s
+	}
+	var swapFail domain.SwapFail
+	if s := req.SwapFail; s != nil {
+		swapFail = s
+	}
+	txID, fail, err := t.tradeSvc.TradeComplete(
+		ctx, swapComplete, swapFail,
+	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	var swapFailStub *pbswap.SwapFail
+	if fail != nil {
+		swapFailStub = &pbswap.SwapFail{
+			Id:             fail.GetId(),
+			MessageId:      fail.GetMessageId(),
+			FailureCode:    fail.GetFailureCode(),
+			FailureMessage: fail.GetFailureMessage(),
+		}
+	}
+
+	return &pb.CompleteTradeReply{
+		Txid:     txID,
+		SwapFail: swapFailStub,
+	}, nil
+}
+
+func (t tradeOldHandler) tradePropose(
+	stream pb.Trade_TradeProposeServer, req *pb.TradeProposeRequest,
+) error {
+	rr := &pb.ProposeTradeRequest{
+		Market:      req.GetMarket(),
+		Type:        req.GetType(),
+		SwapRequest: req.GetSwapRequest(),
+	}
+	reply, err := t.proposeTrade(stream.Context(), rr)
+	if err != nil {
+		return err
+	}
+	resp := &pb.TradeProposeReply{
+		SwapAccept:     reply.GetSwapAccept(),
+		SwapFail:       reply.GetSwapFail(),
+		ExpiryTimeUnix: reply.GetExpiryTimeUnix(),
+	}
+
+	if err := stream.Send(resp); err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	return nil
+}
+
+func (t tradeOldHandler) tradeComplete(
+	stream pb.Trade_TradeCompleteServer, req *pb.TradeCompleteRequest,
+) error {
+	rr := &pb.CompleteTradeRequest{
+		SwapComplete: req.GetSwapComplete(),
+		SwapFail:     req.GetSwapFail(),
+	}
+	reply, err := t.completeTrade(stream.Context(), rr)
+	if err != nil {
+		return err
+	}
+
+	resp := &pb.TradeCompleteReply{
+		Txid:     reply.GetTxid(),
+		SwapFail: reply.GetSwapFail(),
+	}
+	if err := stream.Send(resp); err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	return nil
+}
+
+func parseMarketOld(mkt *pbtypes.Market) (market application.Market, err error) {
+	var baseAsset, quoteAsset string
+	if mkt != nil {
+		baseAsset, quoteAsset = mkt.GetBaseAsset(), mkt.GetQuoteAsset()
+	}
+	m := application.Market{baseAsset, quoteAsset}
+	if err = m.Validate(); err != nil {
+		return
+	}
+
+	market = m
+	return
+}
+
+func validateTradeTypeOld(tType pb.TradeType) error {
+	if int(tType) < application.TradeBuy || int(tType) > application.TradeSell {
+		return errors.New("trade type is unknown")
+	}
+	return nil
+}
+
+func validateSwapRequestOld(swapRequest *pbswap.SwapRequest) error {
+	if swapRequest == nil {
+		return errors.New("swap request is null")
+	}
+	if swapRequest.GetAmountP() <= 0 ||
+		len(swapRequest.GetAssetP()) <= 0 ||
+		swapRequest.GetAmountR() <= 0 ||
+		len(swapRequest.GetAssetR()) <= 0 ||
+		len(swapRequest.GetTransaction()) <= 0 ||
+		len(swapRequest.GetInputBlindingKey()) <= 0 ||
+		len(swapRequest.GetOutputBlindingKey()) <= 0 {
+		return errors.New("swap request is malformed")
+	}
+	return nil
+}

--- a/internal/interfaces/grpc/permissions/permissions.go
+++ b/internal/interfaces/grpc/permissions/permissions.go
@@ -3,10 +3,11 @@ package permissions
 import (
 	"fmt"
 
-	tdexv1 "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex/v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	daemonv1 "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex-daemon/v1"
-	"gopkg.in/macaroon-bakery.v2/bakery"
+	tdexv1 "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex/v1"
+	tdexold "github.com/tdex-network/tdex-protobuf/generated/go/trade"
 )
 
 const (
@@ -273,6 +274,35 @@ func Whitelist() map[string][]bakery.Op {
 		fmt.Sprintf("/%v/SupportedContentTypes", tdexv1.Transport_ServiceDesc.ServiceName): {{
 			Entity: EntityTransport,
 			Action: "read",
+		}},
+		// Tdex old proto
+		fmt.Sprintf("/%s/Markets", tdexold.File_trade_proto.Services().Get(0).FullName()): {{
+			Entity: EntityTrade,
+			Action: "read",
+		}},
+		fmt.Sprintf("/%s/Balances", tdexold.File_trade_proto.Services().Get(0).FullName()): {{
+			Entity: EntityTrade,
+			Action: "read",
+		}},
+		fmt.Sprintf("/%s/MarketPrice", tdexold.File_trade_proto.Services().Get(0).FullName()): {{
+			Entity: EntityTrade,
+			Action: "read",
+		}},
+		fmt.Sprintf("/%s/TradePropose", tdexold.File_trade_proto.Services().Get(0).FullName()): {{
+			Entity: EntityTrade,
+			Action: "write",
+		}},
+		fmt.Sprintf("/%s/ProposeTrade", tdexold.File_trade_proto.Services().Get(0).FullName()): {{
+			Entity: EntityTrade,
+			Action: "write",
+		}},
+		fmt.Sprintf("/%s/TradeComplete", tdexold.File_trade_proto.Services().Get(0).FullName()): {{
+			Entity: EntityTrade,
+			Action: "write",
+		}},
+		fmt.Sprintf("/%s/CompleteTrade", tdexold.File_trade_proto.Services().Get(0).FullName()): {{
+			Entity: EntityTrade,
+			Action: "write",
 		}},
 	}
 }

--- a/internal/interfaces/grpc/permissions/permissions_test.go
+++ b/internal/interfaces/grpc/permissions/permissions_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tdex-network/tdex-daemon/internal/interfaces/grpc/permissions"
+
 	daemonv1 "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex-daemon/v1"
 	tdexv1 "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex/v1"
-	"github.com/tdex-network/tdex-daemon/internal/interfaces/grpc/permissions"
+	tdexold "github.com/tdex-network/tdex-protobuf/generated/go/trade"
 )
 
 func TestRestrictedMethods(t *testing.T) {
@@ -34,6 +36,11 @@ func TestWhitelistedMethods(t *testing.T) {
 
 	for _, v := range tdexv1.Trade_ServiceDesc.Methods {
 		allMethods = append(allMethods, fmt.Sprintf("/%s/%s", tdexv1.Trade_ServiceDesc.ServiceName, v.MethodName))
+	}
+	tradeMethods := tdexold.File_trade_proto.Services().ByName("Trade").Methods()
+	for i := 0; i < tradeMethods.Len(); i++ {
+		m := tradeMethods.Get(i)
+		allMethods = append(allMethods, fmt.Sprintf("/Trade/%s", m.Name()))
 	}
 
 	whitelist := permissions.Whitelist()

--- a/internal/interfaces/grpc/service.go
+++ b/internal/interfaces/grpc/service.go
@@ -27,6 +27,7 @@ import (
 
 	daemonv1 "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex-daemon/v1"
 	tdexv1 "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex/v1"
+	tdexold "github.com/tdex-network/tdex-protobuf/generated/go/trade"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 )
@@ -362,8 +363,10 @@ func (s *service) start(withUnlockerOnly bool) (*services, error) {
 			unaryInterceptor,
 			streamInterceptor,
 		)
-		tradeHandler := grpchandler.NewTraderHandler(s.opts.TradeSvc)
+		tradeHandler := grpchandler.NewTradeHandler(s.opts.TradeSvc)
+		tradeOldHandler := grpchandler.NewTradeOldHandler(s.opts.TradeSvc)
 		tdexv1.RegisterTradeServer(grpcTradeServer, tradeHandler)
+		tdexold.RegisterTradeServer(grpcTradeServer, tradeOldHandler)
 
 		tradeGrpcGateway, err := s.tradeGrpcGateway(context.Background(), tradeTLSKey, tradeTLSCert)
 		if err != nil {


### PR DESCRIPTION
This adds support for the old version of tdex-protobuf (before migrating to buf):
- adds a new grpc tradeOldHandler using the same application service, but depending on tdex-protobuf#master instead of #v1 
- adds registration of the handler above to the trade grpc server
- adds macaroon permissions to whitelist accordingly

NOTE: the old version of tdex-protobuf does not have support for grpc-gateway, therefore that part has not been affected by changes.

Closes #583.

Please @tiero review this.