### PR TITLE
Goreleaser build info fix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -165,6 +165,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--build-arg=OS={{.Runtime.Goos}}"
       - "--build-arg=ARCH={{.Runtime.Goarch}}"
+      - "--build-arg=TAG={{.Tag}}"
 
     extra_files:
       - go.mod
@@ -196,6 +197,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--build-arg=OS={{.Runtime.Goos}}"
       - "--build-arg=ARCH={{.Runtime.Goarch}}"
+      - "--build-arg=TAG={{.Tag}}"
 
     extra_files:
       - go.mod

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -170,7 +170,7 @@ dockers:
     use: buildx
     ids:
       - tdex
-      - tdexd
+      - tdexdconnect
       - tdexd-linux-arm64
     dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
       - linux
     goarch:
       - amd64
-    binary: tdexd-{{ .Os }}-{{ .Arch }}
+    binary: tdexd-linux-amd64
 
   - id: "tdexd-linux-arm64"
     main: ./cmd/tdexd
@@ -26,7 +26,7 @@ builds:
       - linux
     goarch:
       - arm64
-    binary: tdexd-{{ .Os }}-{{ .Arch }}
+    binary: tdexd-linux-arm64
 
   ### Darwin
 
@@ -42,7 +42,7 @@ builds:
       - darwin
     goarch:
       - amd64
-    binary: tdexd-{{ .Os }}-{{ .Arch }}
+    binary: tdexd-darwin-amd64
 
   - id: "tdexd-darwin-arm64"
     main: ./cmd/tdexd
@@ -56,7 +56,7 @@ builds:
       - darwin
     goarch:
       - arm64
-    binary: tdexd-{{ .Os }}-{{ .Arch }}
+    binary: tdexd-darwin-arm64
 
   # CLI
   - id: "tdex"
@@ -69,7 +69,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    binary: tdex-{{ .Os }}-{{ .Arch }}
+    binary: tdex
 
   # tdexdconnect
   - id: "tdexdconnect"
@@ -84,7 +84,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    binary: tdexdconnect-{{ .Os }}-{{ .Arch }}
+    binary: tdexdconnect
 ## flag the semver v**.**.**-<tag>.* as pre-release on Github
 release:
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -146,8 +146,8 @@ dockers:
     use: buildx
     ids:
       - tdex
-      - tdexd
       - tdexdconnect
+      - tdexd-linux-amd64
     dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux
@@ -171,7 +171,7 @@ dockers:
     ids:
       - tdex
       - tdexd
-      - tdexdconnect
+      - tdexd-linux-arm64
     dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,7 +115,10 @@ archives:
   - id: tdexd
     format: binary
     builds:
-      - tdexd
+      - tdexd-linux-amd64
+      - tdexd-linux-arm64
+      - tdexd-darwin-amd64
+      - tdexd-darwin-arm64
     name_template: "tdexd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 
   - id: tdex
@@ -141,6 +144,8 @@ dockers:
         # push always either release or prerelease with a docker tag with the semver only
     skip_push: "false"
     use: buildx
+    ids:
+      - tdexd
     dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux
@@ -155,21 +160,14 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
 
-    extra_files:
-      - go.mod
-      - go.sum
-      - internal
-      - config
-      - pkg
-      - cmd
-      - api-spec
-
   # arm64
   - image_templates:
       - "ghcr.io/tdex-network/tdexd:{{ .Tag }}-arm64v8"
         # push always either release or prerelease with a docker tag with the semver only
     skip_push: "false"
     use: buildx
+    ids:
+      - tdexd
     dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux
@@ -183,15 +181,6 @@ dockers:
       - "--label=org.opencontainers.image.title=tdexd"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-
