### PR TITLE
Update gh action's target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,9 @@ name: Go
 on:
   push:
     branches:
-      - master
       - v1
   pull_request:
     branches:
-      - master
       - v1
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,11 +14,9 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - master
       - v1
   pull_request:
     branches:
-      - master
       - v1
   schedule:
     - cron: '43 14 * * 5'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,6 @@ name: Go
 on:
   push:
     branches:
-      - master
       - v1
 
 jobs:


### PR DESCRIPTION
This excludes `master` from the target branches of our gh actions.