### PR TITLE
TLS unset isCA indicator

### DIFF
--- a/internal/interfaces/grpc/http_utils.go
+++ b/internal/interfaces/grpc/http_utils.go
@@ -146,7 +146,6 @@ func generateOperatorTLSKeyCert(
 
 		KeyUsage: x509.KeyUsageKeyEncipherment |
 			x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		IsCA:                  true,
 		BasicConstraintsValid: true,
 
 		DNSNames:    dnsNames,


### PR DESCRIPTION
This unsets isCA certificate indicator.

Regarding: "We might want to explore also if it's possible to remove its expiration date. Currently, it is set to [1 year](https://github.com/tdex-network/tdex-daemon/blob/master/internal/interfaces/grpc/http_utils.go#L70)" -> I dont see any validation preventing this.

This closes #645 

@tiero @altafan please review.