### PR TITLE
Fix GetMarketReport predefined period all

### DIFF
--- a/internal/core/application/operator_service_test.go
+++ b/internal/core/application/operator_service_test.go
@@ -182,6 +182,7 @@ func newOperatorService() (application.OperatorService, error) {
 
 func TestOperatorServiceGetMarketReport(t *testing.T) {
 	ctx := context.Background()
+	all := application.All
 
 	type fields struct {
 		trades []*domain.Trade
@@ -309,6 +310,36 @@ func TestOperatorServiceGetMarketReport(t *testing.T) {
 			},
 			wantGroupedVolumeLen: 6,
 			wantErr:              false,
+		},
+		{
+			name: "4",
+			fields: fields{
+				trades: trades3(),
+			},
+			args: args{
+				ctx: ctx,
+				market: application.Market{
+					BaseAsset:  "b",
+					QuoteAsset: "q",
+				},
+				timeRange: application.TimeRange{
+					PredefinedPeriod: &all,
+				},
+				groupByTimeFrame: 30,
+			},
+			want: func(report *application.MarketReport, notNilAt []int, wantGroupedVolumeLen int) error {
+				//validate that report contains data from 2021 and 2022
+				if report.GroupedVolume[0].StartTime.Year() != 2022 {
+					return errors.New(fmt.Sprintf("expected grouped volume start time year: %v, got: %v", 2022, report.GroupedVolume[0].StartTime.Year()))
+				}
+
+				if report.GroupedVolume[len(report.GroupedVolume)-1].StartTime.Year() != 2021 {
+					return errors.New(fmt.Sprintf("expected grouped volume start time year: %v, got: %v", 2021, report.GroupedVolume[0].StartTime.Year()))
+				}
+
+				return nil
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -473,6 +504,60 @@ func trades2() []*domain.Trade {
 			SwapRequest: domain.Swap{
 				ID:        "",
 				Timestamp: uint64(timePoint2.Unix()),
+			},
+		})
+	}
+
+	return trades
+}
+
+func trades3() []*domain.Trade {
+	trades := make([]*domain.Trade, 0)
+
+	timePoint1, _ := time.Parse(time.RFC3339, "2021-03-17T14:30:00Z")
+	for i := 0; i < 5; i++ {
+		trades = append(trades, &domain.Trade{
+			Status:              domain.CompletedStatus,
+			MarketBaseAsset:     "b",
+			MarketQuoteAsset:    "q",
+			MarketFee:           20,
+			MarketFixedBaseFee:  30,
+			MarketFixedQuoteFee: 40,
+			SwapRequest: domain.Swap{
+				ID:        "",
+				Timestamp: uint64(timePoint1.Unix()),
+			},
+		})
+	}
+
+	timePoint2, _ := time.Parse(time.RFC3339, "2022-03-17T14:30:00Z")
+	for i := 0; i < 5; i++ {
+		trades = append(trades, &domain.Trade{
+			Status:              domain.CompletedStatus,
+			MarketBaseAsset:     "b",
+			MarketQuoteAsset:    "q",
+			MarketFee:           20,
+			MarketFixedBaseFee:  30,
+			MarketFixedQuoteFee: 40,
+			SwapRequest: domain.Swap{
+				ID:        "",
+				Timestamp: uint64(timePoint2.Unix()),
+			},
+		})
+	}
+
+	timePoint3, _ := time.Parse(time.RFC3339, "2022-03-16T15:30:00Z")
+	for i := 0; i < 5; i++ {
+		trades = append(trades, &domain.Trade{
+			Status:              domain.CompletedStatus,
+			MarketBaseAsset:     "b",
+			MarketQuoteAsset:    "q",
+			MarketFee:           20,
+			MarketFixedBaseFee:  30,
+			MarketFixedQuoteFee: 40,
+			SwapRequest: domain.Swap{
+				ID:        "",
+				Timestamp: uint64(timePoint3.Unix()),
 			},
 		})
 	}

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -28,8 +28,8 @@ const (
 	LastMonth
 	LastThreeMonths
 	YearToDate
-	All
 	LastYear
+	All
 
 	StartYear = 2021
 )

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -543,7 +543,7 @@ type PredefinedPeriod int
 
 func (p *PredefinedPeriod) validate() error {
 	if *p > All {
-		return fmt.Errorf("PredefinedPeriod cant be > %v", LastYear)
+		return fmt.Errorf("PredefinedPeriod cant be > %v", All)
 	}
 
 	lastYear := time.Now().Year() - 1

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -542,7 +542,7 @@ func (t *TimeRange) Validate() error {
 type PredefinedPeriod int
 
 func (p *PredefinedPeriod) validate() error {
-	if *p > LastYear {
+	if *p > All {
 		return fmt.Errorf("PredefinedPeriod cant be > %v", LastYear)
 	}
 
@@ -611,13 +611,13 @@ func (t *TimeRange) getStartAndEndTime(now time.Time) (startTime time.Time, endT
 		case YearToDate:
 			y, _, _ := now.Date()
 			start = time.Date(y, time.January, 1, 0, 0, 0, 0, time.UTC)
-		case All:
-			start = time.Date(StartYear, time.January, 1, 0, 0, 0, 0, time.UTC)
 		case LastYear:
 			y, _, _ := now.Date()
 			startTime = time.Date(y-1, time.January, 1, 0, 0, 0, 0, time.UTC)
 			endTime = time.Date(y-1, time.December, 31, 23, 59, 59, 0, time.UTC)
 			return
+		case All:
+			start = time.Date(StartYear, time.January, 1, 0, 0, 0, 0, time.UTC)
 		}
 
 		startTime = start

--- a/internal/interfaces/grpc/handler/operator.go
+++ b/internal/interfaces/grpc/handler/operator.go
@@ -1434,7 +1434,7 @@ func toUtxoInfoList(list []application.UtxoInfo) []*daemonv1.UtxoInfo {
 func parseTimeRange(timeRange *daemonv1.TimeRange) (*application.TimeRange, error) {
 	var predefinedPeriod *application.PredefinedPeriod
 	if timeRange.GetPredefinedPeriod() > daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_UNSPECIFIED {
-		pp := application.PredefinedPeriod(timeRange.GetPredefinedPeriod())
+		pp := parsePredefinedPeriod(timeRange.GetPredefinedPeriod())
 		predefinedPeriod = &pp
 	}
 	var customPeriod *application.CustomPeriod
@@ -1471,4 +1471,27 @@ func parseTimeFrame(timeFrame daemonv1.TimeFrame) int {
 	}
 
 	return 1
+}
+
+func parsePredefinedPeriod(predefinedPeriod daemonv1.PredefinedPeriod) application.PredefinedPeriod {
+	switch predefinedPeriod {
+	case daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_LAST_HOUR:
+		return application.LastHour
+	case daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_LAST_DAY:
+		return application.LastDay
+	case daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_LAST_WEEK:
+		return application.LastWeek
+	case daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_LAST_MONTH:
+		return application.LastMonth
+	case daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_LAST_THREE_MONTHS:
+		return application.LastThreeMonths
+	case daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_YEAR_TO_DATE:
+		return application.YearToDate
+	case daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_LAST_YEAR:
+		return application.LastYear
+	case daemonv1.PredefinedPeriod_PREDEFINED_PERIOD_ALL:
+		return application.All
+	}
+
+	return application.NIL
 }


### PR DESCRIPTION
This fixes bug that was happening when GetMarketReport RPC was invoked with predefined period PREDEFINED_PERIOD_ALL.

This closes #605 

@tiero @altafan @Janaka-Steph please review.