### PR TITLE
Hotfix change password

### DIFF
--- a/internal/interfaces/grpc/service.go
+++ b/internal/interfaces/grpc/service.go
@@ -615,7 +615,7 @@ func (s *service) onUnlock(password string) {
 }
 
 func (s *service) onLock(_ string) {
-	stopMacaroonSvc := true
+	stopMacaroonSvc := false
 	s.stop(stopMacaroonSvc)
 	withWalletOnly := true
 	//nolint

--- a/internal/interfaces/grpc/service_one_port.go
+++ b/internal/interfaces/grpc/service_one_port.go
@@ -437,12 +437,11 @@ func (s *serviceOnePort) onUnlock(password string) {
 }
 
 func (s *serviceOnePort) onLock(_ string) {
-	if !s.withMacaroons() {
-		return
-	}
-	if err := s.macaroonSvc.Close(); err != nil {
-		log.WithError(err).Warn("failed to close macaroon store")
-	}
+	stopMacaroonSvc := false
+	s.stop(stopMacaroonSvc)
+	withWalletOnly := true
+	//nolint
+	s.start(withWalletOnly)
 }
 
 func (s *serviceOnePort) onChangePwd(oldPassword, newPassword string) {


### PR DESCRIPTION
Before this there were problems with the macaroon service after changing the main password and unlocking the daemon.

The reason for this bug was due to the fact that the macaroon service was stopped when locking the daemon, making impossible to update its password and therefore unlocking with the new one.

With this, the macaroon service is not stopped anymore when locking the wallet.

Please @sekulicd review this.