### PR TITLE
Restore watch for trades and unspents after restart

### DIFF
--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -125,6 +125,7 @@ func main() {
 	)
 
 	// Init application services
+	skipCheckTrades := true
 	tradeSvc := application.NewTradeService(
 		repoManager,
 		explorerSvc,
@@ -134,6 +135,7 @@ func main() {
 		pricesSlippagePercentage,
 		network,
 		feeThreshold,
+		!skipCheckTrades,
 	)
 	operatorSvc := application.NewOperatorService(
 		repoManager,

--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -71,6 +71,7 @@ func NewTradeService(
 	priceSlippage decimal.Decimal,
 	net *network.Network,
 	feeAccountBalanceThreshold uint64,
+	skipCheckTrades bool,
 ) TradeService {
 	return newTradeService(
 		repoManager,
@@ -81,6 +82,7 @@ func NewTradeService(
 		priceSlippage,
 		net,
 		feeAccountBalanceThreshold,
+		skipCheckTrades,
 	)
 }
 
@@ -93,6 +95,7 @@ func newTradeService(
 	priceSlippage decimal.Decimal,
 	net *network.Network,
 	feeAccountBalanceThreshold uint64,
+	skipCheckTrades bool,
 ) *tradeService {
 	svc := &tradeService{
 		repoManager:                repoManager,
@@ -106,6 +109,9 @@ func newTradeService(
 		lock:                       &sync.Mutex{},
 	}
 
+	if skipCheckTrades {
+		return svc
+	}
 	// In case of restart, restore watching trades/outpoints: start observing the
 	// inputs of each trade even if it's already expired.
 	// The idea is to wait at least for a minute to give the time to the bc

--- a/internal/core/application/trade_service_test.go
+++ b/internal/core/application/trade_service_test.go
@@ -287,6 +287,7 @@ func newTradeServiceTest(
 		tradePriceSlippage,
 		regtest,
 		feeBalanceThreshold,
+		true,
 	), nil
 }
 

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -631,3 +631,57 @@ func validateTimeFormat(t interface{}) error {
 
 	return nil
 }
+
+type utxoKey struct {
+	txid  string
+	index uint32
+}
+
+func (u utxoKey) Hash() string {
+	return u.txid
+}
+func (u utxoKey) Index() uint32 {
+	return u.index
+}
+func (u utxoKey) Value() uint64 {
+	return 0
+}
+func (u utxoKey) Asset() string {
+	return ""
+}
+func (u utxoKey) ValueCommitment() string {
+	return ""
+}
+func (u utxoKey) AssetCommitment() string {
+	return ""
+}
+func (u utxoKey) ValueBlinder() []byte {
+	return nil
+}
+func (u utxoKey) AssetBlinder() []byte {
+	return nil
+}
+func (u utxoKey) Script() []byte {
+	return nil
+}
+func (u utxoKey) Nonce() []byte {
+	return nil
+}
+func (u utxoKey) RangeProof() []byte {
+	return nil
+}
+func (u utxoKey) SurjectionProof() []byte {
+	return nil
+}
+func (u utxoKey) IsConfidential() bool {
+	return false
+}
+func (u utxoKey) IsConfirmed() bool {
+	return false
+}
+func (u utxoKey) IsRevealed() bool {
+	return false
+}
+func (u utxoKey) Parse() (*transaction.TxInput, *transaction.TxOutput, error) {
+	return nil, nil, nil
+}

--- a/internal/infrastructure/storage/db/badger/trade_repository_impl.go
+++ b/internal/infrastructure/storage/db/badger/trade_repository_impl.go
@@ -213,6 +213,7 @@ func (t tradeRepositoryImpl) getTrade(
 	var trades []domain.Trade
 	var err error
 	query := badgerhold.Where("ID").Eq(ID)
+	// TODO: revert to Get once we fix using a string key instead of uuid.UUID struct.
 	if ctx.Value("tx") != nil {
 		tx := ctx.Value("tx").(*badger.Txn)
 		err = t.store.TxFind(tx, &trades, query)
@@ -236,6 +237,7 @@ func (t tradeRepositoryImpl) updateTrade(
 	trade domain.Trade,
 ) error {
 	query := badgerhold.Where("ID").Eq(ID)
+	// TODO: revert to Update once we fix using a string key instead of uuid.UUID struct.
 	if ctx.Value("tx") != nil {
 		tx := ctx.Value("tx").(*badger.Txn)
 		return t.store.TxUpdateMatching(tx, &domain.Trade{}, query, func(record interface{}) error {

--- a/internal/interfaces/grpc/service.go
+++ b/internal/interfaces/grpc/service.go
@@ -515,6 +515,7 @@ func (s *service) tradeGrpcGateway(
 	if insecureConn {
 		creds = append(creds, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
+		// #nosec
 		creds = append(creds, grpc.WithTransportCredentials(
 			credentials.NewTLS(&tls.Config{
 				InsecureSkipVerify: true,


### PR DESCRIPTION
This makes the trade service restore the watch for accepted trades and locked utxos.

NOTE: if a trade is already expired, the service doesn't update it's status immediately and releases the lock of the utxos, but it waits for a minute before doing that. This to give the time to the bc listener to eventually be notified about a settled trade so that it can correctly update its status and spend the utxos instead.

Closes #564.

Please @tiero review this.