### PR TITLE
Remove Macaroon close on Lock

### DIFF
--- a/internal/interfaces/grpc/interceptor/interceptor.go
+++ b/internal/interfaces/grpc/interceptor/interceptor.go
@@ -3,27 +3,36 @@ package interceptor
 import (
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"github.com/tdex-network/tdex-daemon/internal/core/application"
 	"github.com/tdex-network/tdex-daemon/pkg/macaroons"
 	"google.golang.org/grpc"
 )
 
 // UnaryInterceptor returns the unary interceptor
-func UnaryInterceptor(svc *macaroons.Service) grpc.ServerOption {
+func UnaryInterceptor(
+	macaroonSvc *macaroons.Service,
+	walletUnlockerSvc application.UnlockerService,
+) grpc.ServerOption {
 	return grpc.UnaryInterceptor(
 		middleware.ChainUnaryServer(
 			grpc_recovery.UnaryServerInterceptor(),
-			unaryMacaroonAuthHandler(svc),
+			unaryWalletLockerAuthHandler(walletUnlockerSvc),
+			unaryMacaroonAuthHandler(macaroonSvc),
 			unaryLogger,
 		),
 	)
 }
 
 // StreamInterceptor returns the stream interceptor with a logrus log
-func StreamInterceptor(svc *macaroons.Service) grpc.ServerOption {
+func StreamInterceptor(
+	macaroonSvc *macaroons.Service,
+	walletUnlockerSvc application.UnlockerService,
+) grpc.ServerOption {
 	return grpc.StreamInterceptor(
 		middleware.ChainStreamServer(
 			grpc_recovery.StreamServerInterceptor(),
-			streamMacaroonAuthHandler(svc),
+			streamWalletLockerAuthHandler(walletUnlockerSvc),
+			streamMacaroonAuthHandler(macaroonSvc),
 			streamLogger,
 		),
 	)

--- a/internal/interfaces/grpc/service.go
+++ b/internal/interfaces/grpc/service.go
@@ -403,8 +403,12 @@ func (s *service) newOperatorServer(
 	tlsConfig *tls.Config, withOperatorHandler bool,
 ) (*http.Server, error) {
 	serverOpts := []grpc.ServerOption{
-		interceptor.UnaryInterceptor(s.macaroonSvc),
-		interceptor.StreamInterceptor(s.macaroonSvc),
+		interceptor.UnaryInterceptor(
+			s.macaroonSvc, s.opts.AppConfig.UnlockerService(),
+		),
+		interceptor.StreamInterceptor(
+			s.macaroonSvc, s.opts.AppConfig.UnlockerService(),
+		),
 	}
 
 	creds := insecure.NewCredentials()
@@ -489,8 +493,12 @@ func (s *service) newOperatorServer(
 
 func (s *service) newTradeServer(tlsConfig *tls.Config) (*http.Server, error) {
 	serverOpts := []grpc.ServerOption{
-		interceptor.UnaryInterceptor(s.macaroonSvc),
-		interceptor.StreamInterceptor(s.macaroonSvc),
+		interceptor.UnaryInterceptor(
+			s.macaroonSvc, s.opts.AppConfig.UnlockerService(),
+		),
+		interceptor.StreamInterceptor(
+			s.macaroonSvc, s.opts.AppConfig.UnlockerService(),
+		),
 	}
 
 	creds := insecure.NewCredentials()
@@ -605,8 +613,8 @@ func (s *service) onUnlock(password string) {
 		}
 	}
 
-	stopMacaroonSvc := true
-	s.stop(!stopMacaroonSvc)
+	stopMacaroonSvc := false
+	s.stop(stopMacaroonSvc)
 
 	withWalletOnly := true
 	if err := s.start(!withWalletOnly); err != nil {
@@ -615,7 +623,7 @@ func (s *service) onUnlock(password string) {
 }
 
 func (s *service) onLock(_ string) {
-	stopMacaroonSvc := true
+	stopMacaroonSvc := false
 	s.stop(stopMacaroonSvc)
 	withWalletOnly := true
 	//nolint


### PR DESCRIPTION
This removes code that closes Macaroon service on Wallet lock.
This was causing inner db to close when Wallet is locked which disables Macaroon service once Wallet unlocked
and makes it unusable.
This is specially critical after Wallet lock, user changes password which successfully changes wallet pass but not Macaroon db pass since in Lock step its db is closed. 
Consequence of this is probably that even daemon restart would not resolve the issue since mac db and wallet now have different pass.

This removes call to Close Macaroon svc which closes db and adds another interceptor that checks if Wallet is locked or not.
Before this there was only one auth method and it was Macaroon svc and I guess Macaroon was closed on Lock for the purpose of preventing user to access RPCs, since now Macaroon is not closed on Lock it was necessary to add another auth method which checks wether Wallet is locked or not.

@tiero @altafan @Janaka-Steph please review.