### PR TITLE
Fix integration test & minor fixes

### DIFF
--- a/internal/interfaces/grpc/handler/operator.go
+++ b/internal/interfaces/grpc/handler/operator.go
@@ -485,13 +485,13 @@ func (h *operatorHandler) getMarketReport(
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	groupByTimeFrame, err := parseTimeFrame(req.GetTimeFrame())
+	timeFrame, err := parseTimeFrame(req.GetTimeFrame())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	report, err := h.operatorSvc.GetMarketReport(
-		ctx, market, timeRange, groupByTimeFrame,
+		ctx, market, timeRange, timeFrame,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/interfaces/grpc/handler/utils.go
+++ b/internal/interfaces/grpc/handler/utils.go
@@ -294,7 +294,9 @@ func parseTimeRange(timeRange *daemonv2.TimeRange) (ports.TimeRange, error) {
 
 func parseTimeFrame(timeFrame daemonv2.TimeFrame) (int, error) {
 	switch timeFrame {
-	case daemonv2.TimeFrame_TIME_FRAME_UNSPECIFIED, daemonv2.TimeFrame_TIME_FRAME_HOUR:
+	case daemonv2.TimeFrame_TIME_FRAME_UNSPECIFIED:
+		return 0, nil
+	case daemonv2.TimeFrame_TIME_FRAME_HOUR:
 		return 1, nil
 	case daemonv2.TimeFrame_TIME_FRAME_FOUR_HOURS:
 		return 4, nil
@@ -303,9 +305,7 @@ func parseTimeFrame(timeFrame daemonv2.TimeFrame) (int, error) {
 	case daemonv2.TimeFrame_TIME_FRAME_WEEK:
 		return 24 * 7, nil
 	case daemonv2.TimeFrame_TIME_FRAME_MONTH:
-		year, month, _ := time.Now().Date()
-		numOfDaysForCurrentMont := time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC).Day()
-		return numOfDaysForCurrentMont, nil
+		return 24 * 30, nil
 	default:
 		return -1, fmt.Errorf("unknown time frame")
 	}

--- a/resources/compose/docker-compose.yml
+++ b/resources/compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - "18000:18000"
     volumes:
-      - ../volumes/oceand/data:/home/ocean/.ocean-wallet
+      - ../volumes/oceand/data:/home/ocean/.oceand
       - ../volumes/oceand/cli:/home/ocean/.ocean-cli
   tdexd:
     container_name: tdexd
@@ -27,7 +27,6 @@ services:
     depends_on:
       - oceand
     environment:
-      - TDEX_NETWORK=regtest
       - TDEX_WALLET_ADDR=oceand:18000
       - TDEX_LOG_LEVEL=5
       - TDEX_FEE_ACCOUNT_BALANCE_THRESHOLD=1000

--- a/resources/compose/docker-compose.yml
+++ b/resources/compose/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: oceand
     image: ghcr.io/vulpemventures/oceand:latest
     restart: unless-stopped
+    user: 0:0
     environment:
       - OCEAN_LOG_LEVEL=5
       - OCEAN_NO_TLS=true
@@ -24,6 +25,7 @@ services:
       context: ../../
       dockerfile: Dockerfile
     restart: unless-stopped
+    user: 0:0
     depends_on:
       - oceand
     environment:
@@ -43,6 +45,7 @@ services:
     container_name: feederd
     image: ghcr.io/tdex-network/feederd:latest
     restart: unless-stopped
+    user: 0:0
     depends_on:
       - tdexd
     volumes:

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -19,7 +19,6 @@ import (
 var (
 	composePath = "resources/compose/docker-compose.yml"
 	volumesPath = "resources/volumes"
-	// feederConfigJSON = fmt.Sprintf("%s/feederd/config.json", volumesPath)
 
 	daemonAddr     = "localhost:9945"
 	explorerAddr   = "http://localhost:3001"
@@ -29,7 +28,6 @@ var (
 	feeFragmenterDepositAmount = 0.001
 	marketBaseDepositAmount    = 1.0
 	marketQuoteDepositAmount   = float64(25000)
-	// numOfConcurrentTrades      = 4
 
 	lbtc = network.Regtest.AssetID
 	usdt string


### PR DESCRIPTION
This contains changes for fixing the execution of the e2e on CI.

This also makes changes to the flags defined for `market report` and `market strategy` commands.

Before this, the operator should have specified the time range for `market report` with numeric values, while now more user-friendly flags are specified like `--last-hour`, `--last-day`, etc.
If not specified within the API request, the daemon now makes use of a default time frame that depends on the length of the time range instead of using always `1h` which is ok only for time ranges in the order of few days.

This also adds a new flag `--balanced` to the `market strategy` command so that the operator must specify which strategy he wants for the current market. Before this, instead, only the `--pluggbale` flag was defined.

This also contains fixes to typos and polishes the docker-compose.yml file.
