### PR TITLE
[Hotfix] Make trade HTTP JSON interface reachable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -109,7 +109,7 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 
 changelog:
-  use: github
+  use: github-native
 
 archives:
   - id: tdexd


### PR DESCRIPTION
This fixes the connection established by the trade grpc gateway to the grpc server, by adding a `InsecureSkipVerify: true` to the tls configuration.

Closes #598.

Please @tiero review this.