### PR TITLE
add pathname to increase supports of all deployments

### DIFF
--- a/web/layout.html
+++ b/web/layout.html
@@ -33,8 +33,9 @@
         headers.set('Authorization', 'Basic ' + window.btoa(unescape(encodeURIComponent(authString))))
       }
 
-      const response = await window.fetch("/tdexdconnect", { method: 'GET', headers,});
+      const response = await window.fetch(`${window.location.pathname}tdexdconnect`, { method: 'GET', headers,});
       if (!response.ok) {
+        console.log(response.status, response.statusText)
         render(showLogin(password ? "Invalid password" : ""), document.getElementById("root"));
         attachOnClickLogin();
         return;

--- a/web/layout.html
+++ b/web/layout.html
@@ -33,7 +33,8 @@
         headers.set('Authorization', 'Basic ' + window.btoa(unescape(encodeURIComponent(authString))))
       }
 
-      const response = await window.fetch(`${window.location.pathname}tdexdconnect`, { method: 'GET', headers,});
+      const pathname = window.location.pathname.endsWith('/') ? window.location.pathname : `${window.location.pathname}/`
+      const response = await window.fetch(`${pathname}tdexdconnect`, { method: 'GET', headers,});
       if (!response.ok) {
         console.log(response.status, response.statusText)
         render(showLogin(password ? "Invalid password" : ""), document.getElementById("root"));


### PR DESCRIPTION
If someone is exposing the daemon with some reverse proxy on ie. `/api` the web page would not have worked calling the `/tdexdconnect` endpoint on the main host not honoring base pathname