### PR TITLE
Rename TDRADE_SATS_PER_BYTE to TX_SATS_PER_BYTE & Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,18 @@ In-depth documentation for installing and using the tdex-daemon is available at 
 
 ## 🖥 Local Development
 
-Below is a list of commands you will probably find useful for development.
+Below is a list of commands you will likely find useful for development.
 
 ### Requirements
 
-* Go (^1.16.*)
+* [Golang](https://go.dev/) (^1.16.*)
+* [Ocean wallet](https://github.com/vulpemventures/ocean)
 
-### Run daemon
+### Run daemon (dev mode)
 
-Builds `tdexd` as static binary and runs the project with default configuration.
+[Start](https://github.com/vulpemventures/ocean/#local-run) the ocean wallet.
+
+Start the daemon:
 
 ```bash
 $ make run
@@ -38,7 +41,7 @@ $ make run
 
 ### Build daemon
 
-Builds `tdexd` as static binary in the `./build` folder
+Build `tdexd` as a static binary in the `./build` folder
 
 ```bash
 $ make build
@@ -46,7 +49,7 @@ $ make build
 
 ### Build CLI
 
-Builds `tdex` as static binary in the `./build` folder
+Build `tdex` as a static binary in the `./build` folder
 
 ```bash
 $ make build-cli
@@ -54,35 +57,36 @@ $ make build-cli
 
 ### Build and Run with docker
 
-Build and use `tdex` with docker.
+Start oceand and tdexd services as docker contaniner.
 
-#### Build tdexd docker image
+#### Start oceand and tdexd
 
-_At the root of the repository_
-
-```bash
-$ docker build --pull --rm -f "Dockerfile" -t tdexd:latest "."
-```
-
-#### Run the daemon
+Start `oceand` and `tdexd` containters:
 
 ```bash
-$ docker run -d -it --name tdexd -p 9945:9945 -p 9000:9000 -v `pwd`/tdexd:/.tdex-daemon tdexd:latest
+$ docker-compose -f resources/compose/docker-compose.yml up -d oceand tdexd
 ```
 
 #### Use the CLI
 
 ```bash
-$ alias tdex="docker exec -it tdexd tdex"
+$ alias tdex="docker exec tdexd tdex"
+
+# Configure the CLI
+$ tdex config init --no-tls --no-macaroons
+
+# Use the CLI
+$ tdex status
+$ tdex --help
 ```
 
 ### Test
 
 ```bash
-# Short testing
+# Unit testing
 $ make test
 
-# integration testing
+# Integration testing
 $ make integrationtest
 ```
 

--- a/cmd/tdexd/main.go
+++ b/cmd/tdexd/main.go
@@ -85,7 +85,7 @@ func main() {
 		PriceFeederSvc:      priceFeederSvc,
 		FeeBalanceThreshold: feeBalanceThreshold,
 		TradePriceSlippage:  pricesSlippagePercentage,
-		TradeSatsPerByte:    satsPerByte,
+		TxSatsPerByte:       satsPerByte,
 		DBType:              dbType,
 		DBConfig:            dbDir,
 	}
@@ -142,7 +142,7 @@ func loadConfig() error {
 	dbType = config.GetString(config.DBTypeKey)
 	// App services config
 	pricesSlippagePercentage = decimal.NewFromFloat(config.GetFloat(config.PriceSlippageKey))
-	satsPerByte = decimal.NewFromFloat(config.GetFloat(config.TradeSatsPerByte))
+	satsPerByte = decimal.NewFromFloat(config.GetFloat(config.TxSatsPerByteKey))
 	feeBalanceThreshold = uint64(config.GetInt(config.FeeAccountBalanceThresholdKey))
 	tradeSvcPort = config.GetInt(config.TradeListeningPortKey)
 	operatorSvcPort = config.GetInt(config.OperatorListeningPortKey)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,8 +25,8 @@ const (
 	FeeAccountBalanceThresholdKey = "FEE_ACCOUNT_BALANCE_THRESHOLD"
 	// TradeExpiryTimeKey is the duration in seconds of lock on unspents we reserve for accepted trades, before eventually double spending it
 	TradeExpiryTimeKey = "TRADE_EXPIRY_TIME"
-	// TradeSatsPerByte is the sats per byte ratio to use for paying for trades' network fees
-	TradeSatsPerByte = "TRADE_SATS_PER_BYTE"
+	// TxSatsPerByteKey is the sats per byte ratio used to pay for txs' newtwork fees
+	TxSatsPerByteKey = "TX_SATS_PER_BYTE"
 	// PriceSlippageKey is the percentage of the slipage for accepting trades compared to current spot price
 	PriceSlippageKey = "PRICE_SLIPPAGE"
 	// TradeTLSKeyKey is the path of the the TLS key for the Trade interface
@@ -85,7 +85,7 @@ func InitConfig() error {
 	vip.SetDefault(LogLevelKey, 4)
 	vip.SetDefault(FeeAccountBalanceThresholdKey, 5000)
 	vip.SetDefault(TradeExpiryTimeKey, 120)
-	vip.SetDefault(TradeSatsPerByte, 0.1)
+	vip.SetDefault(TxSatsPerByteKey, 0.11)
 	vip.SetDefault(DatadirKey, defaultDatadir)
 	vip.SetDefault(PriceSlippageKey, 0.05)
 	vip.SetDefault(EnableProfilerKey, false)
@@ -147,9 +147,9 @@ func validate() error {
 		)
 	}
 
-	satsPerByte := GetFloat(TradeSatsPerByte)
+	satsPerByte := GetFloat(TxSatsPerByteKey)
 	if satsPerByte < 0.1 {
-		return fmt.Errorf("%s must be equal or greater than 0.1", TradeSatsPerByte)
+		return fmt.Errorf("%s must be equal or greater than 0.1", TxSatsPerByteKey)
 	}
 
 	if !vip.IsSet(OceanWalletAddrKey) {

--- a/internal/core/application/config.go
+++ b/internal/core/application/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	PriceFeederSvc      ports.PriceFeeder
 	FeeBalanceThreshold uint64
 	TradePriceSlippage  decimal.Decimal
-	TradeSatsPerByte    decimal.Decimal
+	TxSatsPerByte       decimal.Decimal
 
 	repo     ports.RepoManager
 	pubsub   PubSubService
@@ -133,7 +133,7 @@ func (c *Config) operatorService() (OperatorService, error) {
 		pubsub, _ := c.pubsubService()
 		repo, _ := c.repoManager()
 		operator, err := NewOperatorService(
-			wallet, pubsub, repo, c.FeeBalanceThreshold,
+			wallet, pubsub, repo, c.FeeBalanceThreshold, c.TxSatsPerByte,
 		)
 		if err != nil {
 			return nil, err
@@ -149,7 +149,7 @@ func (c *Config) tradeService() (TradeService, error) {
 		pubsub, _ := c.pubsubService()
 		repo, _ := c.repoManager()
 		trade, err := NewTradeService(
-			wallet, pubsub, repo, c.TradePriceSlippage, c.TradeSatsPerByte,
+			wallet, pubsub, repo, c.TradePriceSlippage, c.TxSatsPerByte,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/core/application/operator.go
+++ b/internal/core/application/operator.go
@@ -125,10 +125,11 @@ type OperatorService interface {
 func NewOperatorService(
 	walletSvc WalletService, pubsubSvc PubSubService,
 	repoManager ports.RepoManager, feeAccountBalanceThreshold uint64,
+	satsPerByte decimal.Decimal,
 ) (OperatorService, error) {
 	w := walletSvc.(*wallet.Service)
 	p := pubsubSvc.(*pubsub.Service)
 	return operator.NewService(
-		w, p, repoManager, feeAccountBalanceThreshold,
+		w, p, repoManager, feeAccountBalanceThreshold, satsPerByte,
 	)
 }

--- a/internal/core/application/operator/fee_fragmenter_account.go
+++ b/internal/core/application/operator/fee_fragmenter_account.go
@@ -127,7 +127,7 @@ func (s *service) FeeFragmenterSplitFunds(
 	}
 
 	txHex, err := s.wallet.Transaction().Transfer(
-		ctx, domain.FeeFragmenterAccount, outputs, 100,
+		ctx, domain.FeeFragmenterAccount, outputs, s.milliSatsPerByte,
 	)
 	if err != nil {
 		chRes <- fragmenterReply{"", err}

--- a/internal/core/application/operator/market_fragmenter_account.go
+++ b/internal/core/application/operator/market_fragmenter_account.go
@@ -208,7 +208,9 @@ func (s *service) MarketFragmenterSplitFunds(
 		"crafting and broadcasting transaction to send funds to market account",
 		nil,
 	}
-	txid, err := s.wallet.SendToMany(domain.MarketFragmenterAccount, outputs, 100)
+	txid, err := s.wallet.SendToMany(
+		domain.MarketFragmenterAccount, outputs, s.milliSatsPerByte,
+	)
 	if err != nil {
 		chRes <- fragmenterReply{
 			"", fmt.Errorf("failed to send funds to market account: %s", err),

--- a/resources/compose/docker-compose.yml
+++ b/resources/compose/docker-compose.yml
@@ -48,6 +48,17 @@ services:
       - tdexd
     volumes:
       - ../volumes/feederd/config.json:/config.json
+  # not used in dev mode
+  oceand-db:
+    container_name: oceand-regtest-db
+    image: postgres
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=secret
+      - POSTGRES_DB=oceand-db
+    ports:
+      - "5432:5432"
 
 networks:
   default:

--- a/resources/compose/docker-compose.yml
+++ b/resources/compose/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     container_name: oceand
     image: ghcr.io/vulpemventures/oceand:latest
     restart: unless-stopped
-    depends_on:
-      - oceand-db
     environment:
       - OCEAN_LOG_LEVEL=5
       - OCEAN_NO_TLS=true


### PR DESCRIPTION
This updates the name of the config env var `TDRADE_SATS_PER_BYTE` to a more general `TX_SATS_PER_BYTE`.

The daemon then uses this value for all the transactions it crafts including the trades (as already done originally), and also the fragmentation txs, ie. those txs created by the fee/market fragmenter that split the funds in more fragments before being deposited to the related fee/market account.

Before this, we were hardcoding the `0.1` sats/byte ratio, while now it is configurable through env var.

This also includes fixes to the integration test and docker-compose yaml file.

Please @sekulicd review this.