### PR TITLE
No operator tls & Single port cert

### DIFF
--- a/cmd/tdex/config.go
+++ b/cmd/tdex/config.go
@@ -20,6 +20,7 @@ const (
 	noMacaroonsKey   = "no_macaroons"
 	macaroonsPathKey = "macaroons_path"
 	tlsCertPathKey   = "tls_cert_path"
+	noOperatorTlsKey = "no_operator_tls"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 	defaultNoMacaroonsAuth = false
 	defaultTLSCertPath     = filepath.Join(daemonDatadir, "tls", "cert.pem")
 	defaultMacaroonsPath   = filepath.Join(daemonDatadir, "macaroons", "admin.macaroon")
+	defaultNoOperatorTLS   = false
 
 	networkFlag = cli.StringFlag{
 		Name:  "network, n",
@@ -47,6 +49,12 @@ var (
 		Name:  tlsCertPathKey,
 		Usage: "the path of the TLS certificate file to use",
 		Value: defaultTLSCertPath,
+	}
+
+	noOperatorCertFlag = cli.BoolFlag{
+		Name:  noOperatorTlsKey,
+		Usage: "used to disable operator TLS certificate",
+		Value: defaultNoOperatorTLS,
 	}
 
 	noMacaroonsFlag = cli.BoolFlag{
@@ -82,6 +90,7 @@ var cliConfig = cli.Command{
 				&tlsCertFlag,
 				&noMacaroonsFlag,
 				&macaroonsFlag,
+				&noOperatorCertFlag,
 			},
 		},
 		{
@@ -107,11 +116,12 @@ func configAction(ctx *cli.Context) error {
 
 func configInitAction(c *cli.Context) error {
 	return setState(map[string]string{
-		"network":        c.String("network"),
-		"rpcserver":      c.String("rpcserver"),
-		"no_macaroons":   c.String(noMacaroonsKey),
-		"tls_cert_path":  cleanAndExpandPath(c.String(tlsCertPathKey)),
-		"macaroons_path": cleanAndExpandPath(c.String(macaroonsPathKey)),
+		"network":         c.String("network"),
+		"rpcserver":       c.String("rpcserver"),
+		"no_macaroons":    c.String(noMacaroonsKey),
+		"no_operator_tls": c.String(noOperatorTlsKey),
+		"tls_cert_path":   cleanAndExpandPath(c.String(tlsCertPathKey)),
+		"macaroons_path":  cleanAndExpandPath(c.String(macaroonsPathKey)),
 	})
 }
 

--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -274,6 +274,10 @@ func NewGrpcService(
 			OperatorSvc:              operatorSvc,
 			TradeSvc:                 tradeSvc,
 			RepoManager:              repoManager,
+			TLSLocation:              config.TLSLocation,
+			NoTls:                    noOperatorTls,
+			ExtraIPs:                 operatorTLSExtraIPs,
+			ExtraDomains:             operatorTLSExtraDomains,
 		}
 
 		return grpcinterface.NewServiceOnePort(opts)

--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -59,6 +59,7 @@ var (
 	rescanRangeStart              = config.GetInt(config.RescanRangeStartKey)
 	rescanGapLimit                = config.GetInt(config.RescanGapLimitKey)
 	walletUnlockPasswordFile      = config.GetString(config.WalletUnlockPasswordFile)
+	noOperatorTls                 = config.GetBool(config.NoOperatorTlsKey)
 
 	version = "dev"
 	commit  = "none"
@@ -296,6 +297,7 @@ func NewGrpcService(
 		TradeSvc:                 tradeSvc,
 		WalletUnlockPasswordFile: walletUnlockPasswordFile,
 		RepoManager:              repoManager,
+		NoOperatorTls:            noOperatorTls,
 	}
 	return grpcinterface.NewService(opts)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,8 @@ const (
 	//password for unlocking the wallet, if provided wallet will be unlocked
 	//automatically
 	WalletUnlockPasswordFile = "WALLET_UNLOCK_PASSWORD_FILE"
+	// NoOperatorTlsKey is used to start the daemon without using TLS for the operator service
+	NoOperatorTlsKey = "NO_OPERATOR_TLS"
 
 	DbLocation        = "db"
 	TLSLocation       = "tls"
@@ -134,6 +136,7 @@ func init() {
 	vip.SetDefault(CBFailingRatioKey, 0.7)
 	vip.SetDefault(RescanRangeStartKey, 0)
 	vip.SetDefault(RescanGapLimitKey, 50)
+	vip.SetDefault(NoOperatorTlsKey, false)
 
 	if err := validate(); err != nil {
 		log.Fatalf("error while validating config: %s", err)


### PR DESCRIPTION
This adds option to run daemon without operator TLS and macaroon ON.
This adds self-signed TLS cert to the single port server setup.

This closes #620 
This closes #614 

@tiero please review.