### PR TITLE
Decouple tls and macaroons auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ run: clean
 	export TDEX_BASE_ASSET=5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225; \
 	export TDEX_FEE_ACCOUNT_BALANCE_THRESHOLD=1000; \
 	export TDEX_NO_MACAROONS=true; \
+	export TDEX_NO_OPERATOR_TLS=true; \
 	export TDEX_CONNECT_PROTO=http; \
 	go run ./cmd/tdexd
 

--- a/cmd/tdex/config.go
+++ b/cmd/tdex/config.go
@@ -20,7 +20,7 @@ const (
 	noMacaroonsKey   = "no_macaroons"
 	macaroonsPathKey = "macaroons_path"
 	tlsCertPathKey   = "tls_cert_path"
-	noOperatorTlsKey = "no_operator_tls"
+	noTlsKey         = "no_tls"
 )
 
 var (
@@ -31,7 +31,7 @@ var (
 	defaultNoMacaroonsAuth = false
 	defaultTLSCertPath     = filepath.Join(daemonDatadir, "tls", "cert.pem")
 	defaultMacaroonsPath   = filepath.Join(daemonDatadir, "macaroons", "admin.macaroon")
-	defaultNoOperatorTLS   = false
+	defaultNoTLS           = false
 
 	networkFlag = cli.StringFlag{
 		Name:  "network, n",
@@ -51,10 +51,10 @@ var (
 		Value: defaultTLSCertPath,
 	}
 
-	noOperatorCertFlag = cli.BoolFlag{
-		Name:  noOperatorTlsKey,
+	noTlsFlag = cli.BoolFlag{
+		Name:  noTlsKey,
 		Usage: "used to disable operator TLS certificate",
-		Value: defaultNoOperatorTLS,
+		Value: defaultNoTLS,
 	}
 
 	noMacaroonsFlag = cli.BoolFlag{
@@ -90,7 +90,7 @@ var cliConfig = cli.Command{
 				&tlsCertFlag,
 				&noMacaroonsFlag,
 				&macaroonsFlag,
-				&noOperatorCertFlag,
+				&noTlsFlag,
 			},
 		},
 		{
@@ -116,12 +116,12 @@ func configAction(ctx *cli.Context) error {
 
 func configInitAction(c *cli.Context) error {
 	return setState(map[string]string{
-		"network":         c.String("network"),
-		"rpcserver":       c.String("rpcserver"),
-		"no_macaroons":    c.String(noMacaroonsKey),
-		"no_operator_tls": c.String(noOperatorTlsKey),
-		"tls_cert_path":   cleanAndExpandPath(c.String(tlsCertPathKey)),
-		"macaroons_path":  cleanAndExpandPath(c.String(macaroonsPathKey)),
+		"network":        c.String("network"),
+		"rpcserver":      c.String("rpcserver"),
+		"no_macaroons":   c.String(noMacaroonsKey),
+		"no_tls":         c.String(noTlsKey),
+		"tls_cert_path":  cleanAndExpandPath(c.String(tlsCertPathKey)),
+		"macaroons_path": cleanAndExpandPath(c.String(macaroonsPathKey)),
 	})
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -349,6 +349,9 @@ func initDatadir() error {
 		if err := makeDirectoryIfNotExists(filepath.Join(datadir, MacaroonsLocation)); err != nil {
 			return err
 		}
+	}
+	noOperatorTls := GetBool(NoOperatorTlsKey)
+	if !noOperatorTls {
 		if err := makeDirectoryIfNotExists(filepath.Join(datadir, TLSLocation)); err != nil {
 			return err
 		}


### PR DESCRIPTION
Before this, TLS enabled/disabled for operator interface still depended on `NO_MACAROONS` env var, therefore it wasn't impossible to run a daemon with TLS enabled and macaroons disabled for that interface.

With this TLS auth depends only on `NO_OPERATOR_TLS` env var, therefore it is possible to enable and disable both tls and macaroons at will for operator interface.

This also renames the CLI flag `--no_operator_tls` to `--no_tls`. It's meant to be used to interact with the operator interface only, therefore we can simplify the naming of the flag.

Please @tiero review this.