### PR TITLE
Add missing header to /tdexdconnect response & Fix password validation

### DIFF
--- a/internal/interfaces/http/tdex_connect_handler.go
+++ b/internal/interfaces/http/tdex_connect_handler.go
@@ -117,11 +117,17 @@ func (t *tdexConnect) AuthHandler(w http.ResponseWriter, req *http.Request) {
 	// if is initialized then we need to check auth before appending the macaroon
 	username, password, ok := req.BasicAuth()
 	if !ok {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	    w.Header().Set("Access-control-Allow-Headers", "*")
+	    w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
 		log.Debugln("http: basic auth not provided")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
 	if username != "tdex" {
+	    w.Header().Set("Access-Control-Allow-Origin", "*")
+    	w.Header().Set("Access-control-Allow-Headers", "*")
+    	w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
 		log.Debugln("http: invalid username")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
@@ -138,6 +144,9 @@ func (t *tdexConnect) AuthHandler(w http.ResponseWriter, req *http.Request) {
 		CypherText: vault.EncryptedMnemonic,
 		Passphrase: password,
 	}); err != nil {
+	    w.Header().Set("Access-Control-Allow-Origin", "*")
+        w.Header().Set("Access-control-Allow-Headers", "*")
+        w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
 		log.Debugln("http: invalid password")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return

--- a/pkg/wallet/cypher.go
+++ b/pkg/wallet/cypher.go
@@ -5,6 +5,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"runtime/debug"
 
 	"golang.org/x/crypto/scrypt"
 )
@@ -27,6 +28,11 @@ func (o EncryptOpts) validate() error {
 
 // Encrypt encrypts (with AES-128) a plaintext with the provided passphrase
 func Encrypt(opts EncryptOpts) (string, error) {
+	// Due to https://github.com/golang/go/issues/7168.
+	// This call makes sure that memory is freed in case the GC doesn't do that
+	// right after the encryption/decryption.
+	defer debug.FreeOSMemory()
+
 	if err := opts.validate(); err != nil {
 		return "", err
 	}
@@ -76,6 +82,8 @@ func (o DecryptOpts) validate() error {
 
 // Decrypt decrypts (with AES-128) a cyphertext with the provided passphrase
 func Decrypt(opts DecryptOpts) (string, error) {
+	defer debug.FreeOSMemory()
+
 	if err := opts.validate(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
StatusUnauthorized 401 error response should always have a specific "WWW-Authenticate" header https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/WWW-Authenticate

This adds the missing header to the response of `/tdexdconnect` endpoint.

Furthermore, this changes the way the password passed to `/tdexdconnect` is validated: we now compare the password hashes rather than doing an actual decryption which is expensive in terms of resources and waiting time.

BONUS: this fixes eventual resource glitches after calling `Encrypt | Decrypt` functions from `pkg/wallet`.

Please @tiero @Janaka-Steph review this.

