### PR TITLE
401 response should contain CORS and "WWW-Authenticate" headers

### DIFF
--- a/internal/interfaces/http/tdex_connect_handler.go
+++ b/internal/interfaces/http/tdex_connect_handler.go
@@ -117,11 +117,17 @@ func (t *tdexConnect) AuthHandler(w http.ResponseWriter, req *http.Request) {
 	// if is initialized then we need to check auth before appending the macaroon
 	username, password, ok := req.BasicAuth()
 	if !ok {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	    w.Header().Set("Access-control-Allow-Headers", "*")
+	    w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
 		log.Debugln("http: basic auth not provided")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
 	if username != "tdex" {
+	    w.Header().Set("Access-Control-Allow-Origin", "*")
+    	w.Header().Set("Access-control-Allow-Headers", "*")
+    	w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
 		log.Debugln("http: invalid username")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
@@ -138,6 +144,9 @@ func (t *tdexConnect) AuthHandler(w http.ResponseWriter, req *http.Request) {
 		CypherText: vault.EncryptedMnemonic,
 		Passphrase: password,
 	}); err != nil {
+	    w.Header().Set("Access-Control-Allow-Origin", "*")
+        w.Header().Set("Access-control-Allow-Headers", "*")
+        w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
 		log.Debugln("http: invalid password")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return


### PR DESCRIPTION
StatusUnauthorized 401 error response should always have a specific "WWW-Authenticate" header https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/WWW-Authenticate
Also should reply with CORS headers.

This allow the frontend running in different origin (port 3003) to get the status error code and not a generic error like `Failed to fetch`. See: https://github.com/axios/axios/issues/960

Please review @tiero @altafan 