### PR TITLE
Fix preview amounts after supporting precisions

### DIFF
--- a/internal/core/application/trade_service.go
+++ b/internal/core/application/trade_service.go
@@ -29,7 +29,7 @@ type TradeService interface {
 	GetMarketPrice(
 		ctx context.Context,
 		market Market,
-	) (*decimal.Decimal, uint64, error)
+	) (decimal.Decimal, uint64, error)
 	GetTradePreview(
 		ctx context.Context,
 		market Market,
@@ -190,9 +190,9 @@ func (t *tradeService) GetTradableMarkets(ctx context.Context) (
 func (t *tradeService) GetMarketPrice(
 	ctx context.Context,
 	market Market,
-) (*decimal.Decimal, uint64, error) {
+) (decimal.Decimal, uint64, error) {
 	if err := market.Validate(); err != nil {
-		return nil, 0, err
+		return decimal.Zero, 0, err
 	}
 
 	mkt, _, err := t.repoManager.MarketRepository().GetMarketByAssets(
@@ -200,35 +200,39 @@ func (t *tradeService) GetMarketPrice(
 	)
 	if err != nil {
 		log.Debugf("error while retrieving market: %s", err)
-		return nil, 0, ErrServiceUnavailable
+		return decimal.Zero, 0, ErrServiceUnavailable
 	}
 	if mkt == nil {
-		return nil, 0, ErrMarketNotExist
+		return decimal.Zero, 0, ErrMarketNotExist
 	}
 
 	balance, err := getUnlockedBalanceForMarket(t.repoManager, ctx, mkt)
 	if err != nil {
 		log.WithError(err).Debug("error while retrieving balance")
-		return nil, 0, ErrServiceUnavailable
+		return decimal.Zero, 0, ErrServiceUnavailable
 	}
 
 	price, err := mkt.SpotPrice(balance.BaseAmount, balance.QuoteAmount)
 	if err != nil {
 		log.WithError(err).Debug("error while retrieving spot price")
-		return nil, 0, ErrServiceUnavailable
-	}
-	spotPrice := &price.QuotePrice
-	if mkt.FixedFee.BaseFee > 0 {
-		return spotPrice, uint64(mkt.FixedFee.BaseFee + 1), nil
+		return decimal.Zero, 0, ErrServiceUnavailable
 	}
 
-	minTradableAmount := uint64(1)
-	if price.BasePrice.LessThan(decimal.NewFromInt(1)) {
-		minTradableAmount = decimal.NewFromFloat(
-			math.Pow10(-int(mkt.QuoteAssetPrecision)),
-		).Div(price.BasePrice).BigInt().Uint64()
+	// 1 sat of base asset * quote price is the ideal min tradable amount but
+	// there are max 8 decimal in blockchain, so if the value is < 1, the min
+	// tradable amount is 1 / value.
+	// For example, if 1 sat of base asset * quote price = 0.001, the min
+	// tradable amount is 1 / 0.001 = 100 sats of base asset (fees excluded).
+	minAmount := decimal.NewFromFloat(math.Pow10(-int(mkt.BaseAssetPrecision))).Mul(price.QuotePrice)
+	if one := decimal.NewFromFloat(1); minAmount.LessThan(one) {
+		minAmount = one.Div(minAmount)
 	}
-	return spotPrice, minTradableAmount, nil
+	minTradableAmount := minAmount.BigInt().Uint64()
+	if mkt.FixedFee.BaseFee > 0 {
+		minTradableAmount += uint64(mkt.FixedFee.BaseFee)
+	}
+
+	return price.QuotePrice, minTradableAmount, nil
 }
 
 func (t *tradeService) GetTradePreview(

--- a/internal/core/domain/market_model.go
+++ b/internal/core/domain/market_model.go
@@ -86,11 +86,13 @@ func NewMarket(
 	}
 
 	return &Market{
-		AccountIndex: accountIndex,
-		BaseAsset:    baseAsset,
-		QuoteAsset:   quoteAsset,
-		Fee:          feeInBasisPoint,
-		Strategy:     mm.NewStrategyFromFormula(formula.BalancedReserves{}),
+		AccountIndex:        accountIndex,
+		BaseAsset:           baseAsset,
+		QuoteAsset:          quoteAsset,
+		BaseAssetPrecision:  baseAssetPrecision,
+		QuoteAssetPrecision: quoteAssetPrecision,
+		Fee:                 feeInBasisPoint,
+		Strategy:            mm.NewStrategyFromFormula(formula.BalancedReserves{}),
 	}, nil
 }
 

--- a/pkg/marketmaking/formula/balanced_reserves.go
+++ b/pkg/marketmaking/formula/balanced_reserves.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 
 	"github.com/shopspring/decimal"
-	"github.com/tdex-network/tdex-daemon/pkg/mathutil"
 )
 
-const (
-	balancedWeightIn     = 50
-	balancedWeightOut    = 50
-	BalancedReservesType = 1
+const BalancedReservesType = 1
+
+var (
+	balancedWeightIn  = decimal.NewFromInt(50)
+	balancedWeightOut = decimal.NewFromInt(50)
+	tenThousands      = decimal.NewFromInt(10000)
 )
 
 var (
@@ -25,10 +26,10 @@ var (
 	ErrBalanceTooLow = errors.New("reserve balance amount is too low")
 )
 
-//BalancedReservesOpts defines the parameters needed to calculate the spot price
+// BalancedReservesOpts defines the parameters needed to calculate the spot price
 type BalancedReservesOpts struct {
-	BalanceIn  uint64
-	BalanceOut uint64
+	BalanceIn  decimal.Decimal
+	BalanceOut decimal.Decimal
 	WeightIn   uint64
 	WeightOut  uint64
 	// The fee should be in satoshis and represents the calculated fee to take out from the swap.
@@ -37,7 +38,7 @@ type BalancedReservesOpts struct {
 	ChargeFeeOnTheWayIn bool
 }
 
-//BalancedReserves defines an AMM strategy with fixed 50/50 reserves
+// BalancedReserves defines an AMM strategy with fixed 50/50 reserves
 type BalancedReserves struct{}
 
 // SpotPrice calculates the spot price (without fees) given the balances fo the two reserves. The weight reserve ratio is fixed at 50/50
@@ -48,109 +49,102 @@ func (BalancedReserves) SpotPrice(_opts interface{}) (spotPrice decimal.Decimal,
 		return
 	}
 
-	if opts.BalanceIn == 0 || opts.BalanceOut == 0 {
+	if opts.BalanceIn.Equals(decimal.Zero) || opts.BalanceOut.Equals(decimal.Zero) {
 		err = ErrBalanceTooLow
 		return
 	}
-	// 2 : 20k = 1 : x
-	// BI : BO = OneInput : SpotPrice
-	numer := mathutil.Div(opts.BalanceOut, balancedWeightOut)
-	denom := mathutil.Div(opts.BalanceIn, balancedWeightIn)
-	spotPrice = mathutil.DivDecimal(numer, denom)
+
+	spotPrice = opts.BalanceOut.Div(opts.BalanceIn)
 	return
 }
 
 // OutGivenIn returns the amountOut of asset that will be exchanged for the given amountIn.
-func (BalancedReserves) OutGivenIn(_opts interface{}, amountIn uint64) (uint64, error) {
+func (BalancedReserves) OutGivenIn(
+	_opts interface{}, amountIn decimal.Decimal,
+) (amountOut decimal.Decimal, err error) {
 	opts, ok := _opts.(BalancedReservesOpts)
 	if !ok {
-		return 0, ErrInvalidOptsType
+		err = ErrInvalidOptsType
+		return
+	}
+	if opts.BalanceIn.Equal(decimal.Zero) || opts.BalanceOut.Equal(decimal.Zero) {
+		err = ErrBalanceTooLow
+		return
 	}
 
-	if opts.BalanceIn == 0 || opts.BalanceOut == 0 {
-		return 0, ErrBalanceTooLow
-	}
-
-	if amountIn == 0 {
-		return 0, ErrAmountTooLow
-	}
-
-	amount := amountIn
+	percentageFee := decimal.NewFromInt(int64(opts.Fee)).Div(tenThousands)
 	if opts.ChargeFeeOnTheWayIn {
-		amount, _ = mathutil.LessFee(amountIn, opts.Fee)
+		amountIn = amountIn.Mul(decimal.NewFromInt(1).Sub(percentageFee))
 	}
-	if amount == 0 {
-		return 0, ErrAmountTooLow
+	if amountIn.LessThanOrEqual(decimal.Zero) {
+		err = ErrAmountTooLow
+		return
 	}
 
-	balanceIn := decimal.NewFromInt(int64(opts.BalanceIn))
-	balanceOut := decimal.NewFromInt(int64(opts.BalanceOut))
-	amountOutDecimal := balanceOut.Mul(
-		decimal.NewFromInt(1).Sub(
-			balanceIn.Div(
-				balanceIn.Add(decimal.NewFromInt(int64(amount))),
-			),
-		),
-	)
-
-	amountOut := amountOutDecimal.BigInt().Uint64()
+	amount := opts.BalanceOut.Mul(decimal.NewFromInt(1).Sub(
+		opts.BalanceIn.Div(opts.BalanceIn.Add(amountIn)),
+	))
 	if !opts.ChargeFeeOnTheWayIn {
-		amountOut, _ = mathutil.LessFee(amountOut, opts.Fee)
+		amount = amount.Mul(decimal.NewFromInt(1).Sub(percentageFee))
 	}
-	if amountOut == 0 {
-		return 0, ErrAmountTooLow
+	amount = amount.Round(8)
+	if amount.LessThanOrEqual(decimal.Zero) {
+		err = ErrAmountTooLow
+		return
+	}
+	if amount.GreaterThanOrEqual(opts.BalanceOut) {
+		err = ErrAmountTooBig
+		return
 	}
 
-	return amountOut, nil
+	amountOut = amount
+	return
 }
 
 // InGivenOut returns the amountIn of assets that will be needed for having the desired amountOut in return.
-func (BalancedReserves) InGivenOut(_opts interface{}, amountOut uint64) (uint64, error) {
+func (BalancedReserves) InGivenOut(
+	_opts interface{}, amountOut decimal.Decimal,
+) (amountIn decimal.Decimal, err error) {
 	opts, ok := _opts.(BalancedReservesOpts)
 	if !ok {
-		return 0, ErrInvalidOptsType
+		err = ErrInvalidOptsType
+		return
+	}
+	if opts.BalanceIn.Equals(decimal.Zero) || opts.BalanceOut.Equals(decimal.Zero) {
+		err = ErrBalanceTooLow
+		return
 	}
 
-	if opts.BalanceIn == 0 || opts.BalanceOut == 0 {
-		return 0, ErrBalanceTooLow
-	}
-
-	if amountOut == 0 {
-		return 0, ErrAmountTooLow
-	}
-	if amountOut >= opts.BalanceOut {
-		return 0, ErrAmountTooBig
-	}
-
-	amount := amountOut
+	percentageFee := decimal.NewFromInt(int64(opts.Fee)).Div(tenThousands)
 	if !opts.ChargeFeeOnTheWayIn {
-		amount, _ = mathutil.PlusFee(amountOut, opts.Fee)
+		amountOut = amountOut.Mul(decimal.NewFromInt(1).Add(percentageFee))
+	}
+	if amountOut.Equals(decimal.Zero) {
+		err = ErrAmountTooLow
+		return
+	}
+	if amountOut.GreaterThanOrEqual(opts.BalanceOut) {
+		err = ErrAmountTooBig
+		return
 	}
 
-	if amount == 0 {
-		return 0, ErrAmountTooLow
-	}
-	if amount >= opts.BalanceOut {
-		return 0, ErrAmountTooBig
-	}
-
-	balanceIn := decimal.NewFromInt(int64(opts.BalanceIn))
-	balanceOut := decimal.NewFromInt(int64(opts.BalanceOut))
-	amountInDecimal := balanceIn.Mul(
-		balanceOut.Div(
-			balanceOut.Sub(decimal.NewFromInt(int64(amount))),
-		).Sub(decimal.NewFromInt(1)),
+	amount := opts.BalanceIn.Mul(
+		opts.BalanceOut.Div(opts.BalanceOut.Sub(amountOut)).Sub(
+			decimal.NewFromInt(1),
+		),
 	)
 
-	amountIn := amountInDecimal.BigInt().Uint64()
 	if opts.ChargeFeeOnTheWayIn {
-		amountIn, _ = mathutil.PlusFee(amountIn, opts.Fee)
+		amount = amount.Mul(decimal.NewFromInt(1).Add(percentageFee))
 	}
-	if amountIn == 0 {
-		return 0, ErrAmountTooLow
+	amount = amount.Round(8)
+	if amount.LessThanOrEqual(decimal.Zero) {
+		err = ErrAmountTooLow
+		return
 	}
 
-	return amountIn, nil
+	amountIn = amount
+	return
 }
 
 func (BalancedReserves) FormulaType() int {

--- a/pkg/marketmaking/market_making.go
+++ b/pkg/marketmaking/market_making.go
@@ -13,8 +13,8 @@ type MakingStrategy struct {
 // MakingFormula defines the interface for implementing the formula to derive the spot price
 type MakingFormula interface {
 	SpotPrice(spotPriceOpts interface{}) (spotPrice decimal.Decimal, err error)
-	OutGivenIn(outGivenInOpts interface{}, amountIn uint64) (amountOut uint64, err error)
-	InGivenOut(inGivenOutOpts interface{}, amountOut uint64) (amountIn uint64, err error)
+	OutGivenIn(outGivenInOpts interface{}, amountIn decimal.Decimal) (amountOut decimal.Decimal, err error)
+	InGivenOut(inGivenOutOpts interface{}, amountOut decimal.Decimal) (amountIn decimal.Decimal, err error)
 	FormulaType() int
 }
 


### PR DESCRIPTION
This updates the marketmaking Formula interface in order to express numbers via `decimal.Decimal`s instead of `uint64`s.

Before this change the the formula interface was designed to support satoshis, but this becomes problematic after supporting market assets precision. By changing the representation to `decimal.Decimal`, balances and amounts can be scaled by asset precision before and after applying a formula to calculate a preview amount (in domain layer).

This adds test cases to make sure the applied change work as expected.

This also simplify the calc of the min tradable amount of SpotPrice by applying the following formula:
```
mkt.FixedFee.BaseFee > 0 -> minTradableAmount = mkt.FixedFee.BaseFee+1
mkt.SpotPrice.BasePrice >= 1 -> minTradableAmount = 1
mkt.SpotPrice.BasePrice < 0 > minTradableAmount = minQuoteAmount * mkt.SpotPrice.BasePrice
```

where `minQuoteAmount = 10^(-quoteAssetPrecision)`, ie. `precision = 2 -> minQuoteAmount = 0,01`.

Please @tiero review this.