### PR TITLE
Hotfix auto unlocking

### DIFF
--- a/internal/interfaces/grpc/service.go
+++ b/internal/interfaces/grpc/service.go
@@ -292,7 +292,7 @@ func (s *service) Start() error {
 	}
 
 	if s.opts.WalletUnlockPasswordFile != "" {
-		if err := s.opts.AppConfig.WalletService().Wallet().Unlock(
+		if err := s.opts.AppConfig.UnlockerService().UnlockWallet(
 			context.Background(), s.password,
 		); err != nil {
 			return fmt.Errorf("failed to auto unlock wallet: %s", err)
@@ -306,9 +306,9 @@ func (s *service) Start() error {
 
 func (s *service) Stop() {
 	if s.password != "" {
-		walletSvc := s.opts.AppConfig.WalletService().Wallet()
-		//nolint
-		walletSvc.Lock(context.Background(), s.password)
+		s.opts.AppConfig.UnlockerService().LockWallet(
+			context.Background(), s.password,
+		)
 	}
 	stopMacaroonSvc := true
 	s.stop(stopMacaroonSvc)

--- a/internal/interfaces/grpc/service_one_port.go
+++ b/internal/interfaces/grpc/service_one_port.go
@@ -181,7 +181,7 @@ func (s *serviceOnePort) Start() error {
 	}
 
 	if s.opts.WalletUnlockPasswordFile != "" {
-		if err := s.opts.AppConfig.WalletService().Wallet().Unlock(
+		if err := s.opts.AppConfig.UnlockerService().UnlockWallet(
 			context.Background(), s.password,
 		); err != nil {
 			return fmt.Errorf("failed to auto unlock wallet: %s", err)
@@ -195,9 +195,9 @@ func (s *serviceOnePort) Start() error {
 
 func (s *serviceOnePort) Stop() {
 	if s.password != "" {
-		walletSvc := s.opts.AppConfig.WalletService().Wallet()
-		//nolint
-		walletSvc.Lock(context.Background(), s.password)
+		s.opts.AppConfig.UnlockerService().LockWallet(
+			context.Background(), s.password,
+		)
 	}
 
 	stopMacaroonSvc := true


### PR DESCRIPTION
This fixes the auto-unlock feature of the daemon. Before this, only the wallet was locked/unlocked, now, instead, by using the unlocker app service, also the secure storage for webhooks is locked/unlocked.

Closes #721. 

Please @sekulicd review this.