-    extra_files:
-      - go.mod
-      - go.sum
-      - internal
-      - config
-      - pkg
-      - cmd
-      - api-spec
 
 docker_manifests:
   - name_template: ghcr.io/tdex-network/tdexd:{{ .Tag }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,28 +115,19 @@ archives:
   - id: tdexd
     format: binary
     builds:
-      - tdexd-linux-amd64
-      - tdexd-linux-arm64
-      - tdexd-darwin-amd64
-      - tdexd-darwin-arm64
+      - tdexd
     name_template: "tdexd-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 
   - id: tdex
     format: binary
     builds:
-      - tdex-linux-amd64
-      - tdex-linux-arm64
-      - tdex-darwin-amd64
-      - tdex-darwin-arm64
+      - tdex
     name_template: "tdex-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 
   - id: tdexdconnect
     format: binary
     builds:
-      - tdexdconnect-linux-amd64
-      - tdexdconnect-linux-arm64
-      - tdexdconnect-darwin-amd64
-      - tdexdconnect-darwin-arm64
+      - tdexdconnect
     name_template: "tdexdconnect-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 
 dockers:
@@ -163,9 +154,6 @@ dockers:
       - "--label=org.opencontainers.image.title=tdexd"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--build-arg=OS={{.Runtime.Goos}}"
-      - "--build-arg=ARCH={{.Runtime.Goarch}}"
-      - "--build-arg=TAG={{.Tag}}"
 
     extra_files:
       - go.mod
@@ -195,9 +183,6 @@ dockers:
       - "--label=org.opencontainers.image.title=tdexd"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--build-arg=OS={{.Runtime.Goos}}"
-      - "--build-arg=ARCH={{.Runtime.Goarch}}"
-      - "--build-arg=TAG={{.Tag}}"
 
     extra_files:
       - go.mod

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,19 +5,19 @@ builds:
   - id: "tdexd-linux-amd64"
     main: ./cmd/tdexd
     ldflags:
-      - -s -X './cmd/tdexd/main.version={{.Version}}' -X './cmd/tdexd/main.commit={{.Commit}}' -X './cmd/tdexd/main.date={{.Date}}'
+      - -s -X 'main.version={{.Version}}' -X 'main.commit={{.Commit}}' -X 'main.date={{.Date}}'
     env:
       - CGO_ENABLED=1
     goos:
       - linux
     goarch:
       - amd64
-    binary: tdexd-linux-amd64
+    binary: tdexd-{{ .Os }}-{{ .Arch }}
 
   - id: "tdexd-linux-arm64"
     main: ./cmd/tdexd
     ldflags:
-      - -s -X './cmd/tdexd/main.version={{.Version}}' -X './cmd/tdexd/main.commit={{.Commit}}' -X './cmd/tdexd/main.date={{.Date}}'
+      - -s -X 'main.version={{.Version}}' -X 'main.commit={{.Commit}}' -X 'main.date={{.Date}}'
     env:
       - CGO_ENABLED=1
       - CC=aarch64-linux-gnu-gcc
@@ -26,14 +26,14 @@ builds:
       - linux
     goarch:
       - arm64
-    binary: tdexd-linux-arm64
+    binary: tdexd-{{ .Os }}-{{ .Arch }}
 
   ### Darwin
 
   - id: "tdexd-darwin-amd64"
     main: ./cmd/tdexd
     ldflags:
-      - -s -w
+      - -s -X 'main.version={{.Version}}' -X 'main.commit={{.Commit}}' -X 'main.date={{.Date}}'
     env:
       - CGO_ENABLED=1
       - CC=/home/runner/work/osxcross/target/bin/o64-clang
@@ -42,12 +42,12 @@ builds:
       - darwin
     goarch:
       - amd64
-    binary: tdexd-darwin-amd64
+    binary: tdexd-{{ .Os }}-{{ .Arch }}
 
   - id: "tdexd-darwin-arm64"
     main: ./cmd/tdexd
     ldflags:
-      - -s -X './cmd/tdexd/main.version={{.Version}}' -X './cmd/tdexd/main.commit={{.Commit}}' -X './cmd/tdexd/main.date={{.Date}}'
+      - -s -X 'main.version={{.Version}}' -X 'main.commit={{.Commit}}' -X 'main.date={{.Date}}'
     env:
       - CGO_ENABLED=1
       - CC=/home/runner/work/osxcross/target/bin/oa64-clang
@@ -56,7 +56,7 @@ builds:
       - darwin
     goarch:
       - arm64
-    binary: tdexd-darwin-arm64
+    binary: tdexd-{{ .Os }}-{{ .Arch }}
 
   # CLI
   - id: "tdex"
@@ -69,7 +69,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    binary: tdex-darwin
+    binary: tdex-{{ .Os }}-{{ .Arch }}
 
   # tdexdconnect
   - id: "tdexdconnect"
@@ -84,7 +84,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    binary: tdexdconnect
+    binary: tdexdconnect-{{ .Os }}-{{ .Arch }}
 ## flag the semver v**.**.**-<tag>.* as pre-release on Github
 release:
   prerelease: auto
@@ -124,13 +124,19 @@ archives:
   - id: tdex
     format: binary
     builds:
-      - tdex
+      - tdex-linux-amd64
+      - tdex-linux-arm64
+      - tdex-darwin-amd64
+      - tdex-darwin-arm64
     name_template: "tdex-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 
   - id: tdexdconnect
     format: binary
     builds:
-      - tdexdconnect
+      - tdexdconnect-linux-amd64
+      - tdexdconnect-linux-arm64
+      - tdexdconnect-darwin-amd64
+      - tdexdconnect-darwin-arm64
     name_template: "tdexdconnect-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 
 dockers:
@@ -144,7 +150,7 @@ dockers:
         # push always either release or prerelease with a docker tag with the semver only
     skip_push: "false"
     use: buildx
-    dockerfile: Dockerfile
+    dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux
     # GOARCH of the built binaries/packages that should be used.
@@ -157,9 +163,8 @@ dockers:
       - "--label=org.opencontainers.image.title=tdexd"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--build-arg=VERSION={{.Version}}"
-      - "--build-arg=COMMIT={{.Commit}}"
-      - "--build-arg=DATE={{.Date}}"
+      - "--build-arg=OS={{.Runtime.Goos}}"
+      - "--build-arg=ARCH={{.Runtime.Goarch}}"
 
     extra_files:
       - go.mod
@@ -176,7 +181,7 @@ dockers:
         # push always either release or prerelease with a docker tag with the semver only
     skip_push: "false"
     use: buildx
-    dockerfile: Dockerfile
+    dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux
     # GOARCH of the built binaries/packages that should be used.
@@ -189,9 +194,8 @@ dockers:
       - "--label=org.opencontainers.image.title=tdexd"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--build-arg=VERSION={{.Version}}"
-      - "--build-arg=COMMIT={{.Commit}}"
-      - "--build-arg=DATE={{.Date}}"
+      - "--build-arg=OS={{.Runtime.Goos}}"
+      - "--build-arg=ARCH={{.Runtime.Goarch}}"
 
     extra_files:
       - go.mod

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -145,7 +145,9 @@ dockers:
     skip_push: "false"
     use: buildx
     ids:
+      - tdex
       - tdexd
+      - tdexdconnect
     dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux
@@ -167,7 +169,9 @@ dockers:
     skip_push: "false"
     use: buildx
     ids:
+      - tdex
       - tdexd
+      - tdexdconnect
     dockerfile: goreleaser.Dockerfile
     # GOOS of the built binaries/packages that should be used.
     goos: linux

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:buster-slim
+
+WORKDIR /app
+
+COPY . .
+
+ARG OS
+ARG ARCH
+
+ENV TDEXD="tdexd-${OS}-${ARCH}"
+
+# $USER name, and data $DIR to be used in the `final` image
+ARG USER=tdex
+ARG DIR=/home/tdex
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
+# NOTE: Default GID == UID == 1000
+RUN adduser --disabled-password \
+            --home "$DIR/" \
+            --gecos "" \
+            "$USER"
+USER $USER
+
+# Prevents `VOLUME $DIR/.tdex-daemon/` being created as owned by `root`
+RUN mkdir -p "$DIR/.tdex-daemon/"
+
+# Expose volume containing all `tdexd` data
+VOLUME $DIR/.tdex-daemon/
+
+# expose trader and operator interface ports
+EXPOSE 9945
+EXPOSE 9000
+
+ENTRYPOINT ./$TDEXD

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -2,15 +2,17 @@ FROM debian:buster-slim
 
 ARG TARGETPLATFORM
 
-RUN set -ex \
-  && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=amd64; fi \
-  && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=arm64; fi 
 
 WORKDIR /app
 
-ADD tdex /usr/local/bin/tdex
-ADD "tdexd-linux-$TARGETPLATFORM" /usr/local/bin/tdexd
-ADD tdexdconnect /usr/local/bin/tdexdconnect
+COPY . .
+
+RUN set -ex \
+  && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=amd64; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=arm64; fi \
+  && mv tdex /usr/local/bin/tdex \
+  && mv tdexdconnect /usr/local/bin/tdexdconnect \
+  && mv "tdexd-linux-$TARGETPLATFORM" /usr/local/bin/tdexd
 
 
 # $USER name, and data $DIR to be used in the `final` image

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -2,17 +2,13 @@ FROM debian:buster-slim
 
 WORKDIR /app
 
-COPY . .
+COPY . /usr/local/bin/
 
 # $USER name, and data $DIR to be used in the `final` image
 ARG USER=tdex
 ARG DIR=/home/tdex
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-
-RUN mv ./tdex /usr/local/bin/
-RUN mv ./tdexd /usr/local/bin/
-RUN mv ./tdexdconnect /usr/local/bin/
 
 # NOTE: Default GID == UID == 1000
 RUN adduser --disabled-password \

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -4,18 +4,15 @@ WORKDIR /app
 
 COPY . .
 
-# Build info args
-ARG OS
-ARG ARCH
-ARG TAG
-
-ENV TDEXD="tdexd-${TAG}-${OS}-${ARCH}"
-
 # $USER name, and data $DIR to be used in the `final` image
 ARG USER=tdex
 ARG DIR=/home/tdex
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
+RUN mv ./tdex /usr/local/bin/
+RUN mv ./tdexd /usr/local/bin/
+RUN mv ./tdexdconnect /usr/local/bin/
 
 # NOTE: Default GID == UID == 1000
 RUN adduser --disabled-password \
@@ -34,4 +31,4 @@ VOLUME $DIR/.tdex-daemon/
 EXPOSE 9945
 EXPOSE 9000
 
-ENTRYPOINT ./$TDEXD
+ENTRYPOINT ["tdexd"]

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -7,8 +7,9 @@ COPY . .
 # Build info args
 ARG OS
 ARG ARCH
+ARG TAG
 
-ENV TDEXD="tdexd-${OS}-${ARCH}"
+ENV TDEXD="tdexd-${TAG}-${OS}-${ARCH}"
 
 # $USER name, and data $DIR to be used in the `final` image
 ARG USER=tdex

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY . .
 
+# Build info args
 ARG OS
 ARG ARCH
 

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -1,8 +1,17 @@
 FROM debian:buster-slim
 
+ARG TARGETPLATFORM
+
+RUN set -ex \
+  && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=amd64; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=arm64; fi 
+
 WORKDIR /app
 
-COPY . /usr/local/bin/
+ADD tdex /usr/local/bin/tdex
+ADD "tdexd-linux-$TARGETPLATFORM" /usr/local/bin/tdexd
+ADD tdexdconnect /usr/local/bin/tdexdconnect
+
 
 # $USER name, and data $DIR to be used in the `final` image
 ARG USER=tdex


### PR DESCRIPTION
This updates goreleaser config so that build info's are injected in binaries.

This closes #592

@tiero please review.