### PR TITLE
Fix trade proposal price validation & Minor fixes

### DIFF
--- a/internal/core/application/trade/service.go
+++ b/internal/core/application/trade/service.go
@@ -135,7 +135,8 @@ func (s *Service) checkForPendingTrades() {
 	ctx := context.Background()
 	trades, _ := s.repoManager.TradeRepository().GetAllTrades(ctx, nil)
 	expiredTrades := make([]*domain.Trade, 0)
-	for _, t := range trades {
+	for i := range trades {
+		t := trades[i]
 		trade := &t
 		if trade.IsAccepted() || trade.IsCompleted() {
 			if ok, _ := trade.Expire(); ok {

--- a/internal/core/application/trade/trading.go
+++ b/internal/core/application/trade/trading.go
@@ -78,7 +78,7 @@ func (s *Service) TradePropose(
 		tradeType.IsSell() && feeAsset == mkt.BaseAsset
 
 	if !isValidTradePrice(
-		*mkt, balance, tradeType, swapRequest, s.priceSlippage, feesToAdd,
+		*mkt, balance, tradeType, swapRequest, s.priceSlippage,
 	) {
 		trade.Fail(
 			swapRequest.GetId(), pkgswap.ErrCodeBadPricingSwapRequest,

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -57,7 +57,7 @@ func main() {
 	log.Infof("asset: %s", usdt)
 	log.Infof("done\n\n")
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	log.Info("configuring tdex CLI...")
 	if _, err := runCLICommand("config", "init", "--no_tls", "--no_macaroons"); err != nil {


### PR DESCRIPTION
This fixes the validation of a trade proposal's price, which hasn't been updated after moving to tdex-protobuf@v2.

This also fixes the expiration of the trades by correctly dereferencing elements of a slice within a loop.

Last but not least, this increases the waiting time before configuring the CLI in the e2e tests, which seems to be slower on CI rather than it is locally.